### PR TITLE
chore: golf measurability proofs with fun_prop automation

### DIFF
--- a/Exchangeability/Bridge/CesaroToCondExp.lean
+++ b/Exchangeability/Bridge/CesaroToCondExp.lean
@@ -45,7 +45,7 @@ def pathify {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α] (X : ℕ �
     Ω → PathSpace α :=
   fun ω n => X n ω
 
-@[measurability]
+@[measurability, fun_prop]
 lemma measurable_pathify {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α] {X : ℕ → Ω → α}
     (hX_meas : ∀ n, Measurable (X n)) :
     Measurable (pathify X) :=

--- a/Exchangeability/Bridge/CesaroToCondExp.lean
+++ b/Exchangeability/Bridge/CesaroToCondExp.lean
@@ -48,7 +48,10 @@ def pathify {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α] (X : ℕ �
 lemma measurable_pathify {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α] {X : ℕ → Ω → α}
     (hX_meas : ∀ n, Measurable (X n)) :
     Measurable (pathify X) :=
-  measurable_pi_lambda _ hX_meas
+  by
+    rw [measurable_pi_iff]
+    intro n
+    simpa [pathify] using hX_meas n
 
 /-- Law of the process as a probability measure on path space. -/
 def μ_path {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]

--- a/Exchangeability/Bridge/CesaroToCondExp.lean
+++ b/Exchangeability/Bridge/CesaroToCondExp.lean
@@ -45,13 +45,14 @@ def pathify {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α] (X : ℕ �
     Ω → PathSpace α :=
   fun ω n => X n ω
 
+@[measurability]
 lemma measurable_pathify {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α] {X : ℕ → Ω → α}
     (hX_meas : ∀ n, Measurable (X n)) :
     Measurable (pathify X) :=
   by
-    rw [measurable_pi_iff]
-    intro n
-    simpa [pathify] using hX_meas n
+    have h : Measurable (fun ω => fun n => X n ω) := by
+      fun_prop
+    simpa [pathify] using h
 
 /-- Law of the process as a probability measure on path space. -/
 def μ_path {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
@@ -141,6 +142,7 @@ lemma contractable_shift_invariant_law {Ω : Type*} [MeasurableSpace Ω]
   rw [hX n k hk_strictMono]
 
 /-- Measurability of `shift` on path space. -/
+@[measurability, fun_prop]
 lemma measurable_shift_real : Measurable (shift (α := ℝ)) :=
   shift_measurable
 

--- a/Exchangeability/ConditionallyIID.lean
+++ b/Exchangeability/ConditionallyIID.lean
@@ -237,10 +237,10 @@ theorem exchangeable_of_conditionallyIID {μ : Measure Ω} {X : ℕ → Ω → �
   have h_id : Measure.map (fun ω i => X i.val ω) μ =
               μ.bind (fun ω => Measure.pi fun _ : Fin n => ν ω) :=
     hν_eq n (fun i => i.val) (fun _ _ => id)
-  have hXvec_meas : Measurable (fun ω => fun i : Fin n => X i.val ω) :=
-    measurable_pi_lambda _ (fun i => hX_meas i.val)
-  have hperm_meas : Measurable (fun f : Fin n → α => f ∘ σ) :=
-    measurable_pi_lambda _ (fun i => measurable_pi_apply (σ i))
+  have hXvec_meas : Measurable (fun ω => fun i : Fin n => X i.val ω) := by
+    fun_prop
+  have hperm_meas : Measurable (fun f : Fin n → α => f ∘ σ) := by
+    fun_prop
   calc Measure.map (fun ω i => X (σ i).val ω) μ
       = Measure.map (fun f => f ∘ σ) (Measure.map (fun ω i => X i.val ω) μ) :=
           (Measure.map_map hperm_meas hXvec_meas).symm

--- a/Exchangeability/Contractability.lean
+++ b/Exchangeability/Contractability.lean
@@ -138,7 +138,7 @@ lemma FullyExchangeable.exchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
   let π := extendFinPerm σ
   have hπ := hX π
   let proj : (ℕ → α) → (Fin n → α) := fun f i => f i.val
-  have hproj_meas : Measurable proj := by measurability
+  have hproj_meas : Measurable proj := by fun_prop
   have hmap₁ :=
     Measure.map_map (μ:=μ)
       (f:=fun ω => fun i : ℕ => X (π i) ω)
@@ -373,7 +373,7 @@ lemma exists_perm_extending_strictMono {m n : ℕ} (k : Fin m → ℕ)
 from (Fin n → α) to itself (with product σ-algebra). -/
 lemma measurable_perm_map {n : ℕ} (σ : Equiv.Perm (Fin n)) :
     Measurable (fun (h : Fin n → α) => fun i => h (σ i)) := by
-  measurability
+  fun_prop
 
 /-- Helper lemma: Permuting the output coordinates doesn't change the measure.
 If f and g produce the same measure, then f ∘ σ and g ∘ σ produce the same measure. -/

--- a/Exchangeability/Contractability.lean
+++ b/Exchangeability/Contractability.lean
@@ -517,7 +517,7 @@ theorem contractable_of_exchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
     let proj : (Fin n → α) → (Fin (m' + 1) → α) := fun f i => f (ι i)
 
     have hproj_meas : Measurable proj := by
-      exact measurable_pi_lambda _ (fun i => measurable_pi_apply (ι i))
+      fun_prop
 
     -- Project both sides to the first m' + 1 coordinates
     have hproj_eq : Measure.map (proj ∘ fun ω j => X (σ j).val ω) μ =

--- a/Exchangeability/Contractability.lean
+++ b/Exchangeability/Contractability.lean
@@ -369,7 +369,7 @@ lemma exists_perm_extending_strictMono {m n : ℕ} (k : Fin m → ℕ)
   have hσ_val : (σ (ι i)).val = k i := by simpa [kFin] using congrArg Fin.val (hσ_apply i)
   simpa [ι] using hσ_val
 
-/-- Helper: relabeling coordinates by a finite permutation is measurable as a map
+/- Helper: relabeling coordinates by a finite permutation is measurable as a map
 from (Fin n → α) to itself (with product σ-algebra). -/
 lemma measurable_perm_map {n : ℕ} (σ : Equiv.Perm (Fin n)) :
     Measurable (fun (h : Fin n → α) => fun i => h (σ i)) := by

--- a/Exchangeability/Contractability.lean
+++ b/Exchangeability/Contractability.lean
@@ -144,13 +144,13 @@ lemma FullyExchangeable.exchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
       (f:=fun ω => fun i : ℕ => X (π i) ω)
       (g:=proj)
       hproj_meas
-      (measurable_pi_lambda _ (fun i => hX_meas (π i)))
+      (by fun_prop)
   have hmap₂ :=
     Measure.map_map (μ:=μ)
       (f:=fun ω => fun i : ℕ => X i ω)
       (g:=proj)
       hproj_meas
-      (measurable_pi_lambda _ (fun i => hX_meas i))
+      (by fun_prop)
   have hprojσ :
       proj ∘ (fun ω => fun i : ℕ => X (π i) ω)
         = fun ω => fun i : Fin n => X (σ i) ω := by
@@ -457,9 +457,10 @@ private lemma exchangeable_preserves_projection {μ : Measure Ω} {X : ℕ → �
     Measure.map (proj ∘ fun ω j => X j.val ω) μ := by
   intro ι proj
   have hproj_meas : Measurable proj :=
-    measurable_pi_lambda _ (fun i => measurable_pi_apply (ι i))
-  rw [← Measure.map_map hproj_meas (measurable_pi_lambda _ (fun j => hX_meas (σ j).val)),
-      ← Measure.map_map hproj_meas (measurable_pi_lambda _ (fun j => hX_meas j.val))]
+    by
+      fun_prop
+  rw [← Measure.map_map hproj_meas (by fun_prop),
+      ← Measure.map_map hproj_meas (by fun_prop)]
   exact congrArg (Measure.map proj) hexch
 
 /--
@@ -515,22 +516,26 @@ theorem contractable_of_exchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
     let ι : Fin (m' + 1) → Fin n := fun i => ⟨i.val, Nat.lt_of_lt_of_le i.isLt hmn⟩
     let proj : (Fin n → α) → (Fin (m' + 1) → α) := fun f i => f (ι i)
 
-    have hproj_meas : Measurable proj :=
-      measurable_pi_lambda _ (fun i => measurable_pi_apply (ι i))
+    have hproj_meas : Measurable proj := by
+      exact measurable_pi_lambda _ (fun i => measurable_pi_apply (ι i))
 
     -- Project both sides to the first m' + 1 coordinates
     have hproj_eq : Measure.map (proj ∘ fun ω j => X (σ j).val ω) μ =
                      Measure.map (proj ∘ fun ω j => X j.val ω) μ := by
-      rw [← Measure.map_map hproj_meas (measurable_pi_lambda _ (fun j => hX_meas (σ j).val)),
-          ← Measure.map_map hproj_meas (measurable_pi_lambda _ (fun j => hX_meas j.val))]
+      rw [← Measure.map_map hproj_meas (by fun_prop),
+          ← Measure.map_map hproj_meas (by fun_prop)]
       exact congrArg (Measure.map proj) hexch
 
     -- The projected functions match our desired subsequences
     have hlhs_eq : (proj ∘ fun ω j => X (σ j).val ω) = (fun ω i => X (k i) ω) := by
-      ext ω i; simp only [proj, Function.comp_apply, ι]; rw [hσ i]
+      ext ω i
+      have hσi : (σ (ι i)).val = k i := by
+        simpa [ι] using hσ i
+      simp [proj, Function.comp_apply, hσi]
 
     have hrhs_eq : (proj ∘ fun ω j => X j.val ω) = (fun ω i => X i.val ω) := by
-      ext ω i; simp only [proj, Function.comp_apply, ι]
+      ext ω i
+      simp [proj, Function.comp_apply, ι]
 
     rwa [hlhs_eq, hrhs_eq] at hproj_eq
 

--- a/Exchangeability/Core.lean
+++ b/Exchangeability/Core.lean
@@ -86,9 +86,12 @@ lemma prefixProj_apply {n : ℕ} (x : ℕ → α) (i : Fin n) :
 lemma measurable_prefixProj {n : ℕ} :
     Measurable (prefixProj (α:=α) n) :=
   by
-    rw [measurable_pi_iff]
-    intro i
-    simpa [prefixProj] using (measurable_pi_apply (δ := ℕ) (X := fun _ : ℕ => α) (a := (i : ℕ)))
+    simpa [prefixProj] using
+      (measurable_pi_lambda
+        (f := prefixProj (α := α) n)
+        (fun i => by
+          change Measurable fun c : ℕ → α => c (i : ℕ)
+          exact measurable_pi_apply (i : ℕ)))
 
 /--
 Cylinder set determined by the first `n` coordinates.
@@ -201,9 +204,8 @@ set_option linter.unusedSectionVars false
 lemma takePrefix_measurable {m n : ℕ} (hmn : m ≤ n) :
     Measurable (takePrefix (α:=α) hmn) :=
   by
-    rw [measurable_pi_iff]
-    intro i
-    simpa [takePrefix] using (measurable_pi_apply (Fin.castLE hmn i))
+    simpa [takePrefix] using
+      (measurable_pi_lambda (f := takePrefix (α := α) hmn) (fun i => measurable_pi_apply (Fin.castLE hmn i)))
 
 @[measurability, nolint unusedArguments]
 lemma extendSet_measurable {m n : ℕ} {S : Set (Fin m → α)} {hmn : m ≤ n}
@@ -404,9 +406,8 @@ lemma reindex_apply {π : Equiv.Perm ℕ} (x : ℕ → α) (i : ℕ) :
 lemma measurable_reindex {π : Equiv.Perm ℕ} :
     Measurable (reindex (α:=α) π) :=
   by
-    rw [measurable_pi_iff]
-    intro i
-    simpa [reindex] using (measurable_pi_apply (π i))
+    simpa [reindex] using
+      (measurable_pi_lambda (f := reindex (α := α) π) (fun i => measurable_pi_apply (π i)))
 
 /--
 The path law (or joint distribution) of a stochastic process.

--- a/Exchangeability/Core.lean
+++ b/Exchangeability/Core.lean
@@ -82,6 +82,7 @@ omit [MeasurableSpace α] in
 lemma prefixProj_apply {n : ℕ} (x : ℕ → α) (i : Fin n) :
     prefixProj (α:=α) n x i = x i := rfl
 
+@[measurability, fun_prop]
 lemma measurable_prefixProj {n : ℕ} :
     Measurable (prefixProj (α:=α) n) :=
   by
@@ -196,7 +197,7 @@ variable [MeasurableSpace α]
 -- this transitive dependency and incorrectly suggests omitting `[MeasurableSpace α]`.
 set_option linter.unusedSectionVars false
 
-@[nolint unusedArguments]
+@[measurability, fun_prop, nolint unusedArguments]
 lemma takePrefix_measurable {m n : ℕ} (hmn : m ≤ n) :
     Measurable (takePrefix (α:=α) hmn) :=
   by
@@ -204,7 +205,7 @@ lemma takePrefix_measurable {m n : ℕ} (hmn : m ≤ n) :
     intro i
     simpa [takePrefix] using (measurable_pi_apply (Fin.castLE hmn i))
 
-@[nolint unusedArguments]
+@[measurability, nolint unusedArguments]
 lemma extendSet_measurable {m n : ℕ} {S : Set (Fin m → α)} {hmn : m ≤ n}
     (hS : MeasurableSet S) : MeasurableSet (extendSet (α:=α) hmn S) :=
   (takePrefix_measurable (α:=α) hmn) hS
@@ -399,15 +400,13 @@ def reindex (π : Equiv.Perm ℕ) (x : ℕ → α) : ℕ → α := fun i => x (�
 lemma reindex_apply {π : Equiv.Perm ℕ} (x : ℕ → α) (i : ℕ) :
     reindex (α:=α) π x i = x (π i) := rfl
 
-@[nolint unusedArguments]
+@[measurability, fun_prop, nolint unusedArguments]
 lemma measurable_reindex {π : Equiv.Perm ℕ} :
     Measurable (reindex (α:=α) π) :=
   by
     rw [measurable_pi_iff]
     intro i
     simpa [reindex] using (measurable_pi_apply (π i))
-
-attribute [measurability, fun_prop] measurable_prefixProj takePrefix_measurable measurable_reindex
 
 /--
 The path law (or joint distribution) of a stochastic process.

--- a/Exchangeability/Core.lean
+++ b/Exchangeability/Core.lean
@@ -84,7 +84,10 @@ lemma prefixProj_apply {n : ℕ} (x : ℕ → α) (i : Fin n) :
 
 lemma measurable_prefixProj {n : ℕ} :
     Measurable (prefixProj (α:=α) n) :=
-  measurable_pi_lambda _ (fun i => measurable_pi_apply (↑i : ℕ))
+  by
+    exact
+      (measurable_pi_lambda (f := fun x : ℕ → α => fun i : Fin n => x i)
+        (fun i => (measurable_pi_apply (δ := ℕ) (X := fun _ : ℕ => α) (a := (i : ℕ)))))
 
 /--
 Cylinder set determined by the first `n` coordinates.
@@ -196,7 +199,8 @@ set_option linter.unusedSectionVars false
 @[nolint unusedArguments]
 lemma takePrefix_measurable {m n : ℕ} (hmn : m ≤ n) :
     Measurable (takePrefix (α:=α) hmn) :=
-  measurable_pi_lambda _ (fun i => measurable_pi_apply (Fin.castLE hmn i))
+  by
+    exact measurable_pi_lambda _ (fun i => measurable_pi_apply (Fin.castLE hmn i))
 
 @[nolint unusedArguments]
 lemma extendSet_measurable {m n : ℕ} {S : Set (Fin m → α)} {hmn : m ≤ n}
@@ -396,9 +400,10 @@ lemma reindex_apply {π : Equiv.Perm ℕ} (x : ℕ → α) (i : ℕ) :
 @[nolint unusedArguments]
 lemma measurable_reindex {π : Equiv.Perm ℕ} :
     Measurable (reindex (α:=α) π) :=
-  measurable_pi_lambda _ (fun i => measurable_pi_apply (π i))
+  by
+    exact measurable_pi_lambda _ (fun i => measurable_pi_apply (π i))
 
-attribute [measurability] measurable_prefixProj takePrefix_measurable measurable_reindex
+attribute [measurability, fun_prop] measurable_prefixProj takePrefix_measurable measurable_reindex
 
 /--
 The path law (or joint distribution) of a stochastic process.
@@ -463,12 +468,12 @@ lemma fullyExchangeable_iff_pathLaw_invariant {μ : Measure Ω}
   constructor
   · intro hFull π
     rw [Measure.map_map (measurable_reindex (α:=α) (π:=π))
-      (measurable_pi_lambda _ (fun i => hX i))]
+      (by fun_prop)]
     exact hFull π
   · intro hPath π
     have := hPath π
     rwa [Measure.map_map (measurable_reindex (α:=α) (π:=π))
-      (measurable_pi_lambda _ (fun i => hX i))] at this
+      (by fun_prop)] at this
 
 /-!
 ### Auxiliary combinatorics: approximating infinite permutations
@@ -609,10 +614,10 @@ lemma marginals_perm_eq {μ : Measure Ω} (X : ℕ → Ω → α)
     have hm : n ≤ m := le_permBound (π:=π) (n:=n)
     set σ := approxPerm (π:=π) (n:=n) with hσ_def
     have hσ := hμ m σ
-    have hX₁ : Measurable fun ω => fun i : Fin m => X i ω :=
-      measurable_pi_lambda _ (fun i => hX i)
-    have hX₂ : Measurable fun ω => fun i : Fin m => X (σ i) ω :=
-      measurable_pi_lambda _ (fun i => hX _)
+    have hX₁ : Measurable fun ω => fun i : Fin m => X i ω := by
+      fun_prop
+    have hX₂ : Measurable fun ω => fun i : Fin m => X (σ i) ω := by
+      fun_prop
     have hproj : Measurable (takePrefix (α:=α) hm) := takePrefix_measurable (α:=α) hm
     have hmap₁ :=
       Measure.map_map (μ:=μ)
@@ -697,7 +702,7 @@ private lemma pathLaw_map_reindex_comm {μ : Measure Ω} {X : ℕ → Ω → α}
   rw [hμX]
   simp only [pathLaw]
   rw [Measure.map_map (measurable_reindex (α:=α) (π:=π))
-    (measurable_pi_lambda _ (fun i => hX i))]
+    (by fun_prop)]
   rfl
 
 @[nolint unusedArguments]
@@ -712,13 +717,18 @@ theorem exchangeable_iff_fullyExchangeable {μ : Measure Ω}
     let μX := pathLaw (α:=α) μ X
     have hμ_univ : μ Set.univ = 1 := measure_univ
     have hμX_univ : μX Set.univ = 1 := by
-      simp [μX, pathLaw, Measure.map_apply_of_aemeasurable,
-        (measurable_pi_lambda _ (fun i => hX i)).aemeasurable, hμ_univ]
+      have hX_meas : Measurable fun ω => fun i : ℕ => X i ω := by
+        exact measurable_pi_lambda _ (fun i => hX i)
+      dsimp [μX, pathLaw]
+      rw [Measure.map_apply_of_aemeasurable (hX_meas.aemeasurable) MeasurableSet.univ]
+      simp [hμ_univ]
     haveI : IsProbabilityMeasure μX := ⟨by simpa using hμX_univ⟩
     have hμXπ_univ :
         Measure.map (reindex (α:=α) π) μX Set.univ = 1 := by
-      simp [Measure.map_apply_of_aemeasurable,
-        (measurable_reindex (α:=α) (π:=π)).aemeasurable, hμX_univ]
+      rw [Measure.map_apply_of_aemeasurable
+        (by simpa using (measurable_reindex (α:=α) (π:=π)).aemeasurable)
+        MeasurableSet.univ]
+      simp [hμX_univ]
     haveI : IsProbabilityMeasure (Measure.map (reindex (α:=α) π) μX) :=
       ⟨by simpa using hμXπ_univ⟩
 

--- a/Exchangeability/Core.lean
+++ b/Exchangeability/Core.lean
@@ -84,14 +84,8 @@ lemma prefixProj_apply {n : ℕ} (x : ℕ → α) (i : Fin n) :
 
 @[measurability, fun_prop]
 lemma measurable_prefixProj {n : ℕ} :
-    Measurable (prefixProj (α:=α) n) :=
-  by
-    simpa [prefixProj] using
-      (measurable_pi_lambda
-        (f := prefixProj (α := α) n)
-        (fun i => by
-          change Measurable fun c : ℕ → α => c (i : ℕ)
-          exact measurable_pi_apply (i : ℕ)))
+    Measurable (prefixProj (α:=α) n) := by
+  unfold prefixProj; fun_prop
 
 /--
 Cylinder set determined by the first `n` coordinates.
@@ -202,10 +196,8 @@ set_option linter.unusedSectionVars false
 
 @[measurability, fun_prop, nolint unusedArguments]
 lemma takePrefix_measurable {m n : ℕ} (hmn : m ≤ n) :
-    Measurable (takePrefix (α:=α) hmn) :=
-  by
-    simpa [takePrefix] using
-      (measurable_pi_lambda (f := takePrefix (α := α) hmn) (fun i => measurable_pi_apply (Fin.castLE hmn i)))
+    Measurable (takePrefix (α:=α) hmn) := by
+  unfold takePrefix; fun_prop
 
 @[measurability, nolint unusedArguments]
 lemma extendSet_measurable {m n : ℕ} {S : Set (Fin m → α)} {hmn : m ≤ n}
@@ -404,10 +396,8 @@ lemma reindex_apply {π : Equiv.Perm ℕ} (x : ℕ → α) (i : ℕ) :
 
 @[measurability, fun_prop, nolint unusedArguments]
 lemma measurable_reindex {π : Equiv.Perm ℕ} :
-    Measurable (reindex (α:=α) π) :=
-  by
-    simpa [reindex] using
-      (measurable_pi_lambda (f := reindex (α := α) π) (fun i => measurable_pi_apply (π i)))
+    Measurable (reindex (α:=α) π) := by
+  unfold reindex; fun_prop
 
 /--
 The path law (or joint distribution) of a stochastic process.

--- a/Exchangeability/Core.lean
+++ b/Exchangeability/Core.lean
@@ -240,8 +240,7 @@ lemma cylinder_subset_prefixCylinders {s : Finset ℕ} {S : Set (∀ _ : s, α)}
   -- Transport `S` along the inclusion into the initial segment.
   let ι : s → Fin N := fun x => ⟨x.1, h_mem x.1 x.2⟩
   let pull : (Fin N → α) → (∀ i : s, α) := fun x => fun y => x (ι y)
-  have hpull_meas : Measurable pull := by
-    measurability
+  have hpull_meas : Measurable pull := by fun_prop
   have hs_eq :
       MeasureTheory.cylinder (α:=fun _ : ℕ => α) s S =
         prefixCylinder (α:=α) (pull ⁻¹' S) := by

--- a/Exchangeability/Core.lean
+++ b/Exchangeability/Core.lean
@@ -85,9 +85,9 @@ lemma prefixProj_apply {n : ℕ} (x : ℕ → α) (i : Fin n) :
 lemma measurable_prefixProj {n : ℕ} :
     Measurable (prefixProj (α:=α) n) :=
   by
-    exact
-      (measurable_pi_lambda (f := fun x : ℕ → α => fun i : Fin n => x i)
-        (fun i => (measurable_pi_apply (δ := ℕ) (X := fun _ : ℕ => α) (a := (i : ℕ)))))
+    rw [measurable_pi_iff]
+    intro i
+    simpa [prefixProj] using (measurable_pi_apply (δ := ℕ) (X := fun _ : ℕ => α) (a := (i : ℕ)))
 
 /--
 Cylinder set determined by the first `n` coordinates.
@@ -200,7 +200,9 @@ set_option linter.unusedSectionVars false
 lemma takePrefix_measurable {m n : ℕ} (hmn : m ≤ n) :
     Measurable (takePrefix (α:=α) hmn) :=
   by
-    exact measurable_pi_lambda _ (fun i => measurable_pi_apply (Fin.castLE hmn i))
+    rw [measurable_pi_iff]
+    intro i
+    simpa [takePrefix] using (measurable_pi_apply (Fin.castLE hmn i))
 
 @[nolint unusedArguments]
 lemma extendSet_measurable {m n : ℕ} {S : Set (Fin m → α)} {hmn : m ≤ n}
@@ -401,7 +403,9 @@ lemma reindex_apply {π : Equiv.Perm ℕ} (x : ℕ → α) (i : ℕ) :
 lemma measurable_reindex {π : Equiv.Perm ℕ} :
     Measurable (reindex (α:=α) π) :=
   by
-    exact measurable_pi_lambda _ (fun i => measurable_pi_apply (π i))
+    rw [measurable_pi_iff]
+    intro i
+    simpa [reindex] using (measurable_pi_apply (π i))
 
 attribute [measurability, fun_prop] measurable_prefixProj takePrefix_measurable measurable_reindex
 
@@ -718,7 +722,7 @@ theorem exchangeable_iff_fullyExchangeable {μ : Measure Ω}
     have hμ_univ : μ Set.univ = 1 := measure_univ
     have hμX_univ : μX Set.univ = 1 := by
       have hX_meas : Measurable fun ω => fun i : ℕ => X i ω := by
-        exact measurable_pi_lambda _ (fun i => hX i)
+        simpa using (show Measurable (fun ω => fun i : ℕ => X i ω) from by fun_prop)
       dsimp [μX, pathLaw]
       rw [Measure.map_apply_of_aemeasurable (hX_meas.aemeasurable) MeasurableSet.univ]
       simp [hμ_univ]

--- a/Exchangeability/DeFinetti/BridgeProperty.lean
+++ b/Exchangeability/DeFinetti/BridgeProperty.lean
@@ -87,7 +87,7 @@ lemma measure_eq_implies_lintegral_prod_eq
 
   -- Measurability of the mapping function
   have hf_meas : Measurable (fun ω => fun i : Fin m => X (k i) ω) := by
-    exact measurable_pi_iff.mpr fun i => hX_meas (k i)
+    measurability
 
   -- Characterization: ω in preimage ↔ ∀ i, X (k i) ω ∈ B i
   have hpre_mem : ∀ ω, ω ∈ ⋂ i : Fin m, (X (k i)) ⁻¹' (B i) ↔ ∀ i, X (k i) ω ∈ B i := by

--- a/Exchangeability/DeFinetti/CommonEnding.lean
+++ b/Exchangeability/DeFinetti/CommonEnding.lean
@@ -380,14 +380,11 @@ This connects the map in the ConditionallyIID definition to the probability of e
 
 This is a direct application of `Measure.map_apply` from mathlib. -/
 lemma map_coords_apply {μ : Measure Ω} (X : ℕ → Ω → α) (hX_meas : ∀ i, Measurable (X i))
-    (m : ℕ) (k : Fin m → ℕ) (B : Set (Fin m → α)) (hB : MeasurableSet B) :
+  (m : ℕ) (k : Fin m → ℕ) (B : Set (Fin m → α)) (hB : MeasurableSet B) :
     (Measure.map (fun ω i => X (k i) ω) μ) B = μ {ω | (fun i => X (k i) ω) ∈ B} := by
   -- The function (fun ω i => X (k i) ω) is measurable as a composition of measurable functions
   have h_meas : Measurable (fun ω i => X (k i) ω) := by
-    -- Use measurable_pi_iff: a function to a pi type is measurable iff each component is
-    rw [measurable_pi_iff]
-    intro i
-    exact hX_meas (k i)
+    fun_prop
   -- Apply Measure.map_apply
   rw [Measure.map_apply h_meas hB]
   -- The preimage is definitionally equal to the set we want
@@ -501,9 +498,7 @@ private lemma map_coords_isProbabilityMeasure {μ : Measure Ω} [IsProbabilityMe
     (X : ℕ → Ω → α) (hX_meas : ∀ i, Measurable (X i)) (m : ℕ) (k : Fin m → ℕ) :
     IsProbabilityMeasure (Measure.map (fun ω i => X (k i) ω) μ) := by
   have h_meas : Measurable (fun ω i => X (k i) ω) := by
-    rw [measurable_pi_iff]
-    intro i
-    exact hX_meas (k i)
+    fun_prop
   exact Measure.isProbabilityMeasure_map h_meas.aemeasurable
 
 -- Product of probability measures is a probability measure

--- a/Exchangeability/DeFinetti/ContractableVsExchangeable_Extras.lean
+++ b/Exchangeability/DeFinetti/ContractableVsExchangeable_Extras.lean
@@ -121,9 +121,11 @@ example :
   have hp : Measurable p := by
     exact (measurable_pi_apply (0 : Fin 2)).prod_mk (measurable_pi_apply (1 : Fin 2))
   have h_meas_left : Measurable (fun ω i : Fin 2 => X (σ i : ℕ) ω) :=
-    measurable_pi_lambda _ (fun i => hX_meas (σ i : ℕ))
+    by
+      fun_prop
   have h_meas_right : Measurable (fun ω i : Fin 2 => X (i : ℕ) ω) :=
-    measurable_pi_lambda _ (fun i => hX_meas (i : ℕ))
+    by
+      fun_prop
 
   have h := congrArg (fun ν => Measure.map p ν) hσ
   rw [Measure.map_map hp h_meas_left, Measure.map_map hp h_meas_right] at h

--- a/Exchangeability/DeFinetti/ContractableVsExchangeable_Extras.lean
+++ b/Exchangeability/DeFinetti/ContractableVsExchangeable_Extras.lean
@@ -164,7 +164,7 @@ example (m : ℝ) (hm : ∀ i, ∫ ω, X i ω ∂μ = m) (i : ℕ) :
       map_eq := h_map }
   -- Apply IdentDistrib.comp with g(x) = (x - m)²
   have h_comp : ProbabilityTheory.IdentDistrib (fun ω => (X i ω - m)^2) (fun ω => (X 0 ω - m)^2) μ μ :=
-    h_id.comp (by measurability : Measurable fun x => (x - m)^2)
+    h_id.comp (by fun_prop : Measurable fun x => (x - m)^2)
   -- Use IdentDistrib.integral_eq
   exact h_comp.integral_eq
 
@@ -184,7 +184,7 @@ example (m : ℝ) (hm : ∀ i, ∫ ω, X i ω ∂μ = m) {i j : ℕ} (hij : i < 
   have h_comp : ProbabilityTheory.IdentDistrib
       (fun ω => (X i ω - m) * (X j ω - m))
       (fun ω => (X 0 ω - m) * (X 1 ω - m)) μ μ :=
-    h_id.comp (by measurability : Measurable fun p : ℝ × ℝ => (p.1 - m) * (p.2 - m))
+    h_id.comp (by fun_prop : Measurable fun p : ℝ × ℝ => (p.1 - m) * (p.2 - m))
   -- Use IdentDistrib.integral_eq
   exact h_comp.integral_eq
 
@@ -230,7 +230,7 @@ example (m : ℝ) (hm : ∀ i, ∫ ω, X i ω ∂μ = m) {i j : ℕ} (hij : i �
     have h_comp : ProbabilityTheory.IdentDistrib
         (fun ω => (X i ω - m) * (X j ω - m))
         (fun ω => (X 0 ω - m) * (X 1 ω - m)) μ μ :=
-      h_id.comp (by measurability : Measurable fun p : ℝ × ℝ => (p.1 - m) * (p.2 - m))
+      h_id.comp (by fun_prop : Measurable fun p : ℝ × ℝ => (p.1 - m) * (p.2 - m))
     exact h_comp.integral_eq
   · -- Case i > j: use contractability with j < i, then symmetry of multiplication
     have hji : j < i := Nat.lt_of_le_of_ne (Nat.le_of_not_lt h_lt) (hij.symm)
@@ -244,7 +244,7 @@ example (m : ℝ) (hm : ∀ i, ∫ ω, X i ω ∂μ = m) {i j : ℕ} (hij : i �
     have h_comp : ProbabilityTheory.IdentDistrib
         (fun ω => (X j ω - m) * (X i ω - m))
         (fun ω => (X 0 ω - m) * (X 1 ω - m)) μ μ :=
-      h_id.comp (by measurability : Measurable fun p : ℝ × ℝ => (p.1 - m) * (p.2 - m))
+      h_id.comp (by fun_prop : Measurable fun p : ℝ × ℝ => (p.1 - m) * (p.2 - m))
     -- Use commutativity to swap: (X_i - m)(X_j - m) = (X_j - m)(X_i - m)
     calc ∫ ω, (X i ω - m) * (X j ω - m) ∂μ
         = ∫ ω, (X j ω - m) * (X i ω - m) ∂μ := by simp only [mul_comm]

--- a/Exchangeability/DeFinetti/L2Helpers.lean
+++ b/Exchangeability/DeFinetti/L2Helpers.lean
@@ -156,17 +156,9 @@ lemma contractable_map_pair (hX_contract : Contractable μ X) (hX_meas : ∀ i, 
     refine (measurable_eval_fin2 (i := fin2Zero)).prodMk ?_
     exact measurable_eval_fin2 (i := fin2One)
   have h_meas_k : Measurable fun ω => fun t : Fin 2 => X (k t) ω := by
-    refine measurable_pi_lambda _ ?_
-    intro t
-    by_cases ht : t = fin2Zero
-    · have : k t = i := by simp [k, ht]
-      simp [this]; exact hX_meas i
-    · have : k t = j := by simp [k, if_neg ht]
-      simp [this]; exact hX_meas j
+    fun_prop
   have h_meas_std : Measurable fun ω => fun t : Fin 2 => X t.val ω := by
-    refine measurable_pi_lambda _ ?_
-    intro t
-    simpa using hX_meas t.val
+    fun_prop
   have h_left := (Measure.map_map h_eval_meas h_meas_k (μ := μ)).symm
   have h_right := Measure.map_map h_eval_meas h_meas_std (μ := μ)
   have h_eval := congrArg (Measure.map eval) h_map
@@ -196,9 +188,7 @@ lemma contractable_comp (hX_contract : Contractable μ X) (hX_meas : ∀ i, Meas
   have h_base := hX_contract n k hk
   set Φ : (Fin n → ℝ) → (Fin n → ℝ) := fun g i => f (g i)
   have hΦ_meas : Measurable Φ := by
-    refine measurable_pi_lambda _ ?_
-    intro i
-    simpa [Φ] using hf_meas.comp (measurable_pi_apply i)
+    fun_prop
   have h_meas_k : Measurable fun ω => fun i : Fin n => X (k i) ω := by
     fun_prop
   have h_meas_std : Measurable fun ω => fun i : Fin n => X i.val ω := by

--- a/Exchangeability/DeFinetti/MartingaleHelpers.lean
+++ b/Exchangeability/DeFinetti/MartingaleHelpers.lean
@@ -84,7 +84,10 @@ lemma shiftSeq_apply {d : ℕ} (f : ℕ → β) (n : ℕ) :
 @[measurability, fun_prop]
 lemma measurable_shiftSeq {d : ℕ} :
     Measurable (shiftSeq (β:=β) d) :=
-  measurable_pi_lambda _ (fun n => measurable_pi_apply (n + d))
+  by
+    rw [measurable_pi_iff]
+    intro n
+    simpa [shiftSeq] using (measurable_pi_apply (n + d))
 
 lemma forall_mem_erase {γ : Type*} [DecidableEq γ]
     {s : Finset γ} {a : γ} {P : γ → Prop} (ha : a ∈ s) :

--- a/Exchangeability/DeFinetti/MartingaleHelpers.lean
+++ b/Exchangeability/DeFinetti/MartingaleHelpers.lean
@@ -81,7 +81,7 @@ omit [MeasurableSpace β] in
 lemma shiftSeq_apply {d : ℕ} (f : ℕ → β) (n : ℕ) :
     shiftSeq d f n = f (n + d) := rfl
 
-@[measurability]
+@[measurability, fun_prop]
 lemma measurable_shiftSeq {d : ℕ} :
     Measurable (shiftSeq (β:=β) d) :=
   measurable_pi_lambda _ (fun n => measurable_pi_apply (n + d))

--- a/Exchangeability/DeFinetti/MartingaleHelpers.lean
+++ b/Exchangeability/DeFinetti/MartingaleHelpers.lean
@@ -44,7 +44,7 @@ export PathSpace (tailCylinder tailCylinder_measurable cylinder finCylinder
   firstRCylinder_eq_preimage_finCylinder firstRCylinder_measurable_in_firstRSigma
   firstRCylinder_measurable_ambient measurable_firstRMap firstRSigma_le_ambient
   firstRSigma_mono firstRCylinder_zero mem_firstRCylinder_iff firstRCylinder_univ
-  firstRCylinder_inter drop drop_apply measurable_drop tailCylinder_eq_preimage_cylinder
+  firstRCylinder_inter tailCylinder_eq_preimage_cylinder
   mem_cylinder_iff mem_tailCylinder_iff cylinder_measurable_set cylinder_zero
   tailCylinder_zero' cylinder_univ tailCylinder_univ cylinder_inter)
 

--- a/Exchangeability/DeFinetti/MartingaleHelpers.lean
+++ b/Exchangeability/DeFinetti/MartingaleHelpers.lean
@@ -85,9 +85,8 @@ lemma shiftSeq_apply {d : ℕ} (f : ℕ → β) (n : ℕ) :
 lemma measurable_shiftSeq {d : ℕ} :
     Measurable (shiftSeq (β:=β) d) :=
   by
-    rw [measurable_pi_iff]
-    intro n
-    simpa [shiftSeq] using (measurable_pi_apply (n + d))
+    simpa [shiftSeq] using
+      (measurable_pi_lambda (f := shiftSeq (β := β) d) (fun n => measurable_pi_apply (n + d)))
 
 lemma forall_mem_erase {γ : Type*} [DecidableEq γ]
     {s : Finset γ} {a : γ} {P : γ → Prop} (ha : a ∈ s) :

--- a/Exchangeability/DeFinetti/MartingaleHelpers.lean
+++ b/Exchangeability/DeFinetti/MartingaleHelpers.lean
@@ -83,10 +83,8 @@ lemma shiftSeq_apply {d : ℕ} (f : ℕ → β) (n : ℕ) :
 
 @[measurability, fun_prop]
 lemma measurable_shiftSeq {d : ℕ} :
-    Measurable (shiftSeq (β:=β) d) :=
-  by
-    simpa [shiftSeq] using
-      (measurable_pi_lambda (f := shiftSeq (β := β) d) (fun n => measurable_pi_apply (n + d)))
+    Measurable (shiftSeq (β:=β) d) := by
+  unfold shiftSeq; fun_prop
 
 lemma forall_mem_erase {γ : Type*} [DecidableEq γ]
     {s : Finset γ} {a : γ} {P : γ → Prop} (ha : a ∈ s) :

--- a/Exchangeability/DeFinetti/TheoremViaKoopman.lean
+++ b/Exchangeability/DeFinetti/TheoremViaKoopman.lean
@@ -108,46 +108,12 @@ private lemma conditionallyIID_of_path_ciid
     (X : ℕ → Ω → ℝ) (hX_meas : ∀ i, Measurable (X i))
     (h : ConditionallyIID (μ_path μ X) (fun i (ω : ℕ → ℝ) => ω i)) :
     ConditionallyIID μ X := by
-  -- Extract the directing measure ν' on path space
-  obtain ⟨ν', hν'_prob, hν'_meas, h_marginal⟩ := h
-  -- Define the pathify map φ : Ω → (ℕ → ℝ)
-  let φ : Ω → (ℕ → ℝ) := fun ω i => X i ω
-  have hφ_meas : Measurable φ := measurable_pi_lambda _ hX_meas
-  -- Define ν = ν' ∘ φ as the directing measure on Ω
-  let ν : Ω → Measure ℝ := fun ω => ν' (φ ω)
-  refine ⟨ν, ?_, ?_, ?_⟩
-  · -- IsProbabilityMeasure (ν ω) for all ω
-    intro ω
-    exact hν'_prob (φ ω)
-  · -- Measurability: ∀ B, MeasurableSet B → Measurable (fun ω => ν ω B)
-    intro B hB
-    exact (hν'_meas B hB).comp hφ_meas
-  · -- Marginal condition
-    intro m k hk
-    -- Use the fact that μ_path μ X = μ.map φ
-    have h_path_def : μ_path μ X = μ.map φ := rfl
-    -- Specialize h_marginal
-    specialize h_marginal m k hk
-    -- LHS transformation: coordinates on path space compose with φ
-    have h_lhs : Measure.map (fun ω' => fun i => ω' (k i)) (μ.map φ)
-               = Measure.map (fun ω => fun i => X (k i) ω) μ := by
-      rw [Measure.map_map]
-      · rfl
-      · exact measurable_pi_lambda _ (fun i => measurable_pi_apply (k i))
-      · exact hφ_meas
-    -- RHS transformation: bind distributes over map
-    -- (μ.map φ).bind g = join (map g (μ.map φ)) = join (map (g ∘ φ) μ) = μ.bind (g ∘ φ)
-    have h_rhs : (μ.map φ).bind (fun ω' => Measure.pi fun (_ : Fin m) => ν' ω')
-               = μ.bind (fun ω => Measure.pi fun (_ : Fin m) => ν ω) := by
-      simp only [Measure.bind]
-      congr 1
-      have h_meas_pi : Measurable fun ω' => Measure.pi fun (_ : Fin m) => ν' ω' :=
-        measurable_measure_pi ν' hν'_prob hν'_meas
-      rw [Measure.map_map h_meas_pi hφ_meas]
-      rfl
-    -- Combine
-    rw [h_path_def] at h_marginal
-    rw [← h_lhs, h_marginal, h_rhs]
+  have h_path_ciid :
+      ConditionallyIID (μ.map (pathify X))
+        (fun i (ω : ℕ → ℝ) => ω i) := by
+    simpa [Exchangeability.Bridge.μ_path] using h
+  simpa [Exchangeability.Bridge.μ_path] using
+    conditionallyIID_transfer (μ := μ) X hX_meas h_path_ciid
 
 @[nolint unusedArguments]
 lemma deFinetti_RyllNardzewski_equivalence_viaKoopman

--- a/Exchangeability/DeFinetti/ViaKoopman.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman.lean
@@ -312,11 +312,14 @@ lemma pathSpace_contractable_of_contractable
   intro m k hk
   -- The path-space map is the pushforward of the original contractability
   have hφ_meas : Measurable (fun ω' i => X i ω') :=
-    measurable_pi_lambda _ (fun i => hX_meas i)
+    by
+      fun_prop
   have hk_meas : Measurable (fun (ω : Ω[α]) i => ω (k i)) :=
-    measurable_pi_lambda _ (fun i => measurable_pi_apply (k i))
+    by
+      fun_prop
   have hid_meas : Measurable (fun (ω : Ω[α]) (i : Fin m) => ω i.val) :=
-    measurable_pi_lambda _ (fun i => measurable_pi_apply i.val)
+    by
+      fun_prop
   -- Rewrite using composition
   rw [Measure.map_map hk_meas hφ_meas, Measure.map_map hid_meas hφ_meas]
   -- The compositions give the original contractability
@@ -345,9 +348,11 @@ lemma measure_map_shift_eq_of_contractable
     Measure.map (fun ω' i => X (i + 1) ω') μ = Measure.map (fun ω' i => X i ω') μ := by
   -- Both measures are probability measures
   have hφ_meas : Measurable (fun ω' i => X i ω') :=
-    measurable_pi_lambda _ (fun i => hX_meas i)
+    by
+      fun_prop
   have hφ1_meas : Measurable (fun ω' i => X (i + 1) ω') :=
-    measurable_pi_lambda _ (fun i => hX_meas (i + 1))
+    by
+      fun_prop
   haveI h1 : IsProbabilityMeasure (Measure.map (fun ω' i => X (i + 1) ω') μ) :=
     Measure.isProbabilityMeasure_map hφ1_meas.aemeasurable
   haveI h2 : IsProbabilityMeasure (Measure.map (fun ω' i => X i ω') μ) :=
@@ -392,7 +397,8 @@ lemma pathSpace_shift_preserving_of_contractable
   · exact shift_measurable
   · -- Use contractability with k(i) = i + 1
     have hφ_meas : Measurable (fun ω' i => X i ω') :=
-      measurable_pi_lambda _ (fun i => hX_meas i)
+      by
+        fun_prop
     rw [Measure.map_map shift_measurable hφ_meas]
     -- shift ∘ φ = (fun ω i => X (i+1) ω)
     have h_comp : shift ∘ (fun ω' i => X i ω') = fun ω' i => X (i + 1) ω' := by
@@ -420,7 +426,8 @@ lemma conditionallyIID_transfer
   obtain ⟨ν_path, hν_prob, hν_meas, h_bind⟩ := hCIID_path
   -- Define the directing measure on original space via composition
   let φ : Ω → Ω[α] := fun ω' i => X i ω'
-  have hφ_meas : Measurable φ := measurable_pi_lambda _ (fun i => hX_meas i)
+  have hφ_meas : Measurable φ := by
+    fun_prop
   -- The directing measure on Ω is ν_path ∘ φ
   let ν : Ω → Measure α := fun ω => ν_path (φ ω)
   use ν
@@ -440,7 +447,8 @@ lemma conditionallyIID_transfer
     have h_lhs : Measure.map (fun ω => fun i : Fin m => X (k i) ω) μ =
         Measure.map (fun (ω : Ω[α]) => fun i : Fin m => ω (k i)) (μ.map φ) := by
       have hk_meas : Measurable (fun (ω : Ω[α]) => fun i : Fin m => ω (k i)) :=
-        measurable_pi_lambda _ (fun i => measurable_pi_apply (k i))
+        by
+          fun_prop
       -- Use map_map forward: map f (map g μ) = map (f ∘ g) μ
       rw [Measure.map_map hk_meas hφ_meas]
       -- The composition (fun ω i => ω (k i)) ∘ φ = (fun ω i => X (k i) ω)
@@ -557,9 +565,11 @@ lemma indicator_product_bridge_contractable
   -- Step 5: Integral at ρ-indices equals integral at consecutive indices
   have h_ρ_to_consec : ∫ ω, ∏ j, fs_σ j (ω (ρ j)) ∂μ = ∫ ω, ∏ j, fs_σ j (ω j.val) ∂μ := by
     have hρ_meas : Measurable (fun (ω : Ω[α]) (j : Fin m) => ω (ρ j)) :=
-      measurable_pi_lambda _ (fun j => measurable_pi_apply (ρ j))
+      by
+        fun_prop
     have hconsec_meas : Measurable (fun (ω : Ω[α]) (j : Fin m) => ω j.val) :=
-      measurable_pi_lambda _ (fun j => measurable_pi_apply j.val)
+      by
+        fun_prop
     have hg_meas : Measurable (fun ω' : Fin m → α => ∏ j, fs_σ j (ω' j)) :=
       Finset.measurable_prod Finset.univ (fun j _ => (hfs_meas j).comp (measurable_pi_apply j))
     calc ∫ ω, ∏ j, fs_σ j (ω (ρ j)) ∂μ

--- a/Exchangeability/DeFinetti/ViaKoopman.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman.lean
@@ -394,7 +394,7 @@ lemma pathSpace_shift_preserving_of_contractable
     (hContract : Contractable μ X) :
     MeasurePreserving shift (μ.map (fun ω' i => X i ω')) (μ.map (fun ω' i => X i ω')) := by
   constructor
-  · exact shift_measurable
+  · fun_prop
   · -- Use contractability with k(i) = i + 1
     have hφ_meas : Measurable (fun ω' i => X i ω') :=
       by
@@ -657,7 +657,7 @@ lemma conditionallyIID_bind_of_contractable
   -- Apply CommonEnding.conditional_iid_from_directing_measure
   apply CommonEnding.conditional_iid_from_directing_measure
   -- 1. Coordinates are measurable
-  · exact fun i => measurable_pi_apply i
+  · fun_prop
   -- 2. ν is a probability measure at each point
   · intro ω
     exact ν_isProbabilityMeasure (μ := μ) ω

--- a/Exchangeability/DeFinetti/ViaKoopman/BlockAverage.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/BlockAverage.lean
@@ -287,9 +287,9 @@ lemma integral_prod_reindex_of_contractable
   have h_map := hContract m k hk
   -- The measurable function for mapping to Fin m → α
   have h_meas_orig : Measurable (fun ω (i : Fin m) => ω i.val : Ω[α] → (Fin m → α)) :=
-    measurable_pi_iff.mpr fun _ => measurable_pi_apply _
+    measurable_pi_lambda _ (fun _ => measurable_pi_apply _)
   have h_meas_reindex : Measurable (fun ω i => ω (k i) : Ω[α] → (Fin m → α)) :=
-    measurable_pi_iff.mpr fun _ => measurable_pi_apply _
+    measurable_pi_lambda _ (fun _ => measurable_pi_apply _)
   -- The integrand on Fin m → α
   let F : (Fin m → α) → ℝ := fun ω' => ∏ i, fs i (ω' i)
   have hF_meas_base : Measurable F :=

--- a/Exchangeability/DeFinetti/ViaKoopman/BlockAverage.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/BlockAverage.lean
@@ -287,9 +287,11 @@ lemma integral_prod_reindex_of_contractable
   have h_map := hContract m k hk
   -- The measurable function for mapping to Fin m → α
   have h_meas_orig : Measurable (fun ω (i : Fin m) => ω i.val : Ω[α] → (Fin m → α)) :=
-    measurable_pi_lambda _ (fun _ => measurable_pi_apply _)
+    by
+      fun_prop
   have h_meas_reindex : Measurable (fun ω i => ω (k i) : Ω[α] → (Fin m → α)) :=
-    measurable_pi_lambda _ (fun _ => measurable_pi_apply _)
+    by
+      fun_prop
   -- The integrand on Fin m → α
   let F : (Fin m → α) → ℝ := fun ω' => ∏ i, fs i (ω' i)
   have hF_meas_base : Measurable F :=

--- a/Exchangeability/DeFinetti/ViaKoopman/BlockAverage.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/BlockAverage.lean
@@ -88,7 +88,7 @@ lemma blockAvg_eq_cesaro_shifted {m n : ℕ} (hn : 0 < n) (k : Fin m) (f : α �
 
 /-! ### Measurability of Block Averages -/
 
-@[measurability]
+@[measurability, fun_prop]
 lemma measurable_blockAvg {m n : ℕ} (k : Fin m) {f : α → ℝ} (hf : Measurable f) :
     Measurable (blockAvg (α := α) m n k f) := by
   unfold blockAvg

--- a/Exchangeability/DeFinetti/ViaKoopman/BlockAverage.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/BlockAverage.lean
@@ -88,6 +88,7 @@ lemma blockAvg_eq_cesaro_shifted {m n : ℕ} (hn : 0 < n) (k : Fin m) (f : α �
 
 /-! ### Measurability of Block Averages -/
 
+@[measurability]
 lemma measurable_blockAvg {m n : ℕ} (k : Fin m) {f : α → ℝ} (hf : Measurable f) :
     Measurable (blockAvg (α := α) m n k f) := by
   unfold blockAvg

--- a/Exchangeability/DeFinetti/ViaKoopman/BlockInjection.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/BlockInjection.lean
@@ -141,11 +141,8 @@ lemma reindexBlock_apply (m n : ℕ) (j : Fin m → Fin n) (ω : ℕ → α) (i 
 /-- Reindexing by block injection is measurable. -/
 @[measurability, fun_prop]
 lemma measurable_reindexBlock (m n : ℕ) (j : Fin m → Fin n) :
-    Measurable (reindexBlock (α := α) m n j) :=
-  by
-    simpa [reindexBlock] using
-      (measurable_pi_lambda (f := reindexBlock (α := α) m n j)
-        (fun i => measurable_pi_apply (blockInjection m n j i)))
+    Measurable (reindexBlock (α := α) m n j) := by
+  unfold reindexBlock; fun_prop
 
 /-! ### Block Injection Properties for First m Coordinates -/
 

--- a/Exchangeability/DeFinetti/ViaKoopman/BlockInjection.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/BlockInjection.lean
@@ -143,9 +143,9 @@ lemma reindexBlock_apply (m n : ℕ) (j : Fin m → Fin n) (ω : ℕ → α) (i 
 lemma measurable_reindexBlock (m n : ℕ) (j : Fin m → Fin n) :
     Measurable (reindexBlock (α := α) m n j) :=
   by
-    rw [measurable_pi_iff]
-    intro i
-    simpa [reindexBlock] using (measurable_pi_apply (blockInjection m n j i))
+    simpa [reindexBlock] using
+      (measurable_pi_lambda (f := reindexBlock (α := α) m n j)
+        (fun i => measurable_pi_apply (blockInjection m n j i)))
 
 /-! ### Block Injection Properties for First m Coordinates -/
 

--- a/Exchangeability/DeFinetti/ViaKoopman/BlockInjection.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/BlockInjection.lean
@@ -142,7 +142,10 @@ lemma reindexBlock_apply (m n : ℕ) (j : Fin m → Fin n) (ω : ℕ → α) (i 
 @[measurability, fun_prop]
 lemma measurable_reindexBlock (m n : ℕ) (j : Fin m → Fin n) :
     Measurable (reindexBlock (α := α) m n j) :=
-  measurable_pi_lambda _ (fun i => measurable_pi_apply (blockInjection m n j i))
+  by
+    rw [measurable_pi_iff]
+    intro i
+    simpa [reindexBlock] using (measurable_pi_apply (blockInjection m n j i))
 
 /-! ### Block Injection Properties for First m Coordinates -/
 

--- a/Exchangeability/DeFinetti/ViaKoopman/BlockInjection.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/BlockInjection.lean
@@ -140,10 +140,8 @@ lemma reindexBlock_apply (m n : ℕ) (j : Fin m → Fin n) (ω : ℕ → α) (i 
 
 /-- Reindexing by block injection is measurable. -/
 lemma measurable_reindexBlock (m n : ℕ) (j : Fin m → Fin n) :
-    Measurable (reindexBlock (α := α) m n j) := by
-  rw [measurable_pi_iff]
-  intro i
-  exact measurable_pi_apply (blockInjection m n j i)
+    Measurable (reindexBlock (α := α) m n j) :=
+  measurable_pi_lambda _ (fun i => measurable_pi_apply (blockInjection m n j i))
 
 /-! ### Block Injection Properties for First m Coordinates -/
 

--- a/Exchangeability/DeFinetti/ViaKoopman/BlockInjection.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/BlockInjection.lean
@@ -139,6 +139,7 @@ lemma reindexBlock_apply (m n : ℕ) (j : Fin m → Fin n) (ω : ℕ → α) (i 
     reindexBlock m n j ω i = ω (blockInjection m n j i) := rfl
 
 /-- Reindexing by block injection is measurable. -/
+@[measurability, fun_prop]
 lemma measurable_reindexBlock (m n : ℕ) (j : Fin m → Fin n) :
     Measurable (reindexBlock (α := α) m n j) :=
   measurable_pi_lambda _ (fun i => measurable_pi_apply (blockInjection m n j i))

--- a/Exchangeability/DeFinetti/ViaKoopman/CylinderFunctions.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/CylinderFunctions.lean
@@ -48,6 +48,7 @@ lemma productCylinder_eq_cylinder {m : ℕ} (fs : Fin m → α → ℝ) :
     productCylinder fs = cylinderFunction (fun coords => ∏ k, fs k (coords k)) := rfl
 
 /-- Measurability of cylinder functions. -/
+@[measurability]
 lemma measurable_cylinderFunction {m : ℕ} {φ : (Fin m → α) → ℝ}
     (_hφ : Measurable φ) :
     Measurable (cylinderFunction φ) := by
@@ -56,6 +57,7 @@ lemma measurable_cylinderFunction {m : ℕ} {φ : (Fin m → α) → ℝ}
     Measurable fun ω : ℕ → α => fun k : Fin m => ω k.val)
 
 /-- Measurability of product cylinders. -/
+@[measurability]
 lemma measurable_productCylinder {m : ℕ} {fs : Fin m → α → ℝ}
     (hmeas : ∀ k, Measurable (fs k)) :
     Measurable (productCylinder fs) := by

--- a/Exchangeability/DeFinetti/ViaKoopman/CylinderFunctions.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/CylinderFunctions.lean
@@ -53,7 +53,7 @@ lemma measurable_cylinderFunction {m : ℕ} {φ : (Fin m → α) → ℝ}
     (_hφ : Measurable φ) :
     Measurable (cylinderFunction φ) := by
   classical
-  simpa [cylinderFunction] using _hφ.comp (by measurability :
+  simpa [cylinderFunction] using _hφ.comp (by fun_prop :
     Measurable fun ω : ℕ → α => fun k : Fin m => ω k.val)
 
 /-- Measurability of product cylinders. -/

--- a/Exchangeability/DeFinetti/ViaKoopman/CylinderFunctions.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/CylinderFunctions.lean
@@ -48,7 +48,7 @@ lemma productCylinder_eq_cylinder {m : ℕ} (fs : Fin m → α → ℝ) :
     productCylinder fs = cylinderFunction (fun coords => ∏ k, fs k (coords k)) := rfl
 
 /-- Measurability of cylinder functions. -/
-@[measurability]
+@[measurability, fun_prop]
 lemma measurable_cylinderFunction {m : ℕ} {φ : (Fin m → α) → ℝ}
     (_hφ : Measurable φ) :
     Measurable (cylinderFunction φ) := by
@@ -57,7 +57,7 @@ lemma measurable_cylinderFunction {m : ℕ} {φ : (Fin m → α) → ℝ}
     Measurable fun ω : ℕ → α => fun k : Fin m => ω k.val)
 
 /-- Measurability of product cylinders. -/
-@[measurability]
+@[measurability, fun_prop]
 lemma measurable_productCylinder {m : ℕ} {fs : Fin m → α → ℝ}
     (hmeas : ∀ k, Measurable (fs k)) :
     Measurable (productCylinder fs) := by

--- a/Exchangeability/DeFinetti/ViaKoopman/DirectingKernel.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/DirectingKernel.lean
@@ -47,6 +47,7 @@ local notation "mSI" => shiftInvariantSigma (α := α)
 /-- Projection onto the first coordinate. -/
 def π0 : Ω[α] → α := fun ω => ω 0
 
+@[measurability, fun_prop]
 lemma measurable_pi0 : Measurable (π0 (α := α)) := measurable_pi_apply 0
 
 /-! ## Regular conditional distribution kernel -/
@@ -75,6 +76,7 @@ noncomputable def ν {μ : Measure (Ω[α])} [IsProbabilityMeasure μ]
   fun ω => (rcdKernel (μ := μ)) ω
 
 /-- ν evaluation on measurable sets is measurable in the parameter. -/
+@[measurability]
 lemma ν_eval_measurable
     {μ : Measure (Ω[α])} [IsProbabilityMeasure μ] [StandardBorelSpace α]
     {s : Set α} (hs : MeasurableSet s) :

--- a/Exchangeability/DeFinetti/ViaKoopman/DirectingKernel.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/DirectingKernel.lean
@@ -76,7 +76,7 @@ noncomputable def ν {μ : Measure (Ω[α])} [IsProbabilityMeasure μ]
   fun ω => (rcdKernel (μ := μ)) ω
 
 /-- ν evaluation on measurable sets is measurable in the parameter. -/
-@[measurability]
+@[measurability, fun_prop]
 lemma ν_eval_measurable
     {μ : Measure (Ω[α])} [IsProbabilityMeasure μ] [StandardBorelSpace α]
     {s : Set α} (hs : MeasurableSet s) :

--- a/Exchangeability/DeFinetti/ViaKoopman/InfraCore.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/InfraCore.lean
@@ -173,15 +173,24 @@ lemma restrictNonneg_shiftℤInv (ω : Ωℤ[α]) :
 
 @[measurability, fun_prop]
 lemma measurable_restrictNonneg : Measurable (restrictNonneg (α := α)) :=
-  measurable_pi_lambda _ fun n => measurable_pi_apply (Int.ofNat n)
+  by
+    rw [measurable_pi_iff]
+    intro n
+    simpa [restrictNonneg] using (measurable_pi_apply (Int.ofNat n))
 
 @[measurability, fun_prop]
 lemma measurable_shiftℤ : Measurable (shiftℤ (α := α)) :=
-  measurable_pi_lambda _ fun n => measurable_pi_apply (n + 1)
+  by
+    rw [measurable_pi_iff]
+    intro n
+    simpa [shiftℤ] using (measurable_pi_apply (n + 1))
 
 @[measurability, fun_prop]
 lemma measurable_shiftℤInv : Measurable (shiftℤInv (α := α)) :=
-  measurable_pi_lambda _ fun n => measurable_pi_apply (n - 1)
+  by
+    rw [measurable_pi_iff]
+    intro n
+    simpa [shiftℤInv] using (measurable_pi_apply (n - 1))
 
 /-- Two-sided shift-invariant sets. A set is shift-invariant if it is measurable and equals its preimage under the shift. -/
 def IsShiftInvariantℤ (S : Set (Ωℤ[α])) : Prop :=

--- a/Exchangeability/DeFinetti/ViaKoopman/InfraCore.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/InfraCore.lean
@@ -172,22 +172,16 @@ lemma restrictNonneg_shiftℤInv (ω : Ωℤ[α]) :
       = fun n => ω (Int.ofNat n - 1) := by ext; simp [restrictNonneg, shiftℤInv]
 
 @[measurability, fun_prop]
-lemma measurable_restrictNonneg : Measurable (restrictNonneg (α := α)) :=
-  by
-    simpa [restrictNonneg] using
-      (measurable_pi_lambda (f := restrictNonneg (α := α)) (fun n => measurable_pi_apply (Int.ofNat n)))
+lemma measurable_restrictNonneg : Measurable (restrictNonneg (α := α)) := by
+  unfold restrictNonneg; fun_prop
 
 @[measurability, fun_prop]
-lemma measurable_shiftℤ : Measurable (shiftℤ (α := α)) :=
-  by
-    simpa [shiftℤ] using
-      (measurable_pi_lambda (f := shiftℤ (α := α)) (fun n => measurable_pi_apply (n + 1)))
+lemma measurable_shiftℤ : Measurable (shiftℤ (α := α)) := by
+  unfold shiftℤ; fun_prop
 
 @[measurability, fun_prop]
-lemma measurable_shiftℤInv : Measurable (shiftℤInv (α := α)) :=
-  by
-    simpa [shiftℤInv] using
-      (measurable_pi_lambda (f := shiftℤInv (α := α)) (fun n => measurable_pi_apply (n - 1)))
+lemma measurable_shiftℤInv : Measurable (shiftℤInv (α := α)) := by
+  unfold shiftℤInv; fun_prop
 
 /-- Two-sided shift-invariant sets. A set is shift-invariant if it is measurable and equals its preimage under the shift. -/
 def IsShiftInvariantℤ (S : Set (Ωℤ[α])) : Prop :=

--- a/Exchangeability/DeFinetti/ViaKoopman/InfraCore.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/InfraCore.lean
@@ -174,23 +174,20 @@ lemma restrictNonneg_shiftℤInv (ω : Ωℤ[α]) :
 @[measurability, fun_prop]
 lemma measurable_restrictNonneg : Measurable (restrictNonneg (α := α)) :=
   by
-    rw [measurable_pi_iff]
-    intro n
-    simpa [restrictNonneg] using (measurable_pi_apply (Int.ofNat n))
+    simpa [restrictNonneg] using
+      (measurable_pi_lambda (f := restrictNonneg (α := α)) (fun n => measurable_pi_apply (Int.ofNat n)))
 
 @[measurability, fun_prop]
 lemma measurable_shiftℤ : Measurable (shiftℤ (α := α)) :=
   by
-    rw [measurable_pi_iff]
-    intro n
-    simpa [shiftℤ] using (measurable_pi_apply (n + 1))
+    simpa [shiftℤ] using
+      (measurable_pi_lambda (f := shiftℤ (α := α)) (fun n => measurable_pi_apply (n + 1)))
 
 @[measurability, fun_prop]
 lemma measurable_shiftℤInv : Measurable (shiftℤInv (α := α)) :=
   by
-    rw [measurable_pi_iff]
-    intro n
-    simpa [shiftℤInv] using (measurable_pi_apply (n - 1))
+    simpa [shiftℤInv] using
+      (measurable_pi_lambda (f := shiftℤInv (α := α)) (fun n => measurable_pi_apply (n - 1)))
 
 /-- Two-sided shift-invariant sets. A set is shift-invariant if it is measurable and equals its preimage under the shift. -/
 def IsShiftInvariantℤ (S : Set (Ωℤ[α])) : Prop :=

--- a/Exchangeability/DeFinetti/ViaL2/AlphaIic.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaIic.lean
@@ -163,8 +163,8 @@ lemma measurable_alphaIicRat
     (hX_meas : ∀ i, Measurable (X i))
     (hX_L2 : ∀ i, MemLp (X i) 2 μ) :
     Measurable (alphaIicRat X hX_contract hX_meas hX_L2) := by
-  rw [measurable_pi_iff]
-  intro q
-  simpa [alphaIicRat] using (alphaIic_measurable X hX_contract hX_meas hX_L2 (q : ℝ))
+  simpa [alphaIicRat] using
+    (measurable_pi_lambda (f := alphaIicRat X hX_contract hX_meas hX_L2)
+      (fun q => alphaIic_measurable X hX_contract hX_meas hX_L2 (q : ℝ)))
 
 end Exchangeability.DeFinetti.ViaL2

--- a/Exchangeability/DeFinetti/ViaL2/AlphaIic.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaIic.lean
@@ -81,6 +81,7 @@ noncomputable def alphaIic
       (indIic t) (indIic_measurable t) ⟨1, indIic_bdd t⟩).choose ω))
 
 /-- Measurability of the raw α_{Iic t}. -/
+@[measurability, fun_prop]
 lemma alphaIic_measurable
     {μ : Measure Ω} [IsProbabilityMeasure μ]
     (X : ℕ → Ω → ℝ) (hX_contract : Contractable μ X)

--- a/Exchangeability/DeFinetti/ViaL2/AlphaIic.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaIic.lean
@@ -156,7 +156,7 @@ noncomputable def alphaIicRat
   fun ω q => alphaIic X hX_contract hX_meas hX_L2 (q : ℝ) ω
 
 /-- `alphaIicRat` is measurable, which is required for `stieltjesOfMeasurableRat`. -/
-@[measurability]
+@[measurability, fun_prop]
 lemma measurable_alphaIicRat
     {μ : Measure Ω} [IsProbabilityMeasure μ]
     (X : ℕ → Ω → ℝ) (hX_contract : Contractable μ X)

--- a/Exchangeability/DeFinetti/ViaL2/AlphaIic.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaIic.lean
@@ -162,6 +162,8 @@ lemma measurable_alphaIicRat
     (hX_meas : ∀ i, Measurable (X i))
     (hX_L2 : ∀ i, MemLp (X i) 2 μ) :
     Measurable (alphaIicRat X hX_contract hX_meas hX_L2) := by
-  exact measurable_pi_lambda _ (fun q => alphaIic_measurable X hX_contract hX_meas hX_L2 (q : ℝ))
+  rw [measurable_pi_iff]
+  intro q
+  simpa [alphaIicRat] using (alphaIic_measurable X hX_contract hX_meas hX_L2 (q : ℝ))
 
 end Exchangeability.DeFinetti.ViaL2

--- a/Exchangeability/DeFinetti/ViaL2/AlphaIic.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaIic.lean
@@ -161,8 +161,6 @@ lemma measurable_alphaIicRat
     (hX_meas : ∀ i, Measurable (X i))
     (hX_L2 : ∀ i, MemLp (X i) 2 μ) :
     Measurable (alphaIicRat X hX_contract hX_meas hX_L2) := by
-  refine measurable_pi_iff.2 ?_
-  intro q
-  exact alphaIic_measurable X hX_contract hX_meas hX_L2 (q : ℝ)
+  exact measurable_pi_lambda _ (fun q => alphaIic_measurable X hX_contract hX_meas hX_L2 (q : ℝ))
 
 end Exchangeability.DeFinetti.ViaL2

--- a/Exchangeability/DeFinetti/ViaL2/AlphaIic.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaIic.lean
@@ -156,6 +156,7 @@ noncomputable def alphaIicRat
   fun ω q => alphaIic X hX_contract hX_meas hX_L2 (q : ℝ) ω
 
 /-- `alphaIicRat` is measurable, which is required for `stieltjesOfMeasurableRat`. -/
+@[measurability]
 lemma measurable_alphaIicRat
     {μ : Measure Ω} [IsProbabilityMeasure μ]
     (X : ℕ → Ω → ℝ) (hX_contract : Contractable μ X)

--- a/Exchangeability/DeFinetti/ViaL2/AlphaIic.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaIic.lean
@@ -163,8 +163,6 @@ lemma measurable_alphaIicRat
     (hX_meas : ∀ i, Measurable (X i))
     (hX_L2 : ∀ i, MemLp (X i) 2 μ) :
     Measurable (alphaIicRat X hX_contract hX_meas hX_L2) := by
-  simpa [alphaIicRat] using
-    (measurable_pi_lambda (f := alphaIicRat X hX_contract hX_meas hX_L2)
-      (fun q => alphaIic_measurable X hX_contract hX_meas hX_L2 (q : ℝ)))
+  unfold alphaIicRat; fun_prop
 
 end Exchangeability.DeFinetti.ViaL2

--- a/Exchangeability/DeFinetti/ViaL2/AlphaIicCE.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaIicCE.lean
@@ -81,7 +81,7 @@ Note: Previously had BorelSpace typeclass instance resolution issues.
 The conditional expectation `condExp μ (tailSigma X) f` is measurable by
 `stronglyMeasurable_condExp.measurable`, but Lean can't synthesize the required
 `BorelSpace` instance automatically. This should be straightforward to fix. -/
-@[measurability]
+@[measurability, fun_prop]
 lemma alphaIicCE_measurable
     {μ : Measure Ω} [IsProbabilityMeasure μ]
     (X : ℕ → Ω → ℝ) (hX_contract : Contractable μ X)

--- a/Exchangeability/DeFinetti/ViaL2/AlphaIicCE.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaIicCE.lean
@@ -81,6 +81,7 @@ Note: Previously had BorelSpace typeclass instance resolution issues.
 The conditional expectation `condExp μ (tailSigma X) f` is measurable by
 `stronglyMeasurable_condExp.measurable`, but Lean can't synthesize the required
 `BorelSpace` instance automatically. This should be straightforward to fix. -/
+@[measurability]
 lemma alphaIicCE_measurable
     {μ : Measure Ω} [IsProbabilityMeasure μ]
     (X : ℕ → Ω → ℝ) (hX_contract : Contractable μ X)

--- a/Exchangeability/DeFinetti/ViaL2/BlockAvgDef.lean
+++ b/Exchangeability/DeFinetti/ViaL2/BlockAvgDef.lean
@@ -45,6 +45,7 @@ This is the building block for Kallenberg's L² convergence proof. -/
 def blockAvg (f : α → ℝ) (X : ℕ → Ω → α) (m n : ℕ) (ω : Ω) : ℝ :=
   (n : ℝ)⁻¹ * (Finset.range n).sum (fun k => f (X (m + k) ω))
 
+@[measurability]
 lemma blockAvg_measurable
     {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
     (f : α → ℝ) (X : ℕ → Ω → α)

--- a/Exchangeability/DeFinetti/ViaL2/BlockAvgDef.lean
+++ b/Exchangeability/DeFinetti/ViaL2/BlockAvgDef.lean
@@ -45,7 +45,7 @@ This is the building block for Kallenberg's L² convergence proof. -/
 def blockAvg (f : α → ℝ) (X : ℕ → Ω → α) (m n : ℕ) (ω : Ω) : ℝ :=
   (n : ℝ)⁻¹ * (Finset.range n).sum (fun k => f (X (m + k) ω))
 
-@[measurability]
+@[measurability, fun_prop]
 lemma blockAvg_measurable
     {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
     (f : α → ℝ) (X : ℕ → Ω → α)

--- a/Exchangeability/DeFinetti/ViaMartingale/DirectingMeasure.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/DirectingMeasure.lean
@@ -60,6 +60,7 @@ noncomputable def directingMeasure
 /-- `directingMeasure` evaluates measurably on measurable sets.
 
 Uses: `Kernel.measurable_coe` and `Measure.map_apply`. -/
+@[measurability]
 lemma directingMeasure_measurable_eval
     {Ω : Type*} [MeasurableSpace Ω] [StandardBorelSpace Ω]
     {μ : Measure Ω} [IsProbabilityMeasure μ]

--- a/Exchangeability/DeFinetti/ViaMartingale/DirectingMeasure.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/DirectingMeasure.lean
@@ -60,7 +60,7 @@ noncomputable def directingMeasure
 /-- `directingMeasure` evaluates measurably on measurable sets.
 
 Uses: `Kernel.measurable_coe` and `Measure.map_apply`. -/
-@[measurability]
+@[measurability, fun_prop]
 lemma directingMeasure_measurable_eval
     {Ω : Type*} [MeasurableSpace Ω] [StandardBorelSpace Ω]
     {μ : Measure Ω} [IsProbabilityMeasure μ]

--- a/Exchangeability/DeFinetti/ViaMartingale/FiniteCylinders.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/FiniteCylinders.lean
@@ -75,7 +75,7 @@ lemma finFutureSigma_le_futureFiltration
     simp only [Function.comp_apply, proj, shiftRV]
 
   -- Provide witness for comap: s ∈ futureFiltration means ∃ t', s = (shiftRV X (m+1)) ⁻¹' t'
-  refine ⟨proj ⁻¹' t, (by measurability : Measurable proj) ht, ?_⟩
+  refine ⟨proj ⁻¹' t, (by fun_prop : Measurable proj) ht, ?_⟩
 
   -- Show s = (shiftRV X (m+1)) ⁻¹' (proj ⁻¹' t)
   rw [← Set.preimage_comp, ← h_factor]
@@ -287,9 +287,9 @@ lemma contractable_triple_pushforward
     -- Convert to map equality
     -- First, prove measurability of the triple functions
     have h_meas_future : Measurable (fun ω => (Z_r ω, X r ω, Y_future ω)) :=
-      Measurable.prodMk (by measurability) (Measurable.prodMk (hX_meas r) (by measurability))
+      Measurable.prodMk (by fun_prop) (Measurable.prodMk (hX_meas r) (by fun_prop))
     have h_meas_tail : Measurable (fun ω => (Z_r ω, X r ω, Y_tail ω)) :=
-      Measurable.prodMk (by measurability) (Measurable.prodMk (hX_meas r) (by measurability))
+      Measurable.prodMk (by fun_prop) (Measurable.prodMk (hX_meas r) (by fun_prop))
     -- The rectangle is measurable
     have h_meas_rect : MeasurableSet ((Set.univ.pi A) ×ˢ B ×ˢ (Set.univ.pi C)) :=
       (MeasurableSet.univ_pi hA).prod (hB.prod (MeasurableSet.univ_pi hC))

--- a/Exchangeability/DeFinetti/ViaMartingale/FutureRectangles.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/FutureRectangles.lean
@@ -90,10 +90,10 @@ lemma contractable_dist_eq_on_first_r_tail
       ext v; simp [A, Set.mem_iInter]
     rw [this]
     exact (h0 hB).inter (MeasurableSet.iInter fun i => hS i (hC i))
-  have hφ₁ : Measurable (fun ω i => X (s₁ i) ω) := measurable_pi_lambda _ fun i =>
-    i.cases (hX_meas m) fun j => by simp only [s₁, f]; exact hX_meas (m + (j.1 + 1))
-  have hφ₂ : Measurable (fun ω i => X (s₂ i) ω) := measurable_pi_lambda _ fun i =>
-    i.cases (hX_meas k) fun j => by simp only [s₂, f]; exact hX_meas (m + (j.1 + 1))
+  have hφ₁ : Measurable (fun ω i => X (s₁ i) ω) := by
+    fun_prop
+  have hφ₂ : Measurable (fun ω i => X (s₂ i) ω) := by
+    fun_prop
   calc μ {ω | X m ω ∈ B ∧ ∀ i : Fin r, X (m + (i.1 + 1)) ω ∈ C i}
       = μ ((fun ω i => X (s₁ i) ω) ⁻¹' A) := by rw [hpre₁]
     _ = (Measure.map (fun ω i => X (s₁ i) ω) μ) A := (Measure.map_apply hφ₁ hA).symm

--- a/Exchangeability/DeFinetti/ViaMartingale/KallenbergChain.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/KallenbergChain.lean
@@ -83,16 +83,17 @@ lemma projectPairSeq_embedPairSeq (p : α × (ℕ → α)) : projectPairSeq (emb
 
 @[measurability]
 lemma embedPairSeq_measurable : Measurable (embedPairSeq : α × (ℕ → α) → ℕ → α) := by
-  rw [measurable_pi_iff]
+  refine measurable_pi_lambda _ ?_
   intro n
   cases n with
-  | zero => exact measurable_fst
-  | succ k => exact (measurable_pi_apply k).comp measurable_snd
+  | zero => simpa [embedPairSeq] using measurable_fst
+  | succ k => simpa [embedPairSeq] using (measurable_pi_apply k).comp measurable_snd
 
 @[measurability]
 lemma projectPairSeq_measurable : Measurable (projectPairSeq : (ℕ → α) → α × (ℕ → α)) :=
-  Measurable.prod (measurable_pi_apply 0)
-    (measurable_pi_iff.mpr fun n => measurable_pi_apply (n + 1))
+  by
+    refine Measurable.prod (measurable_pi_apply (0 : ℕ)) ?_
+    exact measurable_pi_lambda _ (fun n => measurable_pi_apply (n + 1))
 
 /-- The injection `k, m, m+1, m+2, ...` for pair law argument.
 This is strictly increasing when k < m. -/
@@ -140,8 +141,8 @@ lemma pair_law_shift_eq_of_contractable
   let seqM : Ω → ℕ → α := fun ω i => X (pairInjection k m i) ω
   let seqN : Ω → ℕ → α := fun ω i => X (pairInjection k n i) ω
 
-  have hSeqM_meas : Measurable seqM := measurable_pi_iff.mpr fun _ => hX _
-  have hSeqN_meas : Measurable seqN := measurable_pi_iff.mpr fun _ => hX _
+  have hSeqM_meas : Measurable seqM := measurable_pi_lambda _ (fun i => hX (pairInjection k m i))
+  have hSeqN_meas : Measurable seqN := measurable_pi_lambda _ (fun i => hX (pairInjection k n i))
 
   -- Both reindexed sequences have the same distribution by contractability
   -- (π-system uniqueness on finite marginals)

--- a/Exchangeability/DeFinetti/ViaMartingale/KallenbergChain.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/KallenbergChain.lean
@@ -83,14 +83,11 @@ lemma projectPairSeq_embedPairSeq (p : α × (ℕ → α)) : projectPairSeq (emb
 
 @[measurability, fun_prop]
 lemma embedPairSeq_measurable : Measurable (embedPairSeq : α × (ℕ → α) → ℕ → α) := by
-  rw [measurable_pi_iff]
+  refine measurable_pi_lambda (f := embedPairSeq) ?_
   intro n
   cases n with
-  | zero =>
-      simpa [embedPairSeq] using
-        (measurable_fst : Measurable (fun x : α × (ℕ → α) => x.1))
-  | succ n =>
-      simpa [embedPairSeq] using ((measurable_pi_apply (n : ℕ)).comp measurable_snd)
+  | zero => exact (measurable_fst : Measurable (fun x : α × (ℕ → α) => x.1))
+  | succ n => exact ((measurable_pi_apply (n : ℕ)).comp measurable_snd)
 
 @[measurability, fun_prop]
 lemma projectPairSeq_measurable : Measurable (projectPairSeq : (ℕ → α) → α × (ℕ → α)) :=

--- a/Exchangeability/DeFinetti/ViaMartingale/KallenbergChain.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/KallenbergChain.lean
@@ -83,11 +83,14 @@ lemma projectPairSeq_embedPairSeq (p : α × (ℕ → α)) : projectPairSeq (emb
 
 @[measurability, fun_prop]
 lemma embedPairSeq_measurable : Measurable (embedPairSeq : α × (ℕ → α) → ℕ → α) := by
-  refine measurable_pi_lambda _ ?_
+  rw [measurable_pi_iff]
   intro n
   cases n with
-  | zero => simpa [embedPairSeq] using measurable_fst
-  | succ k => simpa [embedPairSeq] using (measurable_pi_apply k).comp measurable_snd
+  | zero =>
+      simpa [embedPairSeq] using
+        (measurable_fst : Measurable (fun x : α × (ℕ → α) => x.1))
+  | succ n =>
+      simpa [embedPairSeq] using ((measurable_pi_apply (n : ℕ)).comp measurable_snd)
 
 @[measurability, fun_prop]
 lemma projectPairSeq_measurable : Measurable (projectPairSeq : (ℕ → α) → α × (ℕ → α)) :=

--- a/Exchangeability/DeFinetti/ViaMartingale/KallenbergChain.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/KallenbergChain.lean
@@ -81,7 +81,7 @@ lemma projectPairSeq_embedPairSeq (p : α × (ℕ → α)) : projectPairSeq (emb
   rcases p with ⟨a, f⟩
   simp only [projectPairSeq, embedPairSeq]
 
-@[measurability]
+@[measurability, fun_prop]
 lemma embedPairSeq_measurable : Measurable (embedPairSeq : α × (ℕ → α) → ℕ → α) := by
   refine measurable_pi_lambda _ ?_
   intro n
@@ -89,11 +89,11 @@ lemma embedPairSeq_measurable : Measurable (embedPairSeq : α × (ℕ → α) �
   | zero => simpa [embedPairSeq] using measurable_fst
   | succ k => simpa [embedPairSeq] using (measurable_pi_apply k).comp measurable_snd
 
-@[measurability]
+@[measurability, fun_prop]
 lemma projectPairSeq_measurable : Measurable (projectPairSeq : (ℕ → α) → α × (ℕ → α)) :=
   by
     refine Measurable.prod (measurable_pi_apply (0 : ℕ)) ?_
-    exact measurable_pi_lambda _ (fun n => measurable_pi_apply (n + 1))
+    fun_prop
 
 /-- The injection `k, m, m+1, m+2, ...` for pair law argument.
 This is strictly increasing when k < m. -/
@@ -141,8 +141,10 @@ lemma pair_law_shift_eq_of_contractable
   let seqM : Ω → ℕ → α := fun ω i => X (pairInjection k m i) ω
   let seqN : Ω → ℕ → α := fun ω i => X (pairInjection k n i) ω
 
-  have hSeqM_meas : Measurable seqM := measurable_pi_lambda _ (fun i => hX (pairInjection k m i))
-  have hSeqN_meas : Measurable seqN := measurable_pi_lambda _ (fun i => hX (pairInjection k n i))
+  have hSeqM_meas : Measurable seqM := by
+    fun_prop
+  have hSeqN_meas : Measurable seqN := by
+    fun_prop
 
   -- Both reindexed sequences have the same distribution by contractability
   -- (π-system uniqueness on finite marginals)

--- a/Exchangeability/DeFinetti/ViaMartingale/KallenbergChain.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/KallenbergChain.lean
@@ -83,11 +83,8 @@ lemma projectPairSeq_embedPairSeq (p : α × (ℕ → α)) : projectPairSeq (emb
 
 @[measurability, fun_prop]
 lemma embedPairSeq_measurable : Measurable (embedPairSeq : α × (ℕ → α) → ℕ → α) := by
-  refine measurable_pi_lambda (f := embedPairSeq) ?_
-  intro n
-  cases n with
-  | zero => exact (measurable_fst : Measurable (fun x : α × (ℕ → α) => x.1))
-  | succ n => exact ((measurable_pi_apply (n : ℕ)).comp measurable_snd)
+  refine measurable_pi_lambda _ ?_
+  intro n; cases n <;> simp [embedPairSeq] <;> fun_prop
 
 @[measurability, fun_prop]
 lemma projectPairSeq_measurable : Measurable (projectPairSeq : (ℕ → α) → α × (ℕ → α)) :=

--- a/Exchangeability/DeFinetti/ViaMartingale/LocalInfrastructure.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/LocalInfrastructure.lean
@@ -64,7 +64,7 @@ lemma measurableSpace_pi_nat_le_iSup_fin {α : Type*} [MeasurableSpace α] :
   let g : (Fin (t.sup id + 1) → α) → (t → α) := fun h i => h ⟨i.val,
     Nat.lt_succ_of_le (Finset.le_sup (f := id) i.property)⟩
   exact ⟨g ⁻¹' S,
-    hS_meas.preimage (measurable_pi_lambda _ fun i => measurable_pi_apply _),
+    hS_meas.preimage (by fun_prop),
     Set.preimage_comp.symm⟩
 
 end PiFiniteProjections

--- a/Exchangeability/DeFinetti/ViaMartingale/PairLawEquality.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/PairLawEquality.lean
@@ -229,14 +229,11 @@ lemma pair_law_eq_of_contractable [IsProbabilityMeasure μ]
         conv_rhs => rw [← h_final]
 
   -- Measurability of seq0 and seq1
-  have hU_meas : Measurable U := measurable_pi_iff.mpr fun i => hX i.val
-  have hW_meas : Measurable W := measurable_pi_iff.mpr fun n => hX (m + 1 + n)
+  have hU_meas : Measurable U := by measurability
+  have hW_meas : Measurable W := by measurability
   have hW'_meas : Measurable W' := by
-    simp only [W']
-    rw [measurable_pi_iff]; intro n
-    match n with
-    | 0 => exact hX r
-    | n' + 1 => exact hX (m + 1 + n')
+    simpa [W'] using
+      (measurable_consRV (x := fun ω => X r ω) (t := W) (hX r) hW_meas)
 
   have hseq0_meas : Measurable seq0 := h_concat_meas.comp (hU_meas.prodMk hW_meas)
   have hseq1_meas : Measurable seq1 := h_concat_meas.comp (hU_meas.prodMk hW'_meas)
@@ -319,10 +316,10 @@ lemma condExp_indicator_eq_of_contractable
 
   -- Measurability
   have hU : Measurable U := by measurability
-  have hW : Measurable W := measurable_pi_lambda _ fun n => hX_meas (m + 1 + n)
-  have hW' : Measurable W' := measurable_pi_lambda _ fun
-    | 0 => hX_meas r
-    | n + 1 => hX_meas (m + 1 + n)
+  have hW : Measurable W := by measurability
+  have hW' : Measurable W' := by
+    simpa [W'] using
+      (measurable_consRV (x := fun ω => X r ω) (t := W) (hX_meas r) hW)
 
   -- Apply Kallenberg 1.3 with pair law and contraction σ(W) ⊆ σ(W')
   exact condExp_indicator_eq_of_law_eq_of_comap_le U W W' hU hW hW'
@@ -480,13 +477,10 @@ lemma condExp_Xr_indicator_eq_of_contractable
 
   -- Measurability facts
   have hU_meas : Measurable U := by measurability
-  have hW_meas : Measurable W := measurable_pi_iff.mpr fun n => hX_meas (m + 1 + n)
+  have hW_meas : Measurable W := by measurability
   have hW'_meas : Measurable W' := by
-    -- consRV x t is measurable when x and t are measurable
-    rw [measurable_pi_iff]; intro n
-    cases n with
-    | zero => exact hX_meas r
-    | succ k => exact (measurable_pi_apply k).comp hW_meas
+    simpa [W'] using
+      (measurable_consRV (x := fun ω => X r ω) (t := W) (hX_meas r) hW_meas)
 
   -- Step 5: Establish conditional independence U ⊥⊥_W X_r
   -- From drop-info E[1_{U∈A}|σ(W')] = E[1_{U∈A}|σ(W)], we derive CondIndep μ U (X r) W

--- a/Exchangeability/DeFinetti/ViaMartingale/PairLawEquality.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/PairLawEquality.lean
@@ -228,8 +228,8 @@ lemma pair_law_eq_of_contractable [IsProbabilityMeasure μ]
         conv_rhs => rw [← h_final]
 
   -- Measurability of seq0 and seq1
-  have hU_meas : Measurable U := by measurability
-  have hW_meas : Measurable W := by measurability
+  have hU_meas : Measurable U := by fun_prop
+  have hW_meas : Measurable W := by fun_prop
   have hW'_meas : Measurable W' := by
     simpa [W'] using
       (measurable_consRV (x := fun ω => X r ω) (t := W) (hX r) hW_meas)
@@ -314,8 +314,8 @@ lemma condExp_indicator_eq_of_contractable
   let W' := consRV (fun ω => X r ω) W
 
   -- Measurability
-  have hU : Measurable U := by measurability
-  have hW : Measurable W := by measurability
+  have hU : Measurable U := by fun_prop
+  have hW : Measurable W := by fun_prop
   have hW' : Measurable W' := by
     simpa [W'] using
       (measurable_consRV (x := fun ω => X r ω) (t := W) (hX_meas r) hW)
@@ -472,8 +472,8 @@ lemma condExp_Xr_indicator_eq_of_contractable
   -- This uses condExp_indicator_eq_of_law_eq_of_comap_le (fully proved)
 
   -- Measurability facts
-  have hU_meas : Measurable U := by measurability
-  have hW_meas : Measurable W := by measurability
+  have hU_meas : Measurable U := by fun_prop
+  have hW_meas : Measurable W := by fun_prop
   have hW'_meas : Measurable W' := by
     simpa [W'] using
       (measurable_consRV (x := fun ω => X r ω) (t := W) (hX_meas r) hW_meas)

--- a/Exchangeability/DeFinetti/ViaMartingale/PairLawEquality.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/PairLawEquality.lean
@@ -181,11 +181,10 @@ lemma pair_law_eq_of_contractable [IsProbabilityMeasure μ]
 
   -- Measurability of concat
   have h_concat_meas : Measurable concat := by
-    rw [measurable_pi_iff]
+    refine measurable_pi_lambda (f := concat) ?_
     intro n
     by_cases hn : n < r
-    · simpa [concat, hn] using
-        ((measurable_pi_apply (⟨n, hn⟩ : Fin r)).comp measurable_fst)
+    · simpa [concat, hn] using ((measurable_pi_apply (⟨n, hn⟩ : Fin r)).comp measurable_fst)
     · simpa [concat, hn] using ((measurable_pi_apply (n - r)).comp measurable_snd)
 
   -- Measurability of split
@@ -349,26 +348,19 @@ lemma comap_consRV_eq_sup
     obtain ⟨S, hS_meas, rfl⟩ := hs
     -- S is measurable in ℕ → α. We show consRV x t ⁻¹' S ∈ σ(x) ⊔ σ(t).
     -- Key: consRV x t factors through (x, t) via a measurable "cons" function.
-    -- Define consSeq : α × (ℕ → α) → (ℕ → α) by consSeq (a, f) n = if n = 0 then a else f (n-1)
-    let consSeq : α × (ℕ → α) → (ℕ → α) := fun ⟨a, f⟩ n =>
-      match n with
-      | 0 => a
-      | n + 1 => f n
+    -- Define consSeq via consRV on the pair space.
+    let consSeq : α × (ℕ → α) → (ℕ → α) := fun p =>
+      consRV (x := fun q : α × (ℕ → α) => q.1)
+        (t := fun q : α × (ℕ → α) => q.2) p
     -- consRV x t = consSeq ∘ (fun ω => (x ω, t ω))
     have h_factor : consRV x t = consSeq ∘ (fun ω => (x ω, t ω)) := by
       ext ω n
-      simp only [Function.comp_apply, consRV, consSeq]
-      cases n <;> rfl
+      cases n <;> simp [Function.comp_apply, consSeq, consRV]
     -- consSeq is measurable
     have h_consSeq_meas : Measurable consSeq := by
-      rw [measurable_pi_iff]
-      intro n
-      cases n with
-      | zero =>
-          simpa [consSeq] using
-            (measurable_fst : Measurable (fun x : α × (ℕ → α) => x.1))
-      | succ n =>
-          simpa [consSeq] using ((measurable_pi_apply (n : ℕ)).comp measurable_snd)
+      simpa [consSeq] using
+        (measurable_consRV (x := fun q : α × (ℕ → α) => q.1)
+          (t := fun q : α × (ℕ → α) => q.2) measurable_fst measurable_snd)
     -- So consRV x t ⁻¹' S = (fun ω => (x ω, t ω)) ⁻¹' (consSeq ⁻¹' S)
     rw [h_factor, Set.preimage_comp]
     -- consSeq ⁻¹' S is measurable in α × (ℕ → α)

--- a/Exchangeability/DeFinetti/ViaMartingale/PairLawEquality.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/PairLawEquality.lean
@@ -181,11 +181,12 @@ lemma pair_law_eq_of_contractable [IsProbabilityMeasure μ]
 
   -- Measurability of concat
   have h_concat_meas : Measurable concat := by
-    refine measurable_pi_lambda _ ?_
+    rw [measurable_pi_iff]
     intro n
     by_cases hn : n < r
-    · simpa [concat, hn] using (measurable_pi_apply (⟨n, hn⟩ : Fin r)).comp measurable_fst
-    · simpa [concat, hn] using (measurable_pi_apply (n - r : ℕ)).comp measurable_snd
+    · simpa [concat, hn] using
+        ((measurable_pi_apply (⟨n, hn⟩ : Fin r)).comp measurable_fst)
+    · simpa [concat, hn] using ((measurable_pi_apply (n - r)).comp measurable_snd)
 
   -- Measurability of split
   have h_split_meas : Measurable split := by
@@ -201,7 +202,8 @@ lemma pair_law_eq_of_contractable [IsProbabilityMeasure μ]
     by_cases hn : n < r
     · simp only [hn, dite_true, ite_true]
     · simp only [hn, dite_false, ite_false]
-      congr 1; omega
+      congr 1
+      omega
 
   -- seq1 ω n = X (φ₁ n) ω
   have h_seq1 : ∀ ω n, seq1 ω n = X (phi1 r m n) ω := fun ω n => by
@@ -359,11 +361,14 @@ lemma comap_consRV_eq_sup
       cases n <;> rfl
     -- consSeq is measurable
     have h_consSeq_meas : Measurable consSeq := by
-      exact measurable_pi_lambda _ (fun n =>
-        by
-          cases n with
-          | zero => simpa [consSeq] using measurable_fst
-          | succ k => simpa [consSeq] using (measurable_pi_apply k).comp measurable_snd)
+      rw [measurable_pi_iff]
+      intro n
+      cases n with
+      | zero =>
+          simpa [consSeq] using
+            (measurable_fst : Measurable (fun x : α × (ℕ → α) => x.1))
+      | succ n =>
+          simpa [consSeq] using ((measurable_pi_apply (n : ℕ)).comp measurable_snd)
     -- So consRV x t ⁻¹' S = (fun ω => (x ω, t ω)) ⁻¹' (consSeq ⁻¹' S)
     rw [h_factor, Set.preimage_comp]
     -- consSeq ⁻¹' S is measurable in α × (ℕ → α)

--- a/Exchangeability/DeFinetti/ViaMartingale/PairLawEquality.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/PairLawEquality.lean
@@ -181,11 +181,8 @@ lemma pair_law_eq_of_contractable [IsProbabilityMeasure μ]
 
   -- Measurability of concat
   have h_concat_meas : Measurable concat := by
-    refine measurable_pi_lambda (f := concat) ?_
-    intro n
-    by_cases hn : n < r
-    · simpa [concat, hn] using ((measurable_pi_apply (⟨n, hn⟩ : Fin r)).comp measurable_fst)
-    · simpa [concat, hn] using ((measurable_pi_apply (n - r)).comp measurable_snd)
+    refine measurable_pi_lambda _ ?_
+    intro n; by_cases hn : n < r <;> simp [concat, hn] <;> fun_prop
 
   -- Measurability of split
   have h_split_meas : Measurable split := by fun_prop

--- a/Exchangeability/DeFinetti/ViaMartingale/PairLawEquality.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/PairLawEquality.lean
@@ -189,9 +189,8 @@ lemma pair_law_eq_of_contractable [IsProbabilityMeasure μ]
       exact (measurable_pi_apply (n - r : ℕ)).comp measurable_snd
 
   -- Measurability of split
-  have h_split_meas : Measurable split := Measurable.prod
-    (measurable_pi_iff.mpr fun i => measurable_pi_apply i.val)
-    (measurable_pi_iff.mpr fun n => measurable_pi_apply (r + n))
+  have h_split_meas : Measurable split := by
+    measurability
 
   -- Define concatenated sequences
   let seq0 : Ω → ℕ → α := fun ω => concat (U ω, W ω)

--- a/Exchangeability/DeFinetti/ViaMartingale/PairLawEquality.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/PairLawEquality.lean
@@ -188,8 +188,7 @@ lemma pair_law_eq_of_contractable [IsProbabilityMeasure μ]
     · simpa [concat, hn] using ((measurable_pi_apply (n - r)).comp measurable_snd)
 
   -- Measurability of split
-  have h_split_meas : Measurable split := by
-    measurability
+  have h_split_meas : Measurable split := by fun_prop
 
   -- Define concatenated sequences
   let seq0 : Ω → ℕ → α := fun ω => concat (U ω, W ω)

--- a/Exchangeability/DeFinetti/ViaMartingale/PairLawEquality.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/PairLawEquality.lean
@@ -181,12 +181,11 @@ lemma pair_law_eq_of_contractable [IsProbabilityMeasure μ]
 
   -- Measurability of concat
   have h_concat_meas : Measurable concat := by
-    rw [measurable_pi_iff]; intro n
+    refine measurable_pi_lambda _ ?_
+    intro n
     by_cases hn : n < r
-    · simp only [concat, hn, dite_true]
-      exact (measurable_pi_apply (⟨n, hn⟩ : Fin r)).comp measurable_fst
-    · simp only [concat, hn, dite_false]
-      exact (measurable_pi_apply (n - r : ℕ)).comp measurable_snd
+    · simpa [concat, hn] using (measurable_pi_apply (⟨n, hn⟩ : Fin r)).comp measurable_fst
+    · simpa [concat, hn] using (measurable_pi_apply (n - r : ℕ)).comp measurable_snd
 
   -- Measurability of split
   have h_split_meas : Measurable split := by
@@ -360,10 +359,11 @@ lemma comap_consRV_eq_sup
       cases n <;> rfl
     -- consSeq is measurable
     have h_consSeq_meas : Measurable consSeq := by
-      rw [measurable_pi_iff]; intro n
-      cases n with
-      | zero => exact measurable_fst
-      | succ k => exact (measurable_pi_apply k).comp measurable_snd
+      exact measurable_pi_lambda _ (fun n =>
+        by
+          cases n with
+          | zero => simpa [consSeq] using measurable_fst
+          | succ k => simpa [consSeq] using (measurable_pi_apply k).comp measurable_snd)
     -- So consRV x t ⁻¹' S = (fun ω => (x ω, t ω)) ⁻¹' (consSeq ⁻¹' S)
     rw [h_factor, Set.preimage_comp]
     -- consSeq ⁻¹' S is measurable in α × (ℕ → α)

--- a/Exchangeability/DeFinetti/ViaMartingale/RevFiltration.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/RevFiltration.lean
@@ -52,8 +52,8 @@ lemma revFiltration_zero (X : ℕ → Ω → α) :
 
 lemma revFiltration_le (X : ℕ → Ω → α) (hX : ∀ n, Measurable (X n)) (m : ℕ) :
     revFiltration X m ≤ (inferInstance : MeasurableSpace Ω) :=
-  MeasurableSpace.comap_le_iff_le_map.mpr fun _ hs =>
-    (measurable_pi_iff.mpr fun n => hX (m + n)) hs
+  by
+    simpa [revFiltration] using (measurable_iff_comap_le.mp (measurable_shiftRV (X := X) hX (m := m)))
 
 /-! ### Tail σ-Algebra -/
 

--- a/Exchangeability/DeFinetti/ViaMartingale/ShiftOperations.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/ShiftOperations.lean
@@ -83,7 +83,26 @@ lemma shiftProcess_apply (X : ℕ → Ω → α) (m n : ℕ) (ω : Ω) :
 
 /-! ### Measurability -/
 
+/-! ### Measurable combinators -/
+
+/-- A process viewed as a full path is measurable. -/
+@[measurability, fun_prop]
+lemma measurable_path {X : ℕ → Ω → α} (hX : ∀ n, Measurable (X n)) : Measurable (path X) :=
+  measurable_pi_iff.mpr hX
+
+/-- Consing a head to a sequence is measurable if both pieces are measurable. -/
+@[measurability, fun_prop]
+lemma measurable_consRV (x : Ω → α) (t : Ω → ℕ → α) :
+    Measurable x → Measurable t → Measurable (consRV x t) := by
+  intro hx ht
+  rw [measurable_pi_iff]
+  intro n
+  cases n with
+  | zero => exact hx
+  | succ k => exact (measurable_pi_apply k).comp ht
+
 /-- Tail is measurable when the original sequence is measurable. -/
+@[measurability, fun_prop]
 lemma measurable_tailRV {t : Ω → ℕ → α} (ht : Measurable t) : Measurable (tailRV t) :=
   measurable_pi_iff.mpr fun n => (measurable_pi_apply (n + 1)).comp ht
 

--- a/Exchangeability/DeFinetti/ViaMartingale/ShiftOperations.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/ShiftOperations.lean
@@ -87,10 +87,8 @@ lemma shiftProcess_apply (X : ℕ → Ω → α) (m n : ℕ) (ω : Ω) :
 
 /-- A process viewed as a full path is measurable. -/
 @[measurability, fun_prop]
-lemma measurable_path {X : ℕ → Ω → α} (hX : ∀ n, Measurable (X n)) : Measurable (path X) :=
-  by
-    simpa [path] using
-      (measurable_pi_lambda (f := path (X := X)) (fun n => hX n))
+lemma measurable_path {X : ℕ → Ω → α} (hX : ∀ n, Measurable (X n)) : Measurable (path X) := by
+  unfold path; fun_prop
 
 /-- Consing a head to a sequence is measurable if both pieces are measurable. -/
 @[measurability, fun_prop]
@@ -105,11 +103,8 @@ lemma measurable_consRV (x : Ω → α) (t : Ω → ℕ → α) :
 
 /-- Tail is measurable when the original sequence is measurable. -/
 @[measurability, fun_prop]
-lemma measurable_tailRV {t : Ω → ℕ → α} (ht : Measurable t) : Measurable (tailRV t) :=
-  by
-    simpa [tailRV] using
-      (measurable_pi_lambda (f := tailRV (t := t))
-        (fun n => (measurable_pi_apply (n + 1)).comp ht))
+lemma measurable_tailRV {t : Ω → ℕ → α} (ht : Measurable t) : Measurable (tailRV t) := by
+  unfold tailRV; fun_prop
 
 /-- The contraction property: σ(tailRV t) ≤ σ(t).
 

--- a/Exchangeability/DeFinetti/ViaMartingale/ShiftOperations.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/ShiftOperations.lean
@@ -89,30 +89,27 @@ lemma shiftProcess_apply (X : ℕ → Ω → α) (m n : ℕ) (ω : Ω) :
 @[measurability, fun_prop]
 lemma measurable_path {X : ℕ → Ω → α} (hX : ∀ n, Measurable (X n)) : Measurable (path X) :=
   by
-    rw [measurable_pi_iff]
-    intro n
-    simpa [path] using hX n
+    simpa [path] using
+      (measurable_pi_lambda (f := path (X := X)) (fun n => hX n))
 
 /-- Consing a head to a sequence is measurable if both pieces are measurable. -/
 @[measurability, fun_prop]
 lemma measurable_consRV (x : Ω → α) (t : Ω → ℕ → α) :
     Measurable x → Measurable t → Measurable (consRV x t) := by
   intro hx ht
-  rw [measurable_pi_iff]
-  intro n
-  cases n with
-  | zero =>
-      simpa [consRV] using hx
-  | succ k =>
-      simpa [consRV] using (measurable_pi_apply k).comp ht
+  simpa [consRV] using
+    (measurable_pi_lambda (f := consRV x t) (fun n => by
+      cases n with
+      | zero => exact hx
+      | succ k => exact (measurable_pi_apply k).comp ht))
 
 /-- Tail is measurable when the original sequence is measurable. -/
 @[measurability, fun_prop]
 lemma measurable_tailRV {t : Ω → ℕ → α} (ht : Measurable t) : Measurable (tailRV t) :=
   by
-    rw [measurable_pi_iff]
-    intro n
-    simpa [tailRV] using (measurable_pi_apply (n + 1)).comp ht
+    simpa [tailRV] using
+      (measurable_pi_lambda (f := tailRV (t := t))
+        (fun n => (measurable_pi_apply (n + 1)).comp ht))
 
 /-- The contraction property: σ(tailRV t) ≤ σ(t).
 

--- a/Exchangeability/DeFinetti/ViaMartingale/ShiftOperations.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/ShiftOperations.lean
@@ -88,23 +88,24 @@ lemma shiftProcess_apply (X : ℕ → Ω → α) (m n : ℕ) (ω : Ω) :
 /-- A process viewed as a full path is measurable. -/
 @[measurability, fun_prop]
 lemma measurable_path {X : ℕ → Ω → α} (hX : ∀ n, Measurable (X n)) : Measurable (path X) :=
-  measurable_pi_iff.mpr hX
+  measurable_pi_lambda _ hX
 
 /-- Consing a head to a sequence is measurable if both pieces are measurable. -/
 @[measurability, fun_prop]
 lemma measurable_consRV (x : Ω → α) (t : Ω → ℕ → α) :
     Measurable x → Measurable t → Measurable (consRV x t) := by
   intro hx ht
-  rw [measurable_pi_iff]
-  intro n
-  cases n with
-  | zero => exact hx
-  | succ k => exact (measurable_pi_apply k).comp ht
+  exact measurable_pi_lambda _ (fun n => by
+    cases n with
+    | zero =>
+        simpa [consRV] using hx
+    | succ k =>
+        simpa [consRV] using (measurable_pi_apply k).comp ht)
 
 /-- Tail is measurable when the original sequence is measurable. -/
 @[measurability, fun_prop]
 lemma measurable_tailRV {t : Ω → ℕ → α} (ht : Measurable t) : Measurable (tailRV t) :=
-  measurable_pi_iff.mpr fun n => (measurable_pi_apply (n + 1)).comp ht
+  measurable_pi_lambda _ (fun n => (measurable_pi_apply (n + 1)).comp ht)
 
 /-- The contraction property: σ(tailRV t) ≤ σ(t).
 
@@ -113,10 +114,11 @@ This is the key property for Kallenberg 1.3: tail gives a coarser σ-algebra. -/
 lemma comap_tailRV_le {t : Ω → ℕ → α} :
     MeasurableSpace.comap (tailRV t) inferInstance ≤
     MeasurableSpace.comap t inferInstance := by
+  have hShift : Measurable (fun s : ℕ → α => (fun n => s (n + 1))) :=
+    measurable_pi_lambda _ (fun n => measurable_pi_apply (n + 1))
   intro S hS
   obtain ⟨A, hA, rfl⟩ := hS
-  exact ⟨(fun s : ℕ → α => (fun n => s (n+1))) ⁻¹' A,
-    hA.preimage (measurable_pi_iff.mpr fun n => measurable_pi_apply (n + 1)), rfl⟩
+  exact ⟨(fun s : ℕ → α => (fun n => s (n + 1)) ) ⁻¹' A, hA.preimage hShift, rfl⟩
 
 /-- For W' = consRV x W, we have σ(W) ≤ σ(W').
 
@@ -135,9 +137,7 @@ variable {X : ℕ → Ω → α}
 @[measurability, fun_prop]
 lemma measurable_shiftRV (hX : ∀ n, Measurable (X n)) {m : ℕ} :
     Measurable (shiftRV X m) := by
-  classical
-  simpa [shiftRV] using
-    measurable_pi_iff.mpr (fun n => by simpa using hX (m + n))
+  simpa [shiftRV, path] using (measurable_path (fun n => hX (m + n)))
 
 /-! ### Shift Contractability -/
 

--- a/Exchangeability/DeFinetti/ViaMartingale/ShiftOperations.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/ShiftOperations.lean
@@ -114,8 +114,8 @@ This is the key property for Kallenberg 1.3: tail gives a coarser σ-algebra. -/
 lemma comap_tailRV_le {t : Ω → ℕ → α} :
     MeasurableSpace.comap (tailRV t) inferInstance ≤
     MeasurableSpace.comap t inferInstance := by
-  have hShift : Measurable (fun s : ℕ → α => (fun n => s (n + 1))) :=
-    measurable_pi_lambda _ (fun n => measurable_pi_apply (n + 1))
+  have hShift : Measurable (fun s : ℕ → α => (fun n => s (n + 1))) := by
+    fun_prop
   intro S hS
   obtain ⟨A, hA, rfl⟩ := hS
   exact ⟨(fun s : ℕ → α => (fun n => s (n + 1)) ) ⁻¹' A, hA.preimage hShift, rfl⟩

--- a/Exchangeability/DeFinetti/ViaMartingale/ShiftOperations.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/ShiftOperations.lean
@@ -88,24 +88,31 @@ lemma shiftProcess_apply (X : ℕ → Ω → α) (m n : ℕ) (ω : Ω) :
 /-- A process viewed as a full path is measurable. -/
 @[measurability, fun_prop]
 lemma measurable_path {X : ℕ → Ω → α} (hX : ∀ n, Measurable (X n)) : Measurable (path X) :=
-  measurable_pi_lambda _ hX
+  by
+    rw [measurable_pi_iff]
+    intro n
+    simpa [path] using hX n
 
 /-- Consing a head to a sequence is measurable if both pieces are measurable. -/
 @[measurability, fun_prop]
 lemma measurable_consRV (x : Ω → α) (t : Ω → ℕ → α) :
     Measurable x → Measurable t → Measurable (consRV x t) := by
   intro hx ht
-  exact measurable_pi_lambda _ (fun n => by
-    cases n with
-    | zero =>
-        simpa [consRV] using hx
-    | succ k =>
-        simpa [consRV] using (measurable_pi_apply k).comp ht)
+  rw [measurable_pi_iff]
+  intro n
+  cases n with
+  | zero =>
+      simpa [consRV] using hx
+  | succ k =>
+      simpa [consRV] using (measurable_pi_apply k).comp ht
 
 /-- Tail is measurable when the original sequence is measurable. -/
 @[measurability, fun_prop]
 lemma measurable_tailRV {t : Ω → ℕ → α} (ht : Measurable t) : Measurable (tailRV t) :=
-  measurable_pi_lambda _ (fun n => (measurable_pi_apply (n + 1)).comp ht)
+  by
+    rw [measurable_pi_iff]
+    intro n
+    simpa [tailRV] using (measurable_pi_apply (n + 1)).comp ht
 
 /-- The contraction property: σ(tailRV t) ≤ σ(t).
 

--- a/Exchangeability/DeFinetti/ViaMartingale/ShiftOperations.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/ShiftOperations.lean
@@ -95,11 +95,8 @@ lemma measurable_path {X : ℕ → Ω → α} (hX : ∀ n, Measurable (X n)) : M
 lemma measurable_consRV (x : Ω → α) (t : Ω → ℕ → α) :
     Measurable x → Measurable t → Measurable (consRV x t) := by
   intro hx ht
-  simpa [consRV] using
-    (measurable_pi_lambda (f := consRV x t) (fun n => by
-      cases n with
-      | zero => exact hx
-      | succ k => exact (measurable_pi_apply k).comp ht))
+  refine measurable_pi_lambda _ ?_
+  intro n; cases n <;> simp [consRV] <;> fun_prop
 
 /-- Tail is measurable when the original sequence is measurable. -/
 @[measurability, fun_prop]

--- a/Exchangeability/Ergodic/ShiftInvariantRepresentatives.lean
+++ b/Exchangeability/Ergodic/ShiftInvariantRepresentatives.lean
@@ -98,7 +98,7 @@ def gRep (g0 : Ω[α] → ℝ) : Ω[α] → ℝ :=
   fun ω => (gLimsupE g0 ω).toReal
 
 
-@[measurability]
+@[measurability, fun_prop]
 lemma gRep_measurable {g0 : Ω[α] → ℝ} (hg0 : Measurable g0) :
     Measurable (gRep g0) := by
   have hstep : ∀ n : ℕ, Measurable fun ω => (g0 (shift^[n] ω) : EReal) := by

--- a/Exchangeability/Ergodic/ShiftInvariantRepresentatives.lean
+++ b/Exchangeability/Ergodic/ShiftInvariantRepresentatives.lean
@@ -98,6 +98,7 @@ def gRep (g0 : Ω[α] → ℝ) : Ω[α] → ℝ :=
   fun ω => (gLimsupE g0 ω).toReal
 
 
+@[measurability]
 lemma gRep_measurable {g0 : Ω[α] → ℝ} (hg0 : Measurable g0) :
     Measurable (gRep g0) := by
   have hstep : ∀ n : ℕ, Measurable fun ω => (g0 (shift^[n] ω) : EReal) := by

--- a/Exchangeability/Ergodic/ShiftInvariantSigma.lean
+++ b/Exchangeability/Ergodic/ShiftInvariantSigma.lean
@@ -150,6 +150,7 @@ lemma shiftInvariantSigma_measurable_shift_eq
       exact lt_irrefl _ this
 
 -- Helper: Measurability of iterated shifts follows from measurability of `shift`.
+@[measurability, fun_prop]
 lemma shift_iterate_measurable (n : ℕ) :
     Measurable (shift^[n] : Ω[α] → Ω[α]) := by
   simpa using measurable_shift.iterate n

--- a/Exchangeability/PathSpace/CylinderHelpers.lean
+++ b/Exchangeability/PathSpace/CylinderHelpers.lean
@@ -239,27 +239,26 @@ section CylinderBridge
 
 variable {α : Type*} [MeasurableSpace α]
 
-/-- Drop the first coordinate of a path. -/
-def drop (f : ℕ → α) : ℕ → α := fun n => f (n + 1)
+/-- Drop the first coordinate of a path (alias for `shift`). -/
+abbrev drop : (ℕ → α) → (ℕ → α) := shift
 
 omit [MeasurableSpace α] in
 @[simp] lemma drop_apply (f : ℕ → α) (n : ℕ) :
-    drop f n = f (n + 1) := rfl
+    drop f n = f (n + 1) := shift_apply f n
 
 @[measurability, fun_prop]
-lemma measurable_drop : Measurable (drop : (ℕ → α) → (ℕ → α)) := by
-  simpa [drop] using (measurable_shift (α := α))
+lemma measurable_drop : Measurable (drop : (ℕ → α) → (ℕ → α)) := shift_measurable
 
 omit [MeasurableSpace α] in
-/-- `tailCylinder` is the preimage of a standard cylinder under `drop`. -/
+/-- `tailCylinder` is the preimage of a standard cylinder under `shift`. -/
 lemma tailCylinder_eq_preimage_cylinder
     {r : ℕ} {C : Fin r → Set α} :
     tailCylinder (α:=α) r C
-      = (drop : (ℕ → α) → (ℕ → α)) ⁻¹' (cylinder (α:=α) r C) := by
+      = (shift : (ℕ → α) → (ℕ → α)) ⁻¹' (cylinder (α:=α) r C) := by
   ext f
   constructor <;> intro hf
-  · simpa [tailCylinder, drop, cylinder]
-  · simpa [tailCylinder, drop, cylinder]
+  · simpa [tailCylinder, shift, cylinder]
+  · simpa [tailCylinder, shift, cylinder]
 
 omit [MeasurableSpace α] in
 @[simp] lemma mem_cylinder_iff {r : ℕ} {C : Fin r → Set α} {f : ℕ → α} :

--- a/Exchangeability/PathSpace/CylinderHelpers.lean
+++ b/Exchangeability/PathSpace/CylinderHelpers.lean
@@ -162,7 +162,10 @@ lemma firstRCylinder_measurable_ambient
 lemma measurable_firstRMap
     (X : ℕ → Ω → α) (r : ℕ) (hX : ∀ i, Measurable (X i)) :
     Measurable (firstRMap X r) :=
-  measurable_pi_lambda _ (fun i => hX i)
+  by
+    rw [measurable_pi_iff]
+    intro i
+    simpa [firstRMap] using hX i
 
 /-- The first-r σ-algebra is a sub-σ-algebra of the ambient σ-algebra when coordinates are measurable. -/
 lemma firstRSigma_le_ambient
@@ -190,9 +193,9 @@ lemma firstRSigma_mono
     simp [firstRMap, π]
   -- π is measurable (composition of coordinate projections)
   have hπ : Measurable π := by
-    exact
-      measurable_pi_lambda _ (fun i =>
-        measurable_pi_apply (show Fin s from ⟨i.val, Nat.lt_of_lt_of_le i.isLt hrs⟩))
+    rw [measurable_pi_iff]
+    intro i
+    simpa [π] using (measurable_pi_apply (show Fin s from ⟨i.val, Nat.lt_of_lt_of_le i.isLt hrs⟩))
   -- Preimage factors through composition
   rw [h_comp, Set.preimage_comp]
   exact ⟨π ⁻¹' u, hπ hu, rfl⟩
@@ -244,7 +247,9 @@ omit [MeasurableSpace α] in
 
 @[measurability, fun_prop]
 lemma measurable_drop : Measurable (drop : (ℕ → α) → (ℕ → α)) := by
-  exact measurable_pi_lambda _ (fun n => measurable_pi_apply (n + 1))
+  rw [measurable_pi_iff]
+  intro i
+  simpa [drop] using (measurable_pi_apply (i + 1))
 
 omit [MeasurableSpace α] in
 /-- `tailCylinder` is the preimage of a standard cylinder under `drop`. -/

--- a/Exchangeability/PathSpace/CylinderHelpers.lean
+++ b/Exchangeability/PathSpace/CylinderHelpers.lean
@@ -189,11 +189,7 @@ lemma firstRSigma_mono
     funext ω i
     simp [firstRMap, π]
   -- π is measurable (composition of coordinate projections)
-  have hπ : Measurable π := by
-    simpa [π] using
-      (measurable_pi_lambda (f := π)
-        (fun i => measurable_pi_apply (show Fin s from ⟨i.val, Nat.lt_of_lt_of_le i.isLt hrs⟩))
-      )
+  have hπ : Measurable π := by fun_prop
   -- Preimage factors through composition
   rw [h_comp, Set.preimage_comp]
   exact ⟨π ⁻¹' u, hπ hu, rfl⟩

--- a/Exchangeability/PathSpace/CylinderHelpers.lean
+++ b/Exchangeability/PathSpace/CylinderHelpers.lean
@@ -162,10 +162,8 @@ lemma firstRCylinder_measurable_ambient
 @[measurability, fun_prop]
 lemma measurable_firstRMap
     (X : ℕ → Ω → α) (r : ℕ) (hX : ∀ i, Measurable (X i)) :
-    Measurable (firstRMap X r) :=
-  by
-    simpa [firstRMap] using
-      (measurable_pi_lambda (f := firstRMap (X := X) r) (fun i => hX i))
+    Measurable (firstRMap X r) := by
+  unfold firstRMap; fun_prop
 
 /-- The first-r σ-algebra is a sub-σ-algebra of the ambient σ-algebra when coordinates are measurable. -/
 lemma firstRSigma_le_ambient

--- a/Exchangeability/PathSpace/CylinderHelpers.lean
+++ b/Exchangeability/PathSpace/CylinderHelpers.lean
@@ -158,7 +158,7 @@ lemma firstRCylinder_measurable_ambient
   exact MeasurableSet.iInter fun i => (hX i) (hC i)
 
 /-- The firstRMap is measurable when all coordinates are measurable. -/
-@[measurability]
+@[measurability, fun_prop]
 lemma measurable_firstRMap
     (X : ℕ → Ω → α) (r : ℕ) (hX : ∀ i, Measurable (X i)) :
     Measurable (firstRMap X r) :=
@@ -192,9 +192,7 @@ lemma firstRSigma_mono
   have hπ : Measurable π := by
     exact
       measurable_pi_lambda _ (fun i =>
-        by
-          simp only [π]
-          exact measurable_pi_apply (show Fin s from ⟨i.val, Nat.lt_of_lt_of_le i.isLt hrs⟩))
+        measurable_pi_apply (show Fin s from ⟨i.val, Nat.lt_of_lt_of_le i.isLt hrs⟩))
   -- Preimage factors through composition
   rw [h_comp, Set.preimage_comp]
   exact ⟨π ⁻¹' u, hπ hu, rfl⟩
@@ -244,7 +242,7 @@ omit [MeasurableSpace α] in
 @[simp] lemma drop_apply (f : ℕ → α) (n : ℕ) :
     drop f n = f (n + 1) := rfl
 
-@[measurability]
+@[measurability, fun_prop]
 lemma measurable_drop : Measurable (drop : (ℕ → α) → (ℕ → α)) := by
   exact measurable_pi_lambda _ (fun n => measurable_pi_apply (n + 1))
 

--- a/Exchangeability/PathSpace/CylinderHelpers.lean
+++ b/Exchangeability/PathSpace/CylinderHelpers.lean
@@ -190,10 +190,11 @@ lemma firstRSigma_mono
     simp [firstRMap, π]
   -- π is measurable (composition of coordinate projections)
   have hπ : Measurable π := by
-    rw [measurable_pi_iff]
-    intro i
-    simp only [π]
-    exact measurable_pi_apply _
+    exact
+      measurable_pi_lambda _ (fun i =>
+        by
+          simp only [π]
+          exact measurable_pi_apply (show Fin s from ⟨i.val, Nat.lt_of_lt_of_le i.isLt hrs⟩))
   -- Preimage factors through composition
   rw [h_comp, Set.preimage_comp]
   exact ⟨π ⁻¹' u, hπ hu, rfl⟩
@@ -245,10 +246,7 @@ omit [MeasurableSpace α] in
 
 @[measurability]
 lemma measurable_drop : Measurable (drop : (ℕ → α) → (ℕ → α)) := by
-  rw [measurable_pi_iff]
-  intro n
-  simp only [drop]
-  exact measurable_pi_apply (n + 1)
+  exact measurable_pi_lambda _ (fun n => measurable_pi_apply (n + 1))
 
 omit [MeasurableSpace α] in
 /-- `tailCylinder` is the preimage of a standard cylinder under `drop`. -/

--- a/Exchangeability/PathSpace/CylinderHelpers.lean
+++ b/Exchangeability/PathSpace/CylinderHelpers.lean
@@ -22,7 +22,6 @@ Originally extracted from `MartingaleHelpers.lean` for broader reusability.
 * `finCylinder r C`: Cylinder for functions with domain `Fin r`
 * `firstRMap X r`: Map collecting the first `r` coordinates of a process
 * `firstRCylinder X r C`: Finite block cylinder event on the first `r` coordinates
-* `drop`: Drop the first coordinate of a path
 
 ## Main results
 
@@ -236,16 +235,6 @@ end FirstBlockCylinder
 section CylinderBridge
 
 variable {α : Type*} [MeasurableSpace α]
-
-/-- Drop the first coordinate of a path (alias for `shift`). -/
-abbrev drop : (ℕ → α) → (ℕ → α) := shift
-
-omit [MeasurableSpace α] in
-@[simp] lemma drop_apply (f : ℕ → α) (n : ℕ) :
-    drop f n = f (n + 1) := shift_apply f n
-
-@[measurability, fun_prop]
-lemma measurable_drop : Measurable (drop : (ℕ → α) → (ℕ → α)) := shift_measurable
 
 omit [MeasurableSpace α] in
 /-- `tailCylinder` is the preimage of a standard cylinder under `shift`. -/

--- a/Exchangeability/PathSpace/CylinderHelpers.lean
+++ b/Exchangeability/PathSpace/CylinderHelpers.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Cameron Freer
 -/
 import Mathlib.MeasureTheory.MeasurableSpace.Constructions
+import Exchangeability.PathSpace.Shift
 
 /-!
 # Cylinder Sets on Path Space
@@ -163,9 +164,8 @@ lemma measurable_firstRMap
     (X : ℕ → Ω → α) (r : ℕ) (hX : ∀ i, Measurable (X i)) :
     Measurable (firstRMap X r) :=
   by
-    rw [measurable_pi_iff]
-    intro i
-    simpa [firstRMap] using hX i
+    simpa [firstRMap] using
+      (measurable_pi_lambda (f := firstRMap (X := X) r) (fun i => hX i))
 
 /-- The first-r σ-algebra is a sub-σ-algebra of the ambient σ-algebra when coordinates are measurable. -/
 lemma firstRSigma_le_ambient
@@ -193,9 +193,10 @@ lemma firstRSigma_mono
     simp [firstRMap, π]
   -- π is measurable (composition of coordinate projections)
   have hπ : Measurable π := by
-    rw [measurable_pi_iff]
-    intro i
-    simpa [π] using (measurable_pi_apply (show Fin s from ⟨i.val, Nat.lt_of_lt_of_le i.isLt hrs⟩))
+    simpa [π] using
+      (measurable_pi_lambda (f := π)
+        (fun i => measurable_pi_apply (show Fin s from ⟨i.val, Nat.lt_of_lt_of_le i.isLt hrs⟩))
+      )
   -- Preimage factors through composition
   rw [h_comp, Set.preimage_comp]
   exact ⟨π ⁻¹' u, hπ hu, rfl⟩
@@ -247,9 +248,7 @@ omit [MeasurableSpace α] in
 
 @[measurability, fun_prop]
 lemma measurable_drop : Measurable (drop : (ℕ → α) → (ℕ → α)) := by
-  rw [measurable_pi_iff]
-  intro i
-  simpa [drop] using (measurable_pi_apply (i + 1))
+  simpa [drop] using (measurable_shift (α := α))
 
 omit [MeasurableSpace α] in
 /-- `tailCylinder` is the preimage of a standard cylinder under `drop`. -/

--- a/Exchangeability/PathSpace/Shift.lean
+++ b/Exchangeability/PathSpace/Shift.lean
@@ -72,8 +72,7 @@ which is measurable by definition of the product σ-algebra.
 -/
 @[measurability, fun_prop]
 lemma shift_measurable [MeasurableSpace α] : Measurable (@shift α) := by
-  simpa [shift] using
-    (measurable_pi_lambda (f := shift (α := α)) (fun i => measurable_pi_apply (i + 1)))
+  unfold shift; fun_prop
 
 /- Alternative name for `shift_measurable` (used in ergodic theory contexts). -/
 @[measurability, fun_prop]

--- a/Exchangeability/PathSpace/Shift.lean
+++ b/Exchangeability/PathSpace/Shift.lean
@@ -72,8 +72,9 @@ which is measurable by definition of the product σ-algebra.
 -/
 @[measurability, fun_prop]
 lemma shift_measurable [MeasurableSpace α] : Measurable (@shift α) := by
-  refine measurable_pi_lambda _ (fun i => ?_)
-  simpa [shift, Function.comp] using (measurable_pi_apply (i + 1))
+  rw [measurable_pi_iff]
+  intro i
+  simpa [shift] using (measurable_pi_apply (i + 1))
 
 /- Alternative name for `shift_measurable` (used in ergodic theory contexts). -/
 @[measurability, fun_prop]

--- a/Exchangeability/PathSpace/Shift.lean
+++ b/Exchangeability/PathSpace/Shift.lean
@@ -72,9 +72,8 @@ which is measurable by definition of the product σ-algebra.
 -/
 @[measurability, fun_prop]
 lemma shift_measurable [MeasurableSpace α] : Measurable (@shift α) := by
-  rw [measurable_pi_iff]
-  intro i
-  simpa [shift] using (measurable_pi_apply (i + 1))
+  simpa [shift] using
+    (measurable_pi_lambda (f := shift (α := α)) (fun i => measurable_pi_apply (i + 1)))
 
 /- Alternative name for `shift_measurable` (used in ergodic theory contexts). -/
 @[measurability, fun_prop]

--- a/Exchangeability/PathSpace/Shift.lean
+++ b/Exchangeability/PathSpace/Shift.lean
@@ -72,10 +72,11 @@ which is measurable by definition of the product σ-algebra.
 -/
 @[measurability, fun_prop]
 lemma shift_measurable [MeasurableSpace α] : Measurable (@shift α) := by
-  exact measurable_pi_lambda _ (fun i => measurable_pi_apply (i + 1))
+  refine measurable_pi_lambda _ (fun i => ?_)
+  simpa [shift, Function.comp] using (measurable_pi_apply (i + 1))
 
-/-- Alternative name for `shift_measurable` (used in ergodic theory contexts). -/
-@[measurability]
+/- Alternative name for `shift_measurable` (used in ergodic theory contexts). -/
+@[measurability, fun_prop]
 lemma measurable_shift [MeasurableSpace α] : Measurable (@shift α) := shift_measurable
 
 /-- A set in the path space is **shift-invariant** if it equals its preimage under the shift.

--- a/Exchangeability/PathSpace/Shift.lean
+++ b/Exchangeability/PathSpace/Shift.lean
@@ -70,14 +70,9 @@ lemma shift_comp_shift : @shift α ∘ shift = fun ξ n => ξ (n + 2) := by
 Since `(shift ξ) i = ξ (i + 1)`, this is the projection onto coordinate `(i + 1)`,
 which is measurable by definition of the product σ-algebra.
 -/
-@[measurability]
+@[measurability, fun_prop]
 lemma shift_measurable [MeasurableSpace α] : Measurable (@shift α) := by
-  -- A function to a pi type is measurable iff each component is measurable
-  rw [measurable_pi_iff]
-  intro i
-  -- The i-th component of shift ξ is ξ (i + 1)
-  -- This is just the projection onto coordinate (i + 1)
-  exact measurable_pi_apply (i + 1)
+  exact measurable_pi_lambda _ (fun i => measurable_pi_apply (i + 1))
 
 /-- Alternative name for `shift_measurable` (used in ergodic theory contexts). -/
 @[measurability]

--- a/Exchangeability/Probability/CenteredVariables.lean
+++ b/Exchangeability/Probability/CenteredVariables.lean
@@ -87,15 +87,13 @@ lemma centered_uniform_covariance
 
     -- h is measurable
     have h_meas : Measurable h := by
-      apply measurable_pi_iff.mpr
-      intro i
-      exact (measurable_pi_apply i).sub measurable_const
+      refine measurable_pi_lambda _ (fun i => (measurable_pi_apply i).sub measurable_const)
 
     -- Input functions are measurable
     have hL_meas : Measurable (fun ω (i : Fin n) => f (X (k i) ω)) :=
-      measurable_pi_iff.mpr (fun i => hf_meas.comp (hX_meas (k i)))
+      measurable_pi_lambda _ (fun i => hf_meas.comp (hX_meas (k i)))
     have hR_meas : Measurable (fun ω (i : Fin n) => f (X (↑i) ω)) :=
-      measurable_pi_iff.mpr (fun i => hf_meas.comp (hX_meas i))
+      measurable_pi_lambda _ (fun i => hf_meas.comp (hX_meas i))
 
     -- Apply map_map: map (h ∘ g) μ = map h (map g μ)
     calc Measure.map (fun ω i => f (X (k i) ω) - m) μ

--- a/Exchangeability/Probability/CenteredVariables.lean
+++ b/Exchangeability/Probability/CenteredVariables.lean
@@ -87,13 +87,13 @@ lemma centered_uniform_covariance
 
     -- h is measurable
     have h_meas : Measurable h := by
-      refine measurable_pi_lambda _ (fun i => (measurable_pi_apply i).sub measurable_const)
+      fun_prop
 
     -- Input functions are measurable
-    have hL_meas : Measurable (fun ω (i : Fin n) => f (X (k i) ω)) :=
-      measurable_pi_lambda _ (fun i => hf_meas.comp (hX_meas (k i)))
-    have hR_meas : Measurable (fun ω (i : Fin n) => f (X (↑i) ω)) :=
-      measurable_pi_lambda _ (fun i => hf_meas.comp (hX_meas i))
+    have hL_meas : Measurable (fun ω (i : Fin n) => f (X (k i) ω)) := by
+      fun_prop
+    have hR_meas : Measurable (fun ω (i : Fin n) => f (X (↑i) ω)) := by
+      fun_prop
 
     -- Apply map_map: map (h ∘ g) μ = map h (map g μ)
     calc Measure.map (fun ω i => f (X (k i) ω) - m) μ

--- a/Exchangeability/Probability/InfiniteProduct.lean
+++ b/Exchangeability/Probability/InfiniteProduct.lean
@@ -212,8 +212,7 @@ lemma cylinder_fintype {n : ℕ} :
   intro s hs
 
   -- Compute the LHS: (iidProduct ν).map (...) applied to rectangle Set.univ.pi s
-  have h_meas : Measurable (fun f : ℕ → α => fun i : Fin n => f i) := by
-    measurability
+  have h_meas : Measurable (fun f : ℕ → α => fun i : Fin n => f i) := by fun_prop
 
   calc (iidProduct ν).map (fun f : ℕ → α => fun i : Fin n => f i) (Set.univ.pi s)
       = iidProduct ν ((fun f : ℕ → α => fun i : Fin n => f i) ⁻¹' (Set.univ.pi s)) := by
@@ -286,7 +285,7 @@ lemma perm_eq {σ : Equiv.Perm ℕ} :
   -- Need to show: (infinitePi ν).map (fun f => f ∘ σ) (Set.pi s t) = ∏ i ∈ s, ν (t i)
   rw [Measure.map_apply _ (.pi s.countable_toSet (fun _ _ => ht _))]
   swap
-  · measurability
+  · fun_prop
 
   -- The preimage under (fun f => f ∘ σ) of Set.pi s t
   -- We'll express this using Finset.map instead of Set.image for cleaner measure computation

--- a/Exchangeability/Probability/MeasureKernels.lean
+++ b/Exchangeability/Probability/MeasureKernels.lean
@@ -49,6 +49,7 @@ variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
 This is a wrapper around `Finset.measurable_prod` specialized to ENNReal.
 -/
+@[measurability, fun_prop]
 lemma measurable_prod_ennreal {ι : Type*} [Fintype ι] {Ω : Type*} [MeasurableSpace Ω]
     (f : ι → Ω → ENNReal) (hf : ∀ i, Measurable (f i)) :
     Measurable fun ω => ∏ i, f i ω :=
@@ -160,6 +161,7 @@ This is a key lemma for proving the ConditionallyIID property in de Finetti's th
 yield measurable kernels, which is essential for disintegration theory and
 conditional independence.
 -/
+@[measurability, fun_prop]
 lemma measurable_measure_pi {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
     {m : ℕ}
     (ν : Ω → Measure α) (hν_prob : ∀ ω, IsProbabilityMeasure (ν ω))

--- a/Exchangeability/Tail/CondExpShiftInvariance.lean
+++ b/Exchangeability/Tail/CondExpShiftInvariance.lean
@@ -91,10 +91,10 @@ lemma condExp_shift_eq_condExp
         have h_preimage_0 : X 0 ⁻¹' s = (fun ω (i : Fin 1) => X i.val ω) ⁻¹' S := by
           ext ω
           simp only [Set.mem_preimage, Set.mem_setOf_eq, S, Fin.val_zero]
-        have h_meas_n1 : Measurable (fun ω (i : Fin 1) => X ((n + 1) + i.val) ω) :=
-          measurable_pi_lambda _ (fun i => hX_meas ((n + 1) + i.val))
-        have h_meas_0 : Measurable (fun ω (i : Fin 1) => X i.val ω) :=
-          measurable_pi_lambda _ (fun i => hX_meas i.val)
+        have h_meas_n1 : Measurable (fun ω (i : Fin 1) => X ((n + 1) + i.val) ω) := by
+          fun_prop
+        have h_meas_0 : Measurable (fun ω (i : Fin 1) => X i.val ω) := by
+          fun_prop
         rw [Measure.map_apply (hX_meas (n + 1)) hs, Measure.map_apply (hX_meas 0) hs]
         rw [h_preimage_n1, h_preimage_0]
         have h_eq := congrFun (congrArg (·.toOuterMeasure) h1) S

--- a/Exchangeability/Tail/ShiftInvariantMeasure.lean
+++ b/Exchangeability/Tail/ShiftInvariantMeasure.lean
@@ -533,9 +533,7 @@ lemma setIntegral_comp_shift_eq
         z ⟨i.val + 1, by omega⟩
 
       have hproj_meas : Measurable proj := by
-        apply measurable_pi_lambda
-        intro i
-        exact measurable_pi_apply _
+        fun_prop
 
       have h_indices_mem : ∀ i : Fin d, indices.get ⟨i.val, by rw [h_len]; exact i.isLt⟩ ∈ pt := by
         intro i

--- a/Exchangeability/Tail/ShiftInvariantMeasure.lean
+++ b/Exchangeability/Tail/ShiftInvariantMeasure.lean
@@ -83,10 +83,10 @@ lemma tailSigma_shift_invariant_for_contractable
   let ν₂ := Measure.map (fun ω i => X i ω) μ
 
   -- Both are probability measures
-  have h_meas_shifted : Measurable (fun ω i => X (1 + i) ω) :=
-    measurable_pi_lambda _ (fun i => hX_meas (1 + i))
-  have h_meas_orig : Measurable (fun ω i => X i ω) :=
-    measurable_pi_lambda _ hX_meas
+  have h_meas_shifted : Measurable (fun ω i => X (1 + i) ω) := by
+    fun_prop
+  have h_meas_orig : Measurable (fun ω i => X i ω) := by
+    fun_prop
   haveI : IsProbabilityMeasure ν₁ := Measure.isProbabilityMeasure_map h_meas_shifted.aemeasurable
   haveI : IsProbabilityMeasure ν₂ := Measure.isProbabilityMeasure_map h_meas_orig.aemeasurable
 
@@ -197,10 +197,10 @@ private lemma setIntegral_cylinder_eq
   let C' : Set Ω := {ω | (fun i => X (N + i.val) ω) ∈ S}
   have hC_C' : C' = {ω | (fun i => X (N + i.val) ω) ∈ S} := rfl
 
-  have hσ_meas : Measurable (fun ω i => X (σ i) ω) :=
-    measurable_pi_lambda _ (fun i => hX_meas (σ i))
-  have hτ_meas : Measurable (fun ω i => X (τ i) ω) :=
-    measurable_pi_lambda _ (fun i => hX_meas (τ i))
+  have hσ_meas : Measurable (fun ω i => X (σ i) ω) := by
+    fun_prop
+  have hτ_meas : Measurable (fun ω i => X (τ i) ω) := by
+    fun_prop
 
   have hσ_0 : σ ⟨0, by omega⟩ = k + 1 := by simp only [σ, ↓reduceIte]
   have hτ_0 : τ ⟨0, by omega⟩ = 0 := by simp only [τ, ↓reduceIte]
@@ -251,7 +251,7 @@ private lemma setIntegral_cylinder_eq
 
   have hC'_meas : MeasurableSet C' := by
     apply MeasurableSet.preimage _hS
-    exact measurable_pi_lambda _ (fun i => hX_meas (N + i.val))
+    fun_prop
 
   have h_ind_eq : ∀ (h : α → ℝ) (ω : Ω),
       C'.indicator (fun ω => h (X 0 ω)) ω = h (X 0 ω) * (C'.indicator 1 ω) := by
@@ -284,7 +284,7 @@ private lemma setIntegral_cylinder_eq
           apply Measurable.mul
           · exact hf_meas.comp (measurable_pi_apply _)
           · apply Measurable.indicator measurable_const
-            exact MeasurableSet.preimage _hS (measurable_pi_lambda _ (fun i => measurable_pi_apply _))
+            exact MeasurableSet.preimage _hS (by fun_prop)
     _ = ∫ z, g z ∂(Measure.map (fun ω i => X (τ i) ω) μ) := by rw [h_eq]
     _ = ∫ ω, g (fun i => X (τ i) ω) ∂μ := by
           rw [← integral_map hτ_meas.aemeasurable]
@@ -292,7 +292,7 @@ private lemma setIntegral_cylinder_eq
           apply Measurable.mul
           · exact hf_meas.comp (measurable_pi_apply _)
           · apply Measurable.indicator measurable_const
-            exact MeasurableSet.preimage _hS (measurable_pi_lambda _ (fun i => measurable_pi_apply _))
+            exact MeasurableSet.preimage _hS (by fun_prop)
     _ = ∫ ω, f (X 0 ω) * (C'.indicator 1 ω) ∂μ := by
           apply integral_congr_ae
           filter_upwards with ω
@@ -337,10 +337,10 @@ lemma setIntegral_comp_shift_eq
       ext s hs
       let S : Set (Fin 1 → α) := {g | g 0 ∈ s}
       have hS : MeasurableSet S := measurable_pi_apply 0 hs
-      have h_meas_k1 : Measurable (fun ω (i : Fin 1) => X ((k + 1) + i.val) ω) :=
-        measurable_pi_lambda _ (fun i => hX_meas ((k + 1) + i.val))
-      have h_meas_0 : Measurable (fun ω (i : Fin 1) => X i.val ω) :=
-        measurable_pi_lambda _ (fun i => hX_meas i.val)
+      have h_meas_k1 : Measurable (fun ω (i : Fin 1) => X ((k + 1) + i.val) ω) := by
+        fun_prop
+      have h_meas_0 : Measurable (fun ω (i : Fin 1) => X i.val ω) := by
+        fun_prop
       rw [Measure.map_apply (hX_meas (k + 1)) hs, Measure.map_apply (hX_meas 0) hs]
       have h_pre_k1 : X (k + 1) ⁻¹' s = (fun ω (i : Fin 1) => X ((k + 1) + i.val) ω) ⁻¹' S := by
         ext ω
@@ -506,10 +506,10 @@ lemma setIntegral_comp_shift_eq
       have hσ_0 : σ ⟨0, by omega⟩ = k + 1 := by simp only [σ, ↓reduceDIte]
       have hτ_0 : τ ⟨0, by omega⟩ = 0 := by simp only [τ, ↓reduceDIte]
 
-      have hσ_meas : Measurable (fun ω i => X (σ i) ω) :=
-        measurable_pi_lambda _ (fun i => hX_meas (σ i))
-      have hτ_meas : Measurable (fun ω i => X (τ i) ω) :=
-        measurable_pi_lambda _ (fun i => hX_meas (τ i))
+      have hσ_meas : Measurable (fun ω i => X (σ i) ω) := by
+        fun_prop
+      have hτ_meas : Measurable (fun ω i => X (τ i) ω) := by
+        fun_prop
 
       have hσ_succ : ∀ i : Fin d, σ ⟨i.val + 1, by omega⟩ =
           N + indices.get ⟨i.val, by rw [h_len]; exact i.isLt⟩ := by


### PR DESCRIPTION
## Summary

Systematic cleanup of measurability proofs across 36 files, leveraging Lean 4's `fun_prop` and `measurability` automation to replace verbose manual proof patterns.

### What changed

- **Replaced ~50 manual `measurable_pi_lambda` / `simpa` proof bodies** with `unfold <def>; fun_prop` or `by fun_prop` (1-liners replacing 3–6 line proofs)
- **Tagged ~25 lemmas with `@[measurability, fun_prop]`** so they participate in automation, enabling downstream proofs to close with `by fun_prop` or `by measurability`
- **Swapped ~30 downstream `by measurability` sites to `by fun_prop`**, avoiding aesop search overhead
- **Removed the `drop` abbreviation entirely** — it was just `shift` with a duplicate API surface
- **Added new `@[fun_prop]` combinator lemmas** for `shiftRV`, `consRV`, `tailRV`, `path`, `embedPairSeq`, `projectPairSeq`, and kernel/measure operations

### Commits (chronological)

1. `94fb1a96` — Add measurability automation lemmas for path combinators
2. `0e7fd8f7` — Golf measurability proofs in de Finetti path arguments
3. `d2d73114` — Refactor: golf measurability proofs across core files
4. `3949b82b` — Audit measurability: replace Pi combinator proofs with `fun_prop`
5. `938e47b9` — Golf future-rectangles measurability with `fun_prop`
6. `b253720b` — Further measurability golf with `fun_prop`/`measurability`
7. `c225db37` — Tag standalone measurability lemmas with `@[measurability, fun_prop]`
8. `ef6ddca6` — Golf measurable proofs with measurability automation
9. `76715600` — Unify `drop` with `shift` as `abbrev`
10. `529af684` — Golf proof bodies with `unfold` + `fun_prop`
11. `2a6b2f4c` — Add `@[fun_prop]` tags and swap downstream `by measurability` → `by fun_prop`
12. `30e23a90` — Swap remaining `by measurability` to `fun_prop` across 7 more files
13. `c785c732` — Remove `drop` abbreviation (it was just `shift`)
14. `a55ec545` — Golf InfraCore + CylinderHelpers `measurable_pi_lambda` bodies with `unfold`/`fun_prop`
15. `e6ce32b0` — Golf last 3 `measurable_pi_lambda` bodies with case-split + `fun_prop`

### Net impact

- 36 files changed, ~250 insertions, ~280 deletions (**net −30+ lines**)
- No new `sorry`s introduced
- Only standard axioms (`propext`, `quot.sound`, `Classical.choice`)

## Test plan

- [x] `lake build` passes on all 3296 modules
- [x] Spot-checked `lean_diagnostic_messages` on modified files (no new errors)
- [x] No new sorries or non-standard axioms