### PR TITLE
ci: Remove lean_exe to fix docgen compatibility

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,6 +1,6 @@
 name = "exchangeability"
 version = "0.1.0"
-defaultTargets = ["exchangeability", "Exchangeability", "ForMathlib"]
+defaultTargets = ["Exchangeability", "ForMathlib"]
 
 [[require]]
 name = "mathlib"
@@ -16,7 +16,3 @@ name = "ForMathlib"
 
 [[lean_lib]]
 name = "Exchangeability"
-
-[[lean_exe]]
-name = "exchangeability"
-root = "Main"


### PR DESCRIPTION
Remove [[lean_exe]] section from lakefile.toml. The docgen-action script was trying to build exchangeability:docs but the docs facet only exists for lean_lib targets, not lean_exe.

The Main.lean was just an informational welcome message and is not essential for the mathematical proofs.