### PR TITLE
chore: condExp_of_stronglyMeasurable cleanups (stale comments + 2 sites) (−25 lines)

### DIFF
--- a/Exchangeability/DeFinetti/ViaKoopman/InfraCore.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/InfraCore.lean
@@ -552,12 +552,11 @@ lemma aemeasurable_indicator_of_sub {Ω} [mΩ : MeasurableSpace Ω] {μ : Measur
 
 /-- Idempotence of conditional expectation for m-measurable integrable functions.
 
-**Note**: Mathlib API candidates for this standard result:
-- `condExp_of_stronglyMeasurable` (needs StronglyMeasurable, not AEStronglyMeasurable)
-- Some version of `condexp_of_aestronglyMeasurable` (not found in current snapshot)
-- Direct proof via uniqueness characterization
-
-The statement is correct and will be used in rectangle-case proofs. -/
+Wraps mathlib's `condExp_of_aestronglyMeasurable'`. We keep the local name because the
+helper takes the weaker `AEStronglyMeasurable[m] f μ` rather than the
+`StronglyMeasurable[m] f` required by `condExp_of_stronglyMeasurable` (which gives
+*pointwise* equality rather than the a.e. equality stated here). Callers in
+rectangle-case proofs typically have only the AE version. -/
 lemma condExp_idempotent'
     {Ω} [mΩ : MeasurableSpace Ω] {μ : Measure Ω}
     (m : MeasurableSpace Ω) (hm : m ≤ mΩ)

--- a/Exchangeability/Probability/CondExpExtras.lean
+++ b/Exchangeability/Probability/CondExpExtras.lean
@@ -1439,12 +1439,10 @@ theorem condExp_project_of_condIndepFun
           =ᵐ[μ]
         (fun ω => μ[ f_n (ns n) ∘ Y | mW ] ω * μ[ (Z ⁻¹' B).indicator 1 | mW ] ω) := by
       intro n
-      -- The product of two condExps is mW-measurable
-      apply condExp_of_aestronglyMeasurable' hmW_le
-      · -- Product of two mW-strongly measurable functions is mW-strongly measurable
-        exact (stronglyMeasurable_condExp.mul stronglyMeasurable_condExp).aestronglyMeasurable
-      · -- Integrability of the product
-        exact h_gs_subseq_int n
+      -- Product of two condExps is StronglyMeasurable[mW], so condExp gives exact equality
+      -- (`condExp_of_stronglyMeasurable`); convert to a.e. equality via `.of_eq`.
+      exact .of_eq (condExp_of_stronglyMeasurable hmW_le
+        (stronglyMeasurable_condExp.mul stronglyMeasurable_condExp) (h_gs_subseq_int n))
 
     -- Now convert h_factorization_subseq using h_gs_is_mW_measurable
     have h_factorization_as_condExps : ∀ n,
@@ -1477,9 +1475,8 @@ theorem condExp_project_of_condIndepFun
         μ[ (fun ω => μ[ f ∘ Y | mW ] ω * μ[ (Z ⁻¹' B).indicator 1 | mW ] ω) | mW ]
           =ᵐ[μ]
         (fun ω => μ[ f ∘ Y | mW ] ω * μ[ (Z ⁻¹' B).indicator 1 | mW ] ω) := by
-      apply condExp_of_aestronglyMeasurable' hmW_le
-      · exact (stronglyMeasurable_condExp.mul stronglyMeasurable_condExp).aestronglyMeasurable
-      · exact h_g_int
+      exact .of_eq (condExp_of_stronglyMeasurable hmW_le
+        (stronglyMeasurable_condExp.mul stronglyMeasurable_condExp) h_g_int)
 
     -- Combine to get the desired result
     exact h_condExps_equal.trans h_g_is_mW_measurable

--- a/Exchangeability/Probability/CondIndep/Basic.lean
+++ b/Exchangeability/Probability/CondIndep/Basic.lean
@@ -116,27 +116,6 @@ then E[X | σ(W)] = E[X] almost everywhere.
 This is the key property that makes independence "pass through" conditioning:
 knowing W provides no information about X when X ⊥ W.
 -/
-/-
-Note: Idempotence helper pending identification of correct mathlib lemma name.
-
-/-- Idempotence of conditional expectation on the target sub-σ-algebra.
-If f is m-measurable, then E[f|m] = f almost everywhere.
-This avoids hunting for the correct lemma name across mathlib versions. -/
-lemma condExp_idem'
-    (μ : Measure Ω) (m : MeasurableSpace Ω) (f : Ω → ℝ)
-    (hm : m ≤ _)
-    (hf_int : Integrable f μ)
-    (hf_sm : StronglyMeasurable[m] f) :
-    μ[f | m] =ᵐ[μ] f := by
-  -- Try the most common name first:
-  simpa using
-    (condexp_of_stronglyMeasurable  -- This name doesn't exist in current mathlib
-      (μ := μ) (m := m) (hm := hm) (hfmeas := hf_sm) (hfint := hf_int))
-  -- If this fails in your build, replace the line above with either:
-  -- (1) `condexp_of_aestronglyMeasurable'` (with `aestronglyMeasurable_of_stronglyMeasurable`)
-  -- (2) `condexp_condexp` specialized to `m₁ = m₂ := m`
--/
-
 @[nolint unusedArguments]
 lemma condExp_const_of_indepFun (μ : Measure Ω) [IsProbabilityMeasure μ]
     {X : Ω → ℝ} {W : Ω → γ}


### PR DESCRIPTION
## Summary

Three small follow-ups now that mathlib's `condExp_of_stronglyMeasurable` — exact equality `μ[f | m] = f` for `StronglyMeasurable[m] f` — is known to be the right reference for this pattern. Mostly stale-comment cleanup plus two proof-body simplifications.

**Net diff:** 3 files, +11 / −36 (**−25 lines**).

## What changed

### 1. Delete obsolete blocked comment — `Probability/CondIndep/Basic.lean:119-138`

A 20-line `condExp_idem'` commented-out block sat above `condExp_const_of_indepFun` with header `Note: Idempotence helper pending identification of correct mathlib lemma name`. The lemma exists now (`condExp_of_stronglyMeasurable`); the block is dead text and the contained code references a non-existent `condexp_of_stronglyMeasurable` (lowercase `e`). Removed.

### 2. Fix self-contradicting comment — `DeFinetti/ViaKoopman/InfraCore.lean:553-560`

The docstring on `condExp_idempotent'` claimed `condexp_of_aestronglyMeasurable` was "not found in current snapshot" while the body on the very next line was `MeasureTheory.condExp_of_aestronglyMeasurable' hm hf_m hf_int`. Rewrite the note to say truthfully:
- this wraps `condExp_of_aestronglyMeasurable'`;
- kept as a local helper because callers have only AE-strongly-measurable;
- `condExp_of_stronglyMeasurable` gives the pointwise equality version instead.

### 3. Simplify two proof bodies — `Probability/CondExpExtras.lean:1443, 1480`

Each call had this shape:

```lean
apply condExp_of_aestronglyMeasurable' hmW_le
· exact (stronglyMeasurable_condExp.mul stronglyMeasurable_condExp).aestronglyMeasurable
· exact <integrability>
```

This builds a `StronglyMeasurable[mW]` term and immediately downgrades to `AEStronglyMeasurable`. Use `condExp_of_stronglyMeasurable` directly (yielding `=`) and `.of_eq` (i.e. `Filter.EventuallyEq.of_eq`) to convert to `=ᵐ[μ]`:

```lean
exact .of_eq (condExp_of_stronglyMeasurable hmW_le
  (stronglyMeasurable_condExp.mul stronglyMeasurable_condExp) <integrability>)
```

Three lines per site → two.

## Out of scope

Tower-property uses (`condExp_condExp_of_le`) are genuinely tower arguments rather than idempotence; left alone.

## Verification

| Check | Baseline (main = 2b405ca4) | This branch |
|---|---|---|
| `lake build` | clean (3528 jobs) | clean (3528 jobs) |
| Axioms (11 theorem decls) | standard only | standard only |
| Sorries (`Exchangeability`) | 0 | 0 |
| Proof-file churn | — | 3 files, +11 / −36 |

No statement changes; only proof bodies, comments, and one docstring's technical note.