### PR TITLE
docs: Improve documentation site and clean up docstrings

### DIFF
--- a/Exchangeability/ConditionallyIID.lean
+++ b/Exchangeability/ConditionallyIID.lean
@@ -22,8 +22,6 @@ exchangeable. This establishes one direction of de Finetti's representation theo
 * `ConditionallyIID μ X`: A sequence `X` is conditionally i.i.d. under measure `μ` if
   there exists a probability kernel `ν : Ω → Measure α` such that coordinates are
   independent given `ν(ω)`, with each coordinate distributed as `ν(ω)`.
-* `MixtureOfIID`: A sequence whose distribution is a mixture of i.i.d. distributions
-  (placeholder for future development).
 
 ## Main results
 
@@ -43,7 +41,7 @@ This file proves: **conditionally i.i.d. ⇒ exchangeable**
 - **Conditionally i.i.d. ⇒ exchangeable** (this file): Direct from definition using
   permutation invariance of product measures.
 - **Exchangeable ⇒ contractable** (`Contractability.lean`): Via permutation extension.
-- **Contractable ⇒ exchangeable** (`DeFinetti/*.lean`): Deep result using ergodic theory.
+- **Contractable ⇒ exchangeable** (`DeFinetti/Theorem.lean`): Deep result using ergodic theory.
 - **Exchangeable ⇒ conditionally i.i.d.** (de Finetti's theorem): The hard direction,
   requiring the existence of a random measure (the de Finetti measure).
 
@@ -196,16 +194,6 @@ def ConditionallyIID (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
       ∀ (m : ℕ) (k : Fin m → ℕ), StrictMono k →
         Measure.map (fun ω => fun i : Fin m => X (k i) ω) μ
           = μ.bind (fun ω => Measure.pi fun _ : Fin m => ν ω)
-
-/-- A random sequence ξ is a **mixture of i.i.d.** sequences if its distribution is a mixture of
-i.i.d. distributions: P{ξ ∈ ·} = E[ν^∞] = ∫ m^∞ P(ν ∈ dm).
-
-This is an abbreviation for `ConditionallyIID`. The names emphasize different perspectives:
-- "ConditionallyIID" emphasizes conditional independence given the directing random measure
-- "MixtureOfIID" emphasizes that the overall distribution is a mixture over directing measures
-
-**Reference:** Kallenberg (2005), Theorem 1.1 (page 27-28). -/
-abbrev MixtureOfIID (μ : Measure Ω) (X : ℕ → Ω → α) : Prop := ConditionallyIID μ X
 
 /-- Helper lemma: Permuting coordinates after taking a product is the same as taking the product
 and then permuting. -/

--- a/Exchangeability/Contractability.lean
+++ b/Exchangeability/Contractability.lean
@@ -43,7 +43,7 @@ extension argument.
 
 - **Exchangeable → contractable** (this file): Any strictly increasing subsequence
   can be realized as the image of the first m coordinates under some permutation.
-- **Contractable → exchangeable** (`Exchangeability/DeFinetti/*.lean`): Uses ergodic
+- **Contractable → exchangeable** (`Exchangeability/DeFinetti/Theorem.lean`): Uses ergodic
   theory and the martingale convergence approach.
 - **Exchangeable ↔ fully exchangeable** (`Exchangeability/Exchangeability.lean`):
   Uses π-system uniqueness and finite approximation of infinite permutations.

--- a/home_page/_layouts/default.html
+++ b/home_page/_layouts/default.html
@@ -30,7 +30,7 @@
     <a href="blueprint" class="btn">Blueprint (web)</a>
     <a href="blueprint.pdf" class="btn">Blueprint (pdf)</a>
     <a href="blueprint/dep_graph_document.html" class="btn">Dependency Graph</a>
-    <a href="docs" class="btn">API Docs</a>
+    <a href="docs" class="btn">Documentation</a>
     {% if site.github.is_project_page %}
     <a href="{{ site.github.repository_url }}" class="btn">GitHub</a>
     {% endif %}

--- a/home_page/index.md
+++ b/home_page/index.md
@@ -11,7 +11,7 @@ A formalization of **de Finetti's theorem** for infinite sequences on standard B
 2. **(Exchangeable)** Distribution invariant under finite permutations
 3. **(Conditionally i.i.d.)** Coordinates are i.i.d. given the tail σ-algebra
 
-## Three Independent Proofs
+## Three Proofs
 
 We formalize **all three proofs** from Kallenberg (2005):
 
@@ -23,9 +23,10 @@ We formalize **all three proofs** from Kallenberg (2005):
 
 ## Links
 
-* [API Documentation]({{ site.url }}/docs/) - Generated Lean documentation
 * [Blueprint]({{ site.url }}/blueprint/) - Proof structure with Lean links
+* [Blueprint (PDF)]({{ site.url }}/blueprint/print.pdf) - Printable version
 * [Dependency Graph]({{ site.url }}/blueprint/dep_graph_document.html) - Interactive visualization
+* [Documentation]({{ site.url }}/docs/) - Generated Lean documentation
 * [GitHub Repository](https://github.com/cameronfreer/exchangeability)
 
 ## References


### PR DESCRIPTION
## Summary

Improvements to the documentation site and docstring cleanup based on reviewer feedback.

### Home page changes
- "API Docs" button → "Documentation" 
- Reorder Links section to match button order
- Remove "Independent" from "Three Proofs" heading (was confusing)
- Add Blueprint PDF link to Links section

### Docstring cleanup
- Remove unused `MixtureOfIID` abbreviation (was a placeholder for a measure-based definition that was never needed)
- Fix wildcard references `DeFinetti/*.lean` → `DeFinetti/Theorem.lean` (wildcards created broken links in generated docs)

## Test plan

- [x] `lake build` passes
- [ ] After merge: verify home page renders correctly
- [ ] Verify "Documentation" button works
- [ ] Check that doc links no longer 404 for wildcard references

🤖 Generated with [Claude Code](https://claude.com/claude-code)