### PR TITLE
docs(blueprint): article-class restructure, narrative, examples, conclusion

### DIFF
--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -24,6 +24,20 @@ We formalize \emph{all three proofs} from Kallenberg~\cite{Kallenberg2005}:
   \item \textbf{Martingale approach} using reverse martingale convergence (after Aldous~\cite{Aldous1985})
 \end{enumerate}
 
+\begin{table}[h]
+\centering
+\small
+\begin{tabular}{@{}llll@{}}
+\toprule
+\textbf{Route} & \textbf{Key tool} & \textbf{Extra assumptions} & \textbf{Lines} \\
+\midrule
+Martingale & Reverse martingale convergence & None (general $\alpha$) & 3,770 \\
+L$^2$ & Ces\`aro $L^2$ bounds & $\alpha = \mathbb{R}$, square-integrable & 12,476 \\
+Koopman & Mean Ergodic Theorem & None (general $\alpha$) & 6,893 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
 \paragraph{Contributions.}
 The formalization comprises approximately 43,500 lines of Lean~4 across 112 files.
 All three proof routes share a uniform ``common ending'' that packages conditional factorization
@@ -86,6 +100,12 @@ the de Finetti--Ryll-Nardzewski Equivalence (assembling the full result).
   such that for any strictly monotone $k : \mathrm{Fin}(m) \to \mathbb{N}$, the joint distribution
   of $(X_{k(0)}, \ldots, X_{k(m-1)})$ equals the mixture $\mu.\mathrm{bind}(\omega \mapsto \nu(\omega)^{\otimes m})$.
 \end{definition}
+
+\paragraph{Example (Polya urn / Beta-Bernoulli).}
+Draw $p \sim \mathrm{Uniform}[0,1]$, then $X_i \mid p \sim \mathrm{Bernoulli}(p)$ independently.
+The sequence $(X_i)$ is exchangeable (by symmetry of the product) and conditionally i.i.d.\
+with directing measure $\nu(\omega) = \mathrm{Bernoulli}(p(\omega))$.
+De Finetti's theorem says every exchangeable $\{0,1\}$-valued sequence arises in this way.
 
 \section{\texorpdfstring{$\sigma$}{σ}-algebra Infrastructure}
 
@@ -183,6 +203,15 @@ All three routes ultimately feed the shared final step described in the next cha
 \section{Via Martingale (Aldous' proof)}
 
 The martingale approach uses reverse martingale convergence to the tail $\sigma$-algebra.
+
+\paragraph{Key idea.}
+Contractability implies that conditional expectations of indicators
+$\mathbb{E}[\mathbf{1}_{X_k \in B} \mid \mathcal{F}_m]$ are independent of the index~$k$
+for $k \le m$.
+These form a reverse martingale with respect to the future filtration~$(\mathcal{F}_m)$.
+The reverse martingale convergence theorem yields $L^1$ convergence to
+$\mathbb{E}[\mathbf{1}_{X_0 \in B} \mid \mathcal{T}]$, from which the directing measure and
+conditional factorization are extracted.
 
 \subsection{Pair Law Equality}
 
@@ -306,6 +335,14 @@ This is Kallenberg's ``second proof'' and has the lightest dependencies.
 \textbf{Note:} This proof applies to \emph{real-valued} sequences ($X : \mathbb{N} \to \Omega \to \mathbb{R}$)
 with $L^2$ integrability (i.e., $\mathbb{E}[X_i^2] < \infty$ for all $i$).
 
+\paragraph{Key idea.}
+Contractability forces the covariance $\mathrm{Cov}(f(X_i), f(X_j))$ to be constant
+for $i \ne j$, which gives $L^2$ bounds on block-average differences.
+Ces\`aro averaging and these bounds yield $L^2$ (hence $L^1$) convergence of
+empirical averages $\frac{1}{n}\sum f(X_i)$ to a limiting function.
+This limit, evaluated on indicator functions $f = \mathbf{1}_{(-\infty, t]}$, produces a CDF
+from which a Stieltjes probability measure (the directing measure) is constructed.
+
 \subsection{Block Averages and Covariance Structure}
 
 \begin{definition}[Block average (L$^2$ version)]
@@ -411,6 +448,14 @@ with $L^2$ integrability (i.e., $\mathbb{E}[X_i^2] < \infty$ for all $i$).
 
 The Koopman approach uses the Mean Ergodic Theorem via the shift operator on L$^2$.
 This is Kallenberg's ``first proof'' and uses disjoint-block averaging.
+
+\paragraph{Key idea.}
+The shift map $\theta$ on path space $\alpha^{\mathbb{N}}$ induces a Koopman operator on $L^2$.
+For a shift-invariant measure, the mean ergodic theorem gives $L^2$ convergence of
+Birkhoff averages to the orthogonal projection onto the shift-invariant subspace, i.e.,
+the conditional expectation given the shift-invariant $\sigma$-algebra~$\mathcal{I}$.
+Contractability then implies that products of conditional expectations factor,
+yielding the conditional independence needed for the common ending.
 
 \subsection{Block Averages and Ergodic Theory}
 

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -599,3 +599,24 @@ and packages the result as a measurable directing kernel.
   \textbf{Remark:} The martingale proof constructs $\nu$ from the tail $\sigma$-algebra $\mathcal{T}$
   via $\nu(\omega)(B) = \mathbb{E}[\mathbf{1}_{X_0 \in B} \mid \mathcal{T}](\omega)$.
 \end{theorem}
+
+
+\chapter{Conclusion and Future Work}
+
+The formalization is complete: all three proof routes compile, share a common ending, and
+assemble into the full de Finetti--Ryll-Nardzewski equivalence.
+The Lean kernel verifies that only standard axioms are used.
+
+Several directions remain for future work:
+\begin{itemize}
+  \item \textbf{Upstreaming to mathlib.}
+    Reusable components---exchangeability and contractability definitions,
+    finite-marginal reindexing lemmas, conditional independence infrastructure---are
+    candidates for staged contribution to mathlib~\cite{mathlib}.
+  \item \textbf{Partial exchangeability.}
+    Extending the formalization to Aldous--Hoover-type results for
+    partially exchangeable arrays.
+  \item \textbf{Parametric families.}
+    Connecting the directing measure to exponential family theory
+    and Bayesian nonparametrics (e.g., Dirichlet process mixtures).
+\end{itemize}

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -106,7 +106,7 @@ We formalize \emph{all three proofs} from Kallenberg (2005):
 \end{definition}
 
 
-\chapter{Easy Directions}
+\chapter{Elementary Implications}
 
 \section{Exchangeable implies Contractable}
 
@@ -467,7 +467,7 @@ This is Kallenberg's ``first proof'' and uses disjoint-block averaging.
 \end{theorem}
 
 
-\chapter{Common Ending}
+\chapter{Shared Final Step}
 
 All three proofs converge to the same final step: extending from indicators to general sets
 via a monotone class argument.
@@ -496,7 +496,7 @@ via a monotone class argument.
 \end{theorem}
 
 
-\chapter{Main Theorem}
+\chapter{The de Finetti--Ryll-Nardzewski Equivalence}
 
 \begin{theorem}[de Finetti--Ryll-Nardzewski equivalence]
   \label{thm:deFinetti}

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -3,8 +3,12 @@
 
 \chapter{Introduction}
 
-This blueprint documents the formalization of \textbf{de Finetti's theorem} and the
+This document presents the mathematical blueprint for a Lean~4 formalization of
+\textbf{de Finetti's theorem} and the
 \textbf{de Finetti--Ryll-Nardzewski equivalence} for infinite sequences on \emph{standard Borel spaces}.
+It maps each definition and theorem in the formalization to its mathematical counterpart,
+records the proof-level dependency structure, and links to the corresponding Lean declarations.
+The companion web version of this blueprint renders an interactive dependency graph.
 
 The main result establishes a three-way equivalence between:
 \begin{itemize}
@@ -13,12 +17,39 @@ The main result establishes a three-way equivalence between:
   \item \textbf{Conditionally i.i.d.}: There exists a probability kernel such that finite marginals equal mixtures of product measures
 \end{itemize}
 
-We formalize \emph{all three proofs} from Kallenberg (2005):
+We formalize \emph{all three proofs} from Kallenberg~\cite{Kallenberg2005}:
 \begin{enumerate}
   \item \textbf{Koopman/Ergodic approach} using the Mean Ergodic Theorem
   \item \textbf{L$^2$ approach} using elementary contractability bounds
-  \item \textbf{Martingale approach} using reverse martingale convergence (after Aldous)
+  \item \textbf{Martingale approach} using reverse martingale convergence (after Aldous~\cite{Aldous1985})
 \end{enumerate}
+
+\paragraph{Contributions.}
+The formalization comprises approximately 43,500 lines of Lean~4 across 112 files.
+All three proof routes share a uniform ``common ending'' that packages conditional factorization
+into a measurable directing kernel, avoiding duplication of measurability and product-measure
+uniqueness arguments.
+
+\paragraph{Setting and conventions.}
+Throughout, we fix a probability space $(\Omega, \mathcal{F}, \mu)$ and a sequence
+$X : \mathbb{N} \to \Omega \to \alpha$ of random variables taking values in
+a standard Borel space~$\alpha$ (assumed nonempty).
+Conditional expectations are with respect to~$\mu$;
+$L^2$ denotes $L^2(\Omega, \mu)$.
+Measurability is always with respect to the Borel $\sigma$-algebra on~$\alpha$
+and the ambient $\sigma$-algebra~$\mathcal{F}$ on~$\Omega$.
+
+\paragraph{Terminology.}
+Kallenberg~\cite{Kallenberg2005} uses \emph{contractable} for the subsequence-invariance property
+that some authors call \emph{spreadable} or \emph{subsymmetric}.
+We follow Kallenberg's terminology throughout.
+
+The remainder of this document is organized as follows:
+Foundations (core definitions, $\sigma$-algebra infrastructure),
+Elementary Implications (the two easy directions),
+Main Implication (three independent proofs of contractable $\Rightarrow$ conditionally i.i.d.),
+Shared Final Step (the common ending), and
+the de Finetti--Ryll-Nardzewski Equivalence (assembling the full result).
 
 
 \chapter{Foundations}
@@ -108,6 +139,11 @@ We formalize \emph{all three proofs} from Kallenberg (2005):
 
 \chapter{Elementary Implications}
 
+Two of the three implications are straightforward.
+Exchangeability implies contractability via a permutation extension argument,
+and the converse direction (conditionally i.i.d.\ implies exchangeable) follows from
+the symmetry of product measures.
+
 \section{Exchangeable implies Contractable}
 
 \begin{lemma}[Permutation extension]
@@ -139,7 +175,10 @@ We formalize \emph{all three proofs} from Kallenberg (2005):
 
 \chapter{Main Implication: Contractable implies Conditionally i.i.d.}
 
-This is the deep direction of de Finetti's theorem. We formalize three independent proofs.
+This is the deep direction of de Finetti's theorem.
+Each proof route extracts a conditional factorization from the symmetry hypothesis, but uses
+different analytical tools: reverse martingale convergence, $L^2$ bounds, or the mean ergodic theorem.
+All three routes ultimately feed the shared final step described in the next chapter.
 
 \section{Via Martingale (Aldous' proof)}
 
@@ -469,8 +508,10 @@ This is Kallenberg's ``first proof'' and uses disjoint-block averaging.
 
 \chapter{Shared Final Step}
 
-All three proofs converge to the same final step: extending from indicators to general sets
-via a monotone class argument.
+All three proofs converge to the same final step.
+Given conditional factorization on indicators (produced by any of the three routes above),
+the common ending extends it to full measurable sets via a $\pi$-system/monotone class argument
+and packages the result as a measurable directing kernel.
 
 \begin{lemma}[$\pi$-system uniqueness]
   \label{lem:pi_system}

--- a/blueprint/src/macros/print.tex
+++ b/blueprint/src/macros/print.tex
@@ -1,14 +1,25 @@
-% In this file you should put macros to be used only by
+% In this file you should put macros to be used only by
 % the printed version. Of course they should have a corresponding
 % version in macros/web.tex.
 % Typically the printed version could have more fancy decorations.
-% This should be a very short file.
 %
 % This file starts with dummy macros that ensure the pdf
 % compiler will ignore macros provided by plasTeX that make
 % sense only for the web version, such as dependency graph
 % macros.
 
+% --- Chapter-to-section remapping (print only) ---
+% content.tex uses \chapter for web navigation; in the article-class
+% print PDF we remap to sections for a compact layout.
+% The article class has no \chapter, so we define it as \section.
+% We save the original \section and \subsection first, then remap.
+\makeatletter
+\let\print@origsection\section
+\let\print@origsubsection\subsection
+\newcommand{\chapter}[1]{\print@origsection{#1}}
+\renewcommand{\section}[1]{\print@origsubsection{#1}}
+\renewcommand{\subsection}[1]{\subsubsection{#1}}
+\makeatother
 
 % Dummy macros that make sense only for web version.
 \newcommand{\lean}[1]{}

--- a/blueprint/src/print.tex
+++ b/blueprint/src/print.tex
@@ -37,4 +37,7 @@ The formalization comprises approximately 43,500 lines of Lean across 112 files.
 \bigskip
 
 \input{content}
+
+\bibliographystyle{alpha}
+\bibliography{references}
 \end{document}

--- a/blueprint/src/print.tex
+++ b/blueprint/src/print.tex
@@ -1,18 +1,9 @@
-% This file makes a printable version of the blueprint
-% It should include all the \usepackage needed for the pdf version.
-% The template version assume you want to use a modern TeX compiler
-% such as xeLaTeX or luaLaTeX including support for unicode
-% and Latin Modern Math font with standard bugfixes applied.
-% It also uses expl3 in order to support macros related to the dependency graph.
-% It also includes standard AMS packages (and their improved version
-% mathtools) as well as support for links with a sober decoration
-% (no ugly rectangles around links).
-% It is otherwise a very minimal preamble (you should probably at least
-% add cleveref and tikz-cd).
+% This file makes a printable version of the blueprint.
+% It uses XeLaTeX with unicode-math and article class for a compact layout.
 
-\documentclass[letter]{report}
+\documentclass[letter]{article}
 
-\usepackage{geometry}
+\usepackage[margin=1in]{geometry}
 
 \usepackage{expl3}
 
@@ -24,10 +15,26 @@
 \input{macros/common}
 \input{macros/print}
 
-\title{Exchangeability and de Finetti's theorem}
+\title{Exchangeability and de Finetti's Theorem:\\A Lean 4 Formalization Blueprint}
 \author{Cameron Freer}
+\date{}
 
 \begin{document}
+
 \maketitle
+
+\begin{abstract}
+This document provides the mathematical blueprint for a Lean~4 formalization of
+the de Finetti--Ryll-Nardzewski theorem on standard Borel spaces.
+We describe the definitions, lemmas, and proof structure underlying three
+independent proofs of the core implication---via reverse martingales,
+$L^2$ bounds, and the mean ergodic theorem---all sharing a uniform common ending.
+The formalization comprises approximately 43,500 lines of Lean across 112 files.
+\end{abstract}
+
+{\small\tableofcontents}
+
+\bigskip
+
 \input{content}
 \end{document}

--- a/blueprint/src/print.tex
+++ b/blueprint/src/print.tex
@@ -8,6 +8,7 @@
 \usepackage{expl3}
 
 \usepackage{amssymb, amsthm, mathtools}
+\usepackage{booktabs}
 \usepackage[unicode,colorlinks=true,linkcolor=blue,urlcolor=magenta, citecolor=blue]{hyperref}
 
 \usepackage[warnings-off={mathtools-colon,mathtools-overbracket}]{unicode-math}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -1,0 +1,67 @@
+@article{deFinetti1931,
+  author  = {Bruno de Finetti},
+  title   = {Funzione caratteristica di un fenomeno aleatorio},
+  journal = {Atti della R.\ Accademia Nazionale dei Lincei, Memorie, Classe di Scienze Fisiche, Matematiche e Naturali},
+  volume  = {4},
+  pages   = {251--299},
+  year    = {1931}
+}
+
+@article{RyllNardzewski1957,
+  author  = {Czes{\l}aw Ryll-Nardzewski},
+  title   = {On stationary sequences of random variables and the de Finetti's equivalence},
+  journal = {Colloquium Mathematicum},
+  volume  = {4},
+  number  = {2},
+  pages   = {149--156},
+  year    = {1957},
+  doi     = {10.4064/cm-4-2-149-156}
+}
+
+@book{Kallenberg2005,
+  author    = {Olav Kallenberg},
+  title     = {Probabilistic Symmetries and Invariance Principles},
+  series    = {Probability and Its Applications},
+  publisher = {Springer},
+  year      = {2005},
+  doi       = {10.1007/0-387-28861-9}
+}
+
+@incollection{Aldous1985,
+  author    = {David J. Aldous},
+  title     = {Exchangeability and related topics},
+  booktitle = {Ecole d'Ete de Probabilites de Saint-Flour XIII --- 1983},
+  series    = {Lecture Notes in Mathematics},
+  volume    = {1117},
+  pages     = {1--198},
+  publisher = {Springer},
+  year      = {1985},
+  doi       = {10.1007/BFb0099421}
+}
+
+@article{HewittSavage1955,
+  author  = {Edwin Hewitt and Leonard J. Savage},
+  title   = {Symmetric measures on {C}artesian products},
+  journal = {Transactions of the American Mathematical Society},
+  volume  = {80},
+  number  = {2},
+  pages   = {470--501},
+  year    = {1955},
+  doi     = {10.1090/S0002-9947-1955-0076206-8}
+}
+
+@misc{mathlib,
+  author       = {{mathlib community}},
+  title        = {mathlib4: {T}he math library of {L}ean 4},
+  howpublished = {GitHub repository},
+  year         = {2024},
+  url          = {https://github.com/leanprover-community/mathlib4}
+}
+
+@misc{leanblueprint,
+  author       = {Patrick Massot},
+  title        = {leanblueprint: {A} tool for {L}ean formalization blueprints},
+  howpublished = {GitHub repository},
+  year         = {2024},
+  url          = {https://github.com/PatrickMassot/leanblueprint}
+}


### PR DESCRIPTION

## Summary

Substantive expansion of the blueprint document: switches the print build from `report` to `article` class with a tighter layout, adds narrative framing and notation conventions, adds proof sketches and a Beta-Bernoulli example, and adds a conclusion / future-work chapter. All changes are confined to `blueprint/`; no Lean code is touched.

## Commits (oldest first)

| Commit | Scope |
|---|---|
| `916053f9` — docs(blueprint): Switch to article class and restructure chapters | `print.tex`: report → article, tighter margins, compact title + abstract + ToC; chapter→section remap in `macros/print.tex` (print-only). Chapter renames: "Easy Directions" → "Elementary Implications", "Common Ending" → "Shared Final Step", "Main Theorem" → "The de Finetti–Ryll-Nardzewski Equivalence". |
| `b0e90ab0` — docs(blueprint): Add narrative, notation section, and references | Expanded Introduction; "Setting and conventions" paragraph; "Terminology" note (contractable vs spreadable); "Contributions" paragraph (43,500 lines, 112 files); transitions between theorem blocks; new `references.bib` (7 entries) wired into `print.tex`. |
| `bf3ebe73` — docs(blueprint): Add proof sketches, comparison table, and example | Route comparison table (key tool, extra assumptions, line count); Beta-Bernoulli urn example after core definitions; "Key idea" paragraphs for each of the three routes (martingale, L², Koopman); `booktabs` package for table formatting. |
| `0076e5b6` — docs(blueprint): Add conclusion, future work, and notation polish | New "Conclusion and Future Work" chapter (upstreaming, partial exchangeability, parametric families); notation consistency pass (L², en-dash, i.i.d.\ spacing); chapter→section restructuring resolves the prior page-6 orphan issue. |

## Files changed

- `blueprint/src/content.tex` — narrative additions, proof sketches, table, example, conclusion (the bulk of the diff)
- `blueprint/src/print.tex` — article-class switch, ToC/abstract/bibliography wiring, `booktabs`
- `blueprint/src/macros/print.tex` — chapter→section remap for print-only build
- `blueprint/src/references.bib` — new file, 7 bib entries

No Lean files touched; no impact on `lake build`, axioms, or sorries.

## Rebase note

This branch was originally cut from `aec253b6` (pre-bump base) and does not yet contain the v4.30.0-rc2 toolchain bump (PR #17). Since all changes are confined to `blueprint/src/` and the bump did not touch that subtree, a rebase onto current `main` should be conflict-free; alternatively merge resolves with no Lean-side concerns. Recommend rebase to keep history linear:

```bash
git fetch origin main
git rebase origin/main blueprint-docs
```

## Test plan

- [ ] `blueprint/src/` builds with `latexmk` / `leanblueprint` against current `main` after rebase.
- [ ] PDF (`blueprint/print/print.pdf`) renders with the new ToC, sections, and bibliography.
- [ ] Web build (`blueprint/web/`) still generates correctly.

