### PR TITLE
refactor: route Core.approxPerm through Equiv.Perm.exists_extending_pair (−31 lines)

### DIFF
--- a/Exchangeability/Core.lean
+++ b/Exchangeability/Core.lean
@@ -508,41 +508,17 @@ lemma lt_permBound_of_lt {i : ℕ} (hi : i < n) :
 lemma lt_permBound_fin {i : Fin n} :
     π i < permBound π n := lt_permBound_of_lt (π:=π) (n:=n) i.isLt
 
-/-- Equivalence between indices below n and indices in the image of a permutation.
-Used in the proof of exchangeability via permutation extension. -/
-def approxEquiv :
-    {x : Fin (permBound π n) // (x : ℕ) < n} ≃
-      {x : Fin (permBound π n) // ∃ j : Fin n, (x : ℕ) = π j} :=
-  by
-    classical
-    refine
-      { toFun := ?_, invFun := ?_, left_inv := ?_, right_inv := ?_ }
-    · intro x
-      have hx := x.property
-      let i : Fin n := ⟨x.1, hx⟩
-      have hi : (π i : ℕ) < permBound π n := lt_permBound_fin (π:=π) (n:=n) (i:=i)
-      refine ⟨⟨π i, hi⟩, ?_⟩
-      exact ⟨i, rfl⟩
-    · intro y
-      let j := Classical.choose y.property
-      have hj := Classical.choose_spec y.property
-      have hj_lt : (j : ℕ) < n := j.isLt
-      have hj_eq : π.symm y.1 = j := by
-        apply π.symm_apply_eq.2
-        exact hj
-      have hjm : (π.symm y.1 : ℕ) < permBound π n :=
-        lt_of_lt_of_le (by simp [hj_eq, hj_lt])
-          (le_permBound (π:=π) (n:=n))
-      refine ⟨⟨π.symm y.1, hjm⟩, ?_⟩
-      simp [hj_eq]
-    · intro x
-      ext
-      simp
-    · intro y
-      rcases y with ⟨y, hy⟩
-      rcases hy with ⟨j, hj⟩
-      ext
-      simp [hj]
+/-- Existence of a permutation of `Fin (permBound π n)` that agrees with `π` on
+`{0,...,n-1}`. The witness is extracted as `approxPerm` below via `Classical.choose`. -/
+private theorem exists_approxPerm :
+    ∃ σ : Equiv.Perm (Fin (permBound π n)), ∀ i : Fin n,
+      σ (Fin.castLE (le_permBound (π:=π) (n:=n)) i)
+        = ⟨π i, lt_permBound_fin (π:=π) (n:=n) (i:=i)⟩ :=
+  Equiv.Perm.exists_extending_pair
+    (f := Fin.castLE (le_permBound (π:=π) (n:=n)))
+    (g := fun i => ⟨π i, lt_permBound_fin (π:=π) (n:=n) (i:=i)⟩)
+    (Fin.castLE_injective _)
+    (fun _ _ hij => Fin.ext (π.injective (Fin.mk.inj hij)))
 
 /--
 A finite permutation of `Fin (permBound π n)` that agrees with `π` on `{0,...,n-1}`.
@@ -552,20 +528,13 @@ This extends the restriction of π to an equivalence on the finite type
 outside the range of π restricted to `{0,...,n-1}`.
 -/
 def approxPerm : Equiv.Perm (Fin (permBound π n)) :=
-  (approxEquiv (π:=π) (n:=n)).extendSubtype
+  Classical.choose (exists_approxPerm (π:=π) (n:=n))
 
 lemma approxPerm_apply_cast {i : Fin n} :
     approxPerm (π:=π) (n:=n)
         (Fin.castLE (le_permBound (π:=π) (n:=n)) i)
-      = ⟨π i, lt_permBound_fin (π:=π) (n:=n) (i:=i)⟩ := by
-  classical
-  have hmem : ((Fin.castLE (le_permBound (π:=π) (n:=n)) i) : ℕ) < n :=
-    i.2
-  have := Equiv.extendSubtype_apply_of_mem
-      (e:=approxEquiv (π:=π) (n:=n))
-      (x:=Fin.castLE (le_permBound (π:=π) (n:=n)) i)
-      hmem
-  simpa using this
+      = ⟨π i, lt_permBound_fin (π:=π) (n:=n) (i:=i)⟩ :=
+  Classical.choose_spec (exists_approxPerm (π:=π) (n:=n)) i
 
 @[simp]
 lemma approxPerm_apply_cast_coe {i : Fin n} :


### PR DESCRIPTION
## Summary

Second in the post-bump series of targeted mathlib-refactor PRs (after #18). Routes `Core.approxPerm` through the same `Equiv.Perm.exists_extending_pair` API (mathlib #34599) that PR #18 used for `exists_perm_extending_strictMono`.

**Net diff:** 1 file, +14 / −45 (**−31 lines**) in `Exchangeability/Core.lean`.

## Why this PR is focused on Core.approxPerm only

`Core.approxPerm` (line 547) and its supporting `approxEquiv` (line 511) used the exact same pattern that PR #18 already removed from `Contractability.lean`: hand-built subtype equivalence + `Equiv.extendSubtype` + `extendSubtype_apply_of_mem`. The `Equiv.Perm.exists_extending_pair` mathlib API collapses this directly.

Per agreed scope, the `Fin.castLE` consistency cleanup is deferred to a tiny separate PR; this one is just the `approxPerm` rewrite.

## What changed

- **Added** `private theorem exists_approxPerm` packaging the existence witness via `Equiv.Perm.exists_extending_pair` with:
  - `f := Fin.castLE (le_permBound (π:=π) (n:=n))` (initial-segment inclusion)
  - `g := fun i => ⟨π i, lt_permBound_fin (π:=π) (n:=n) (i:=i)⟩` (π-image inclusion)
  - `hf := Fin.castLE_injective _`
  - `hg := fun _ _ hij => Fin.ext (π.injective (Fin.mk.inj hij))` (lifts ℕ-injectivity of `π` to `Fin n`-injectivity of `g` via `Fin.ext`)
- **`approxPerm`** body becomes `Classical.choose (exists_approxPerm (π:=π) (n:=n))`.
- **`approxPerm_apply_cast`** body becomes `Classical.choose_spec (exists_approxPerm (π:=π) (n:=n)) i`.
- **Removed** unused local helper `approxEquiv` (the only caller was `approxPerm` itself, now gone).
- **`approxPerm_apply_cast_coe`** unchanged (it's a coercion wrapper around `approxPerm_apply_cast`).

`approxPerm`, `approxPerm_apply_cast`, and `approxPerm_apply_cast_coe` keep their signatures, so the downstream caller `marginals_perm_eq` (line 593+) is unaffected. The `noncomputable section` opened at line 52 already covers the new `Classical.choose` usage, so no explicit `noncomputable` keyword is needed.

`approxEquiv` was a public `def` with no in-repo callers; removing it is a public-API deletion in the narrow sense. Calling it out explicitly: **removes unused local helper `approxEquiv`; keeps `approxPerm` and apply lemmas unchanged.**

## Axiom footprint

Identical. `Equiv.extendSubtype` already pulled in `Classical.choice`; switching to `Classical.choose` of an `exists_extending_pair`-based proof uses the same axiom.

## Verification

| Check | Baseline (main = bd32ed2e) | This branch |
|---|---|---|
| `lake build` | clean (3531 jobs) | clean (3531 jobs) |
| Axioms (11 theorem decls) | standard only | standard only |
| Sorries (`Exchangeability` + `ForMathlib`) | 0 | 0 |
| Proof-file churn | — | 1 file, +14 / −45 |

## Out of scope (planned next tiny PR)

`Fin.castLE` consistency cleanup at two sites that don't touch lemma statements:

- `Exchangeability/Contractability.lean:470` (call site of `exists_perm_extending_strictMono`)
- `Exchangeability/Util/FinsetHelpers.lean:32`

(`Contractability.lean:408` is inside a lemma statement via a `let`, so a `Fin.castLE` substitution there would be statement-level cleanup, not proof-body-only. Deferred unless statement-level cleanup is explicitly in scope.)