### PR TITLE
chore: Fin.castLE consistency + README version drift fix

### DIFF
--- a/Exchangeability/Contractability.lean
+++ b/Exchangeability/Contractability.lean
@@ -467,7 +467,7 @@ theorem contractable_of_exchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
     have hexch := hX n σ
 
     -- Define embedding and projection
-    let ι : Fin (m' + 1) → Fin n := fun i => ⟨i.val, Nat.lt_of_lt_of_le i.isLt hmn⟩
+    let ι : Fin (m' + 1) → Fin n := Fin.castLE hmn
     let proj : (Fin n → α) → (Fin (m' + 1) → α) := fun f i => f (ι i)
 
     have hproj_meas : Measurable proj := by

--- a/Exchangeability/Util/FinsetHelpers.lean
+++ b/Exchangeability/Util/FinsetHelpers.lean
@@ -29,11 +29,9 @@ The proof uses an explicit bijection between `Fin n` and the filtered set. -/
 lemma filter_val_lt_card {m n : ℕ} (h : m ≥ n) :
     (Finset.filter (fun i : Fin m => i.val < n) Finset.univ).card = n := by
   -- Establish bijection with Fin n via the natural inclusion
-  let f : Fin n → Fin m := fun i => ⟨i.val, Nat.lt_of_lt_of_le i.isLt h⟩
+  let f : Fin n → Fin m := Fin.castLE h
 
-  have hf_inj : Function.Injective f := by
-    intros i j hij
-    exact Fin.ext (Fin.mk.injEq _ _ _ _ ▸ hij)
+  have hf_inj : Function.Injective f := Fin.castLE_injective h
 
   have h_image : Finset.filter (fun i : Fin m => i.val < n) Finset.univ =
                  Finset.image f Finset.univ := by
@@ -41,13 +39,9 @@ lemma filter_val_lt_card {m n : ℕ} (h : m ≥ n) :
     simp only [mem_filter, mem_univ, true_and, mem_image]
     constructor
     · intro hi_lt
-      refine ⟨⟨i.val, hi_lt⟩, ?_⟩
-      simp only [f]
-    · intro ⟨j, hj_eq⟩
-      simp only [f] at hj_eq
-      calc i.val = (⟨j.val, _⟩ : Fin m).val := by rw [← hj_eq]
-        _ = j.val := rfl
-        _ < n := j.isLt
+      exact ⟨⟨i.val, hi_lt⟩, Fin.ext rfl⟩
+    · rintro ⟨j, rfl⟩
+      exact j.isLt
 
   rw [h_image, card_image_of_injective _ hf_inj]
   simp only [card_univ, Fintype.card_fin]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ We implement **all three proofs** from Kallenberg (2005) of the key implication 
 
 ### Prerequisites
 
-- [Lean 4](https://leanprover.github.io/lean4/doc/setup.html) (this project uses `lean-toolchain` pinned to 4.27.0-rc1)
+- [Lean 4](https://leanprover.github.io/lean4/doc/setup.html) (see `lean-toolchain` for the pinned version)
 - [elan](https://github.com/leanprover/elan) (Lean version manager)
 
 ### Installation


### PR DESCRIPTION
## Summary

Small batched cleanup PR with two unrelated-but-trivial items:

1. **`Fin.castLE` consistency** — two open-coded `fun i => ⟨i.val, Nat.lt_of_lt_of_le i.isLt h⟩` inclusions are replaced with the mathlib spelling `Fin.castLE h`. The codebase already uses `Fin.castLE` in many places (`Core.lean`, the recently refactored `Contractability.exists_perm_extending_strictMono` from #18, and the new `Core.exists_approxPerm` from #20); these two sites had been missed.
2. **README version drift fix** — `README.md:51` still claimed `lean-toolchain` was pinned to `4.27.0-rc1`; the v4.30.0-rc2 bump (#17) missed updating it. Rather than re-pin (and re-drift on the next bump), point at the file itself.

**Net diff:** 3 files, +7 / −13 (**−6 lines**).

## What changed

### Lean (proof-body-only, statements unchanged)

| File | Site | Change |
|---|---|---|
| `Exchangeability/Contractability.lean:470` | `contractable_of_exchangeable` call site | `let ι := fun i => ⟨i.val, Nat.lt_of_lt_of_le i.isLt hmn⟩` → `let ι := Fin.castLE hmn`. Existing `simpa [ι]` and `simp [..., ι]` calls work unchanged (still unfold the let). |
| `Exchangeability/Util/FinsetHelpers.lean:32` | `filter_val_lt_card` | Same `let` substitution. Inline `hf_inj` collapses from a 3-line proof to `Fin.castLE_injective h`. The `Finset.image` ext-step's `simp only [f]` is replaced by direct `Fin.ext rfl` / `rintro ⟨j, rfl⟩`. |

`Contractability.lean:408` was deliberately left alone — that `let` is inside a lemma statement (not the proof body), and per agreed scope this PR is proof-body-only churn. A statement-level cleanup pass can address it later if desired.

### Docs

| File | Before | After |
|---|---|---|
| `README.md:51` | `(this project uses lean-toolchain pinned to 4.27.0-rc1)` | `(see lean-toolchain for the pinned version)` |

This makes the README impervious to future bump drift.

## Verification

| Check | Baseline (main = 18bf7ab7) | This branch |
|---|---|---|
| `lake build` | clean (3531 jobs) | clean (3531 jobs) |
| Axioms (11 theorem decls) | standard only | standard only |
| Sorries (`Exchangeability` + `ForMathlib`) | 0 | 0 |
| Proof-file churn | — | 2 files, +5 / −12 |
| Docs churn | — | 1 file, +1 / −1 |

## Notes for review

- Statement-level `Fin.castLE` cleanup at `Contractability.lean:408` is out of scope; it's inside a lemma statement.
- This concludes the targeted permutation-extension follow-up sequence (#18 → #20 → this). The next item in the broader follow-up menu is `Kernel.IndepFun.comp` and other PR #16 safe-subset replacements.