### PR TITLE
refactor: delete dead local Kernel.IndepFun.comp duplicate (−41 lines)

### DIFF
--- a/Exchangeability/DeFinetti/ViaKoopman/KernelBridge.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/KernelBridge.lean
@@ -14,7 +14,6 @@ This file contains bridge lemmas connecting kernel-level and measure-level indep
 ## Main results
 
 - `Kernel.IndepFun.ae_measure_indepFun`: Kernel independence implies measure-level integral factorization
-- `Kernel.IndepFun.comp`: Independence is preserved under composition with measurable functions
 - `metProjection_eq_condExpL2_shiftInvariant`: MET projection equals conditional expectation
 
 **Split from**: KernelIndependence.lean (lines 1-280)
@@ -177,46 +176,6 @@ lemma Kernel.IndepFun.ae_measure_indepFun
   haveI : IsProbabilityMeasure (κ a) := IsMarkovKernel.isProbabilityMeasure a
   exact h_indep.integral_fun_mul_eq_mul_integral
     hX.aestronglyMeasurable hY.aestronglyMeasurable
-
-/-- **Composition lemma**: Independence is preserved under composition with measurable functions.
-
-If X and Y are kernel-independent, then f ∘ X and g ∘ Y are also kernel-independent
-for any measurable functions f and g.
-
-**Proof strategy**:
-- Kernel.IndepFun X Y κ μ means Kernel.Indep (comap X) (comap Y) κ μ
-- For measurable f, comap (f ∘ X) ⊆ comap X (preimages under f∘X are preimages under X)
-- Independence of larger σ-algebras implies independence of sub-σ-algebras
--/
-lemma Kernel.IndepFun.comp
-    {α Ω β γ : Type*} [MeasurableSpace α] [MeasurableSpace Ω]
-    [MeasurableSpace β] [MeasurableSpace γ]
-    {κ : Kernel α Ω} {μ : Measure α}
-    {X : Ω → β} {Y : Ω → γ}
-    (hXY : Kernel.IndepFun X Y κ μ)
-    {f : β → ℝ} {g : γ → ℝ}
-    (hf : Measurable f) (hg : Measurable g) :
-    Kernel.IndepFun (f ∘ X) (g ∘ Y) κ μ := by
-  -- The key insight: Kernel.IndepFun is defined as independence of the comap σ-algebras
-  -- For sets s, t in the target σ-algebras, we need to show:
-  -- ∀ s ∈ σ(f∘X), ∀ t ∈ σ(g∘Y), ∀ᵐ a, κ a (s ∩ t) = κ a s * κ a t
-
-  intro s t hs ht
-  -- s is measurable w.r.t. comap (f ∘ X), so s = (f ∘ X)⁻¹(S) for some measurable S ⊆ ℝ
-  -- This means s = X⁻¹(f⁻¹(S)), so s is in comap X
-  -- Similarly t is in comap Y
-
-  -- We need to show s ∈ comap X and t ∈ comap Y
-  -- Key fact: if s is measurable w.r.t. comap (f ∘ X), then s is measurable w.r.t. comap X
-  -- because comap (f ∘ X) ≤ comap X
-
-  have hs' : MeasurableSet[MeasurableSpace.comap X inferInstance] s :=
-    comap_comp_le X f hf s hs
-
-  have ht' : MeasurableSet[MeasurableSpace.comap Y inferInstance] t :=
-    comap_comp_le Y g hg t ht
-
-  exact hXY s t hs' ht'
 
 /-- **Bridge lemma**: The Mean Ergodic Theorem projection equals conditional expectation
 onto the shift-invariant σ-algebra.


### PR DESCRIPTION
## Summary

`KernelBridge.lean` defined a local `Kernel.IndepFun.comp` lemma that duplicates mathlib's `ProbabilityTheory.Kernel.IndepFun.comp` (specialized to ℝ-valued composition targets). It has **zero callers** in the codebase. Delete it.

**Net diff:** 1 file, +0 / −41 (**−41 lines, pure deletion**).

## Why this is a deletion, not a wrapper

The PR #16 autoGolf draft proposed making the local lemma a thin wrapper around `ProbabilityTheory.Kernel.IndepFun.comp`. But the wrapper has no callers: I grep'd for all `Kernel.IndepFun.comp` usages and all `.comp` dot-notation calls on `Kernel.IndepFun` / `IndepFun` instances:

- `Probability/CondIndep/Indicator.lean:135, 144, 150, 179` — these use `_indep.comp` on plain `IndepFun` (measure-based), so dot notation resolves to mathlib's `ProbabilityTheory.IndepFun.comp` (different lemma, different namespace).
- `Probability/CondIndep/Basic.lean:161, 168` — same.
- `KernelBridge.lean:17` — module docstring bullet (advertising the lemma).
- `DeFinetti/ProofPlan.lean:50` — historical planning note ("already proved").

No code actually calls `Kernel.IndepFun.comp` (the kernel-based one). Replacing the body with a wrapper would leave dead code; deleting is the right move.

## What changed

`Exchangeability/DeFinetti/ViaKoopman/KernelBridge.lean`:
- Delete the 30-line proof + 10-line docstring of `Kernel.IndepFun.comp` (lines 181–219).
- Update the module-level docstring "Main results" bullet list to remove the entry advertising the now-deleted lemma. (This is the same kind of "docstring becomes explicitly false" situation we fixed in #18; making the file's claimed API match its actual exports.)

The `DeFinetti/ProofPlan.lean:50` historical note is left alone — it's a session-archaeology document, not user-facing.

If a future `Kernel.IndepFun` term needs `.comp`, dot notation will resolve to mathlib's `ProbabilityTheory.Kernel.IndepFun.comp` via the existing imports, with a strictly more general signature (target type need not be ℝ).

## Verification

| Check | Baseline (main = 1ded130f) | This branch |
|---|---|---|
| `lake build` | clean (3531 jobs) | clean (3531 jobs) |
| Axioms (11 theorem decls) | standard only | standard only |
| Sorries (`Exchangeability` + `ForMathlib`) | 0 | 0 |
| Proof-file churn | — | 1 file, +0 / −41 |

## Notes

- This is part of the post-bump cleanup series mining PR #16's safe-subset suggestions. Going stronger than #16's wrapper version because the wrapper has no purpose.