### PR TITLE
chore: clear all 4.30 deprecation warnings (push_neg, deprecated names + import)

### DIFF
--- a/Exchangeability/DeFinetti/BridgeProperty.lean
+++ b/Exchangeability/DeFinetti/BridgeProperty.lean
@@ -114,7 +114,7 @@ lemma measure_eq_implies_lintegral_prod_eq
       simp only [hprod, Pi.one_apply]
     · -- ω is not in some preimage, so at least one factor is 0
       rw [indicator_of_notMem h]
-      rw [hpre_mem] at h; push_neg at h
+      rw [hpre_mem] at h; push Not at h
       obtain ⟨i, hi⟩ := h
       rw [Finset.prod_eq_zero (i := i) (hi := Finset.mem_univ i)]
       simp only [indicator_of_notMem hi, ENNReal.ofReal_zero]

--- a/Exchangeability/DeFinetti/CommonEnding.lean
+++ b/Exchangeability/DeFinetti/CommonEnding.lean
@@ -168,7 +168,7 @@ lemma prod_eq_zero_iff {ι : Type*} [Fintype ι] {f : ι → ENNReal} :
   constructor
   · intro h
     by_contra h_all_nonzero
-    push_neg at h_all_nonzero
+    push Not at h_all_nonzero
     have : ∀ i, f i ≠ 0 := h_all_nonzero
     have prod_ne_zero : ∏ i, f i ≠ 0 := Finset.prod_ne_zero_iff.mpr fun i _ => this i
     exact prod_ne_zero h

--- a/Exchangeability/DeFinetti/ViaKoopman/CesaroL2ToL1.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/CesaroL2ToL1.lean
@@ -281,7 +281,7 @@ lemma optionB_Step4b_AB_close
     -- B n ω = (1/n) * ∑_{k=0}^{n-1} g(ω k)
     -- Write ∑_{k=0}^n = ∑_{k=0}^{n-1} + g(ω n)
     rw [show Finset.range (n + 1) = Finset.range n ∪ {n} by
-          ext k; simp [Finset.mem_range, Nat.lt_succ]; omega,
+          ext k; simp [Finset.mem_range]; omega,
         Finset.sum_union (by simp : Disjoint (Finset.range n) {n}),
         Finset.sum_singleton]
     -- Now A n ω = (1/(n+1)) * (∑_{k<n} g(ω k) + g(ω n))

--- a/Exchangeability/DeFinetti/ViaKoopman/InfraCore.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/InfraCore.lean
@@ -9,7 +9,7 @@ import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
 import Mathlib.MeasureTheory.Function.SimpleFuncDense
 import Mathlib.Analysis.InnerProductSpace.Projection.Basic
 import Mathlib.Probability.Kernel.Condexp
-import Mathlib.Probability.Independence.Kernel
+import Mathlib.Probability.Independence.Kernel.IndepFun
 import Exchangeability.Ergodic.KoopmanMeanErgodic
 import Exchangeability.Ergodic.InvariantSigma
 import Exchangeability.Ergodic.ProjectionLemmas

--- a/Exchangeability/DeFinetti/ViaL2/AlphaConvergence.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaConvergence.lean
@@ -148,7 +148,7 @@ lemma alphaIic_ae_eq_alphaIicCE
             _ ≤ alpha ω - A n m ω := by linarith
             _ ≤ |A n m ω - alpha ω| := by rw [abs_sub_comm]; exact le_abs_self _
         · -- alpha ∈ [0,1], so clipping does nothing
-          push_neg at halpha halpha1
+          push Not at halpha halpha1
           rw [min_comm, min_eq_left halpha1, max_eq_right halpha]
 
     -- Prove integrability of A n m
@@ -202,7 +202,7 @@ lemma alphaIic_ae_eq_alphaIicCE
               norm_num
             · by_cases h1 : 1 ≤ alpha ω
               · rw [min_eq_left h1, max_eq_right (by linarith : 0 ≤ (1:ℝ)), abs_of_nonneg (by linarith : 0 ≤ (1:ℝ))]
-              · push_neg at h h1
+              · push Not at h h1
                 rw [min_eq_right (le_of_lt h1), max_eq_right (le_of_lt h)]
                 exact abs_of_pos h |>.trans_le (le_of_lt h1)
           · exact (hA_int.sub halpha_int).abs

--- a/Exchangeability/DeFinetti/ViaL2/AlphaIicCE.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaIicCE.lean
@@ -332,7 +332,7 @@ lemma alphaIicCE_right_continuous_at
       simp only [h_ev, ↓reduceIte, hxt]
       exact tendsto_const_nhds
     · -- X 0 ω > t, so eventually X 0 ω > u_n (since u_n → t)
-      push_neg at hxt
+      push Not at hxt
       simp only [Set.indicator_apply, Set.mem_Iic, not_le.mpr hxt, ↓reduceIte]
       -- u_n → t and X 0 ω > t, so eventually u_n < X 0 ω
       have h_ev : ∀ᶠ n in Filter.atTop, (u n : ℝ) < X 0 ω := by

--- a/Exchangeability/DeFinetti/ViaL2/BlockAverages.lean
+++ b/Exchangeability/DeFinetti/ViaL2/BlockAverages.lean
@@ -207,7 +207,7 @@ lemma contractable_covariance_structure
         rw [hρ_def]
         field_simp [ne_of_gt hσSq_pos]
       · -- Case j < i: use symmetry
-        push_neg at h_ord
+        push Not at h_ord
         have h_ji : j < i := Nat.lt_of_le_of_ne h_ord (Ne.symm hij)
         have h_eq_dist := contractable_map_pair (X := X) hX_contract hX_meas h_ji
         have h_int_ji : ∫ ω, (X j ω - m) * (X i ω - m) ∂μ
@@ -337,7 +337,7 @@ lemma contractable_covariance_structure
     exact ⟨m, σSq, ρ, hmean, hvar, hcov, hσSq_nonneg, hρ_bd⟩
 
   · -- Case: zero variance (all X_i are constant a.s.)
-    push_neg at hσSq_pos
+    push Not at hσSq_pos
     have hσSq_zero : σSq = 0 := le_antisymm hσSq_pos hσSq_nonneg
 
     -- When variance is 0, all X_i = m almost surely

--- a/Exchangeability/DeFinetti/ViaL2/CesaroConvergence.lean
+++ b/Exchangeability/DeFinetti/ViaL2/CesaroConvergence.lean
@@ -1221,7 +1221,7 @@ private lemma cesaro_cauchy_rho_lt
         rw [abs_sub_comm, abs_of_nonneg (sub_nonneg_of_le h), max_eq_right h]
         exact sub_le_self _ (inv_nonneg.mpr (Nat.cast_nonneg n))
       · -- Case: n⁻¹ > n'⁻¹, so max = n⁻¹
-        push_neg at h
+        push Not at h
         rw [abs_of_nonneg (sub_nonneg_of_le (le_of_lt h)), max_eq_left (le_of_lt h)]
         exact sub_le_self _ (inv_nonneg.mpr (Nat.cast_nonneg n'))
     · -- Case 2: i.val < n ∧ i.val ≥ n'
@@ -1733,7 +1733,7 @@ private lemma blockAvg_cauchy_in_L2
       exact hε
 
   · -- Degenerate case: σSq = 0 → Z is constant a.e. → blockAvg constant a.e.
-    push_neg at hσ_pos
+    push Not at hσ_pos
     have hσSq_zero : σSq = 0 := by
       have hσSq_nonneg : 0 ≤ σSq := by
         simp only [σSq]
@@ -2058,7 +2058,7 @@ private lemma blockAvg_shift_tendsto
               exact Finset.sum_le_sum (fun k _ => hf_bdd (X (0 + k) ω))
           _ = (n : ℝ)⁻¹ * n := by simp
           _ = 1 := by field_simp [Nat.pos_iff_ne_zero.mp hn]
-    · push_neg at hn
+    · push Not at hn
       have : n = 0 := Nat.eq_zero_of_le_zero hn
       subst this
       have h_eq : blockAvg f X 0 0 = fun _ => 0 := by ext ω; simp [blockAvg]

--- a/Exchangeability/DeFinetti/ViaL2/DirectingMeasureCore.lean
+++ b/Exchangeability/DeFinetti/ViaL2/DirectingMeasureCore.lean
@@ -130,7 +130,7 @@ lemma cdf_from_alpha_bounds
     -- Then eventually f(s) ∈ (-ε, ε), so f(s) > -ε = f(t)/2.
     -- But also f(s) ≤ f(t) for s ≤ t, contradicting f(s) > f(t)/2 > f(t).
     by_contra h_neg
-    push_neg at h_neg
+    push Not at h_neg
     -- f(t) < 0, so ε := -f(t)/2 > 0
     set ε := -cdf_from_alpha X hX_contract hX_meas hX_L2 ω t / 2 with hε_def
     have hε_pos : 0 < ε := by simp [hε_def]; linarith
@@ -163,7 +163,7 @@ lemma cdf_from_alpha_bounds
     -- Similar argument: for any s > t, f(t) ≤ f(s) by monotonicity.
     -- As s → +∞, f(s) → 1, so f(t) ≤ 1.
     by_contra h_gt
-    push_neg at h_gt
+    push Not at h_gt
     -- f(t) > 1, so ε := (f(t) - 1)/2 > 0
     set ε := (cdf_from_alpha X hX_contract hX_meas hX_L2 ω t - 1) / 2 with hε_def
     have hε_pos : 0 < ε := by simp [hε_def]; linarith

--- a/Exchangeability/DeFinetti/ViaL2/DirectingMeasureIntegral.lean
+++ b/Exchangeability/DeFinetti/ViaL2/DirectingMeasureIntegral.lean
@@ -197,7 +197,7 @@ lemma directing_measure_integral_Iic_ae_eq_alphaIicCE
       intro b hb
       -- b ≥ alphaIicRat n for all n, so b ≥ lim alphaIicRat n = 1
       by_contra h_not
-      push_neg at h_not
+      push Not at h_not
       have hε : 1 - b > 0 := by linarith
       -- Since alphaIicRat n → 1, for large n we have alphaIicRat n > b
       have h_nat : Tendsto (fun n : ℕ => alphaIicRat X hX_contract hX_meas hX_L2 ω (n : ℚ))
@@ -235,7 +235,7 @@ lemma directing_measure_integral_Iic_ae_eq_alphaIicCE
     · -- 0 is the greatest lower bound
       intro b hb
       by_contra h_not
-      push_neg at h_not
+      push Not at h_not
       have hε : b > 0 := h_not
       -- Since alphaIicRat (-n) → 0, for large n we have alphaIicRat (-n) < b
       have h_nat : Tendsto (fun n : ℕ => alphaIicRat X hX_contract hX_meas hX_L2 ω (-(n : ℚ)))
@@ -460,7 +460,7 @@ lemma integral_indicator_borel_tailAEStronglyMeasurable
           · simp [Set.indicator_of_mem hx, Set.indicator_of_notMem (Set.notMem_compl_iff.mpr hx)]
           · simp [Set.indicator_of_notMem hx, Set.indicator_of_mem (Set.mem_compl hx)]
         simp_rw [h_ind_compl]
-        rw [integral_sub (integrable_const 1), integral_const, measureReal_univ_eq_one, one_smul]
+        rw [integral_sub (integrable_const 1), integral_const, probReal_univ, one_smul]
         exact (integrable_const 1).indicator ht_meas
       simp_rw [h_eq]
       exact aestronglyMeasurable_const.sub ht_aesm
@@ -595,13 +595,13 @@ lemma integral_indicator_borel_tailAEStronglyMeasurable
                         rw [Set.indicator_of_notMem]
                         exact Set.disjoint_left.mp hdisj_mn hxm
                       · intro hm_not; exact absurd hm_mem hm_not
-                    · push_neg at hx
+                    · push Not at hx
                       have h_zero : ∀ n ∈ Finset.range N, (f n).indicator (fun _ => (1:ℝ)) x = 0 :=
                         fun n hn => Set.indicator_of_notMem (hx n hn) _
                       rw [Finset.sum_eq_zero h_zero]
                       exact zero_le_one
                   exact this
-            _ = 1 := by simp [measureReal_univ_eq_one]
+            _ = 1 := by simp [probReal_univ]
         have h_summable : Summable (fun n => ∫ x, (f n).indicator (fun _ => (1:ℝ)) x
             ∂(directing_measure X hX_contract hX_meas hX_L2 ω)) :=
           summable_of_sum_range_le h_nonneg h_partial_le
@@ -1003,7 +1003,7 @@ lemma setIntegral_directing_measure_indicator_eq
             · simp [Set.indicator_of_mem hx, Set.indicator_of_notMem (Set.notMem_compl_iff.mpr hx)]
             · simp [Set.indicator_of_notMem hx, Set.indicator_of_mem (Set.mem_compl hx)]
           simp_rw [h_ind_compl]
-          rw [integral_sub (integrable_const 1), integral_const, measureReal_univ_eq_one, one_smul]
+          rw [integral_sub (integrable_const 1), integral_const, probReal_univ, one_smul]
           exact (integrable_const 1).indicator ht_meas
         simp_rw [h_compl_eq]
         rw [integral_sub, integral_const]
@@ -1027,7 +1027,7 @@ lemma setIntegral_directing_measure_indicator_eq
                   · exact ae_of_all _ (fun x => by
                       simp only [Set.indicator_apply]
                       split_ifs <;> simp)
-              _ = 1 := by simp [measureReal_univ_eq_one]
+              _ = 1 := by simp [probReal_univ]
       have h_rhs_eq : ∫ ω in A, tᶜ.indicator (fun _ => (1:ℝ)) (X 0 ω) ∂μ =
           ∫ ω in A, (1 : ℝ) ∂μ - ∫ ω in A, t.indicator (fun _ => (1:ℝ)) (X 0 ω) ∂μ := by
         have h_ind_compl : ∀ ω, tᶜ.indicator (fun _ => (1:ℝ)) (X 0 ω) =
@@ -1288,7 +1288,7 @@ lemma setIntegral_directing_measure_bounded_measurable_eq
               have := hφ_range n x
               rw [Set.mem_Icc] at this
               exact abs_le.mpr this
-        _ = M' := by simp [measureReal_univ_eq_one]
+        _ = M' := by simp [probReal_univ]
     · filter_upwards with ω
       -- ∫ φ_n dν(ω) → ∫ f dν(ω) by DCT on ν(ω)
       haveI hprob := directing_measure_isProbabilityMeasure X hX_contract hX_meas hX_L2 ω
@@ -1549,7 +1549,7 @@ lemma directing_measure_integral_eq_condExp
           · exact ae_of_all _ (fun _ => abs_nonneg _)
           · exact integrable_const M'
           · exact ae_of_all _ hM'
-      _ = M' := by simp only [integral_const, measureReal_univ_eq_one, smul_eq_mul, one_mul]
+      _ = M' := by simp only [integral_const, probReal_univ, smul_eq_mul, one_mul]
 
   -- g is AEStronglyMeasurable w.r.t. ambient σ-algebra
   -- Uses monotone class theorem: measurability extends from Iic indicators to bounded measurable f.
@@ -1655,7 +1655,7 @@ lemma directing_measure_integral_via_chain
         apply le_antisymm _ (integral_nonneg (fun _ => abs_nonneg _))
         -- For any ε > 0, ∫|alpha| < ε (using hα_conv with cesaro = 0)
         by_contra h_pos
-        push_neg at h_pos
+        push Not at h_pos
         have hε : (0 : ℝ) < ∫ ω, |alpha ω| ∂μ := h_pos
         obtain ⟨M_idx, hM_idx⟩ := hα_conv 0 (∫ ω, |alpha ω| ∂μ) hε
         specialize hM_idx M_idx (le_refl _)

--- a/Exchangeability/DeFinetti/ViaL2/MoreL2Helpers.lean
+++ b/Exchangeability/DeFinetti/ViaL2/MoreL2Helpers.lean
@@ -1550,7 +1550,7 @@ lemma card_nonInjective_le (m N : ℕ) (_hN : 0 < N) :
       constructor
       intro ⟨φ, hφ⟩
       simp only [Function.Injective] at hφ
-      push_neg at hφ
+      push Not at hφ
       obtain ⟨i, _, _, _⟩ := hφ
       exact Fin.elim0 i
     simp [Fintype.card_eq_zero]
@@ -1561,7 +1561,7 @@ lemma card_nonInjective_le (m N : ℕ) (_hN : 0 < N) :
         constructor
         intro ⟨φ, hφ⟩
         simp only [Function.Injective] at hφ
-        push_neg at hφ
+        push Not at hφ
         obtain ⟨i, j, _, hij⟩ := hφ
         exact absurd (Subsingleton.elim i j) hij
       simp [Fintype.card_eq_zero]
@@ -1576,7 +1576,7 @@ lemma card_nonInjective_le (m N : ℕ) (_hN : 0 < N) :
                    true_and, collisionPairs]
         -- φ is not injective, so ∃ i ≠ j with φ i = φ j
         simp only [Function.Injective] at hφ
-        push_neg at hφ
+        push Not at hφ
         obtain ⟨i, j, heq, hne⟩ := hφ
         refine ⟨(i, j), ?_, heq⟩
         exact hne
@@ -1627,7 +1627,7 @@ lemma nonInjective_fraction_tendsto_zero (m : ℕ) :
       constructor
       intro ⟨φ, hφ⟩
       simp only [Function.Injective] at hφ
-      push_neg at hφ
+      push Not at hφ
       obtain ⟨i, _, _, _⟩ := hφ
       exact Fin.elim0 i
     simp only [h, Nat.cast_zero]

--- a/Exchangeability/DeFinetti/ViaMartingale.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale.lean
@@ -255,7 +255,7 @@ lemma ae_bound_condexp_of_ae_bound
   by_cases hC : 0 ≤ C
   · exact MeasureTheory.ae_bdd_condExp_of_ae_bdd (R := ⟨C, hC⟩) hgC
   · -- C < 0 contradicts |g ω| ≤ C since |g ω| ≥ 0
-    push_neg at hC
+    push Not at hC
     filter_upwards [hgC] with ω hω
     linarith [abs_nonneg (g ω)]
 

--- a/Exchangeability/DeFinetti/ViaMartingale/FutureRectangles.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/FutureRectangles.lean
@@ -54,7 +54,7 @@ lemma contractable_dist_eq_on_first_r_tail
   let f : Fin r → ℕ := fun i => m + (i.1 + 1)
   have hf_mono : StrictMono f := by
     intro i j hij
-    have hij' : i.1 < j.1 := (Fin.lt_iff_val_lt_val).1 hij
+    have hij' : i.1 < j.1 := Fin.lt_def.1 hij
     have : i.1 + 1 < j.1 + 1 := Nat.succ_lt_succ hij'
     simp only [f]; omega
   have hm_lt : ∀ i, m < f i := fun i => by simp only [f]; omega

--- a/Exchangeability/DeFinetti/ViaMartingale/LocalInfrastructure.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/LocalInfrastructure.lean
@@ -95,7 +95,7 @@ lemma integrable_of_bounded_on_prob
     rw [Real.norm_eq_abs] at hx
     rwa [abs_le] at hx
   · -- If C < 0, then ‖h‖ ≤ C < 0 a.e. contradicts ‖h‖ ≥ 0
-    push_neg at hC
+    push Not at hC
     apply MeasureTheory.Integrable.of_mem_Icc 0 0 hmeas.aemeasurable
     filter_upwards [hB] with x hx
     rw [Set.mem_Icc]

--- a/Exchangeability/Ergodic/BirkhoffAvgCLM.lean
+++ b/Exchangeability/Ergodic/BirkhoffAvgCLM.lean
@@ -130,7 +130,7 @@ lemma EventuallyEq.sum' {ι : Type*} [Fintype ι] {fs gs : ι → Ω → ℝ}
     simp only [Set.mem_iUnion, Set.mem_setOf_eq] at hω ⊢
     -- If the sums differ, then some summand must differ
     by_contra h_contra
-    push_neg at h_contra
+    push Not at h_contra
     apply hω
     -- The sums are equal if all summands are equal
     congr 1

--- a/Exchangeability/Probability/CondIndep/Bounded/Approximation.lean
+++ b/Exchangeability/Probability/CondIndep/Bounded/Approximation.lean
@@ -202,7 +202,7 @@ lemma approx_bounded_measurable (μ : Measure α) [IsProbabilityMeasure μ]
   · -- Case M < 0: contradiction since |f x| ≥ 0 > M always
     -- The hypothesis hf_bdd : ∀ᵐ x ∂μ, |f x| ≤ M with M < 0 is impossible
     -- since |f x| ≥ 0 for all x. This implies μ = 0, contradicting probability measure.
-    push_neg at hM_nonneg
+    push Not at hM_nonneg
     exfalso
     have h_ae_false : ∀ᵐ x ∂μ, False := by
       filter_upwards [hf_bdd] with x hx

--- a/Exchangeability/Probability/LpNormHelpers.lean
+++ b/Exchangeability/Probability/LpNormHelpers.lean
@@ -68,7 +68,7 @@ lemma eLpNorm_two_sq_eq_integral_sq
 
   -- Use the fundamental relationship for p = 2
   -- eLpNorm f p μ ^ p = ∫⁻ ‖f‖^p when p ≠ 0, ∞
-  rw [eLpNorm_eq_lintegral_rpow_enorm (by norm_num : (2 : ℝ≥0∞) ≠ 0)
+  rw [eLpNorm_eq_lintegral_rpow_enorm_toReal (by norm_num : (2 : ℝ≥0∞) ≠ 0)
       (by norm_num : (2 : ℝ≥0∞) ≠ ∞)]
 
   -- Simplify: ENNReal.toReal 2 = 2, so we have ((∫⁻ ‖f‖² )^(1/2)).toReal²

--- a/Exchangeability/Probability/TimeReversalCrossing.lean
+++ b/Exchangeability/Probability/TimeReversalCrossing.lean
@@ -59,7 +59,7 @@ private lemma lowerCrossingTime_lt_upperCrossingTime_succ' {Ω : Type*} {a b : �
   have h_le : lowerCrossingTime a b f N n ω ≤ upperCrossingTime a b f N (n+1) ω :=
     lowerCrossingTime_le_upperCrossingTime_succ
   by_contra hge
-  push_neg at hge
+  push Not at hge
   have h_eq : lowerCrossingTime a b f N n ω = upperCrossingTime a b f N (n+1) ω :=
     le_antisymm h_le hge
   have h_neq' : lowerCrossingTime a b f N n ω ≠ N := h_eq ▸ h_neq


### PR DESCRIPTION
## Summary

Zero out the deprecation warnings produced by `lake build` since the v4.30.0-rc2 bump (#17). After this PR, `grep -c "has been deprecated"` over the build log returns 0.

**Net diff:** 18 files, +35 / −35 (renames only; **net 0 lines**).

## Changes by category

### Tactic rename — `push_neg` → `push Not` (25 sites)

| File | Sites |
|---|---|
| `DeFinetti/ViaL2/DirectingMeasureIntegral.lean` | 4 |
| `DeFinetti/ViaL2/MoreL2Helpers.lean` | 4 |
| `DeFinetti/ViaL2/CesaroConvergence.lean` | 3 |
| `DeFinetti/ViaL2/DirectingMeasureCore.lean` | 2 |
| `DeFinetti/ViaL2/AlphaConvergence.lean` | 2 |
| `DeFinetti/ViaL2/BlockAverages.lean` | 2 |
| `DeFinetti/{ViaMartingale,BridgeProperty,CommonEnding}.lean` | 1 each |
| `DeFinetti/ViaMartingale/LocalInfrastructure.lean` | 1 |
| `DeFinetti/ViaL2/AlphaIicCE.lean` | 1 |
| `Ergodic/BirkhoffAvgCLM.lean` | 1 |
| `Probability/{TimeReversalCrossing.lean, CondIndep/Bounded/Approximation.lean}` | 1 each |

All sites had identical shape `push_neg at h…` — straight substitution to `push Not at h…`.

### Deprecated import path

`DeFinetti/ViaKoopman/InfraCore.lean:12`:
- `import Mathlib.Probability.Independence.Kernel` → `import Mathlib.Probability.Independence.Kernel.IndepFun`

The old path is a `deprecated_module` stub (since 2025-12-01) that just re-imports the new one, so this is a transparent swap. Side effect: build target count drops from 3528 to 3527 because the stub is no longer pulled in as a separate file.

### Deprecated theorem names

| Site | Old → New |
|---|---|
| `Probability/LpNormHelpers.lean:71` | `eLpNorm_eq_lintegral_rpow_enorm` → `eLpNorm_eq_lintegral_rpow_enorm_toReal` (same signature) |
| `DeFinetti/ViaMartingale/FutureRectangles.lean:57` | `Fin.lt_iff_val_lt_val` → `Fin.lt_def` |
| `DeFinetti/ViaKoopman/CesaroL2ToL1.lean:284` | drop `Nat.lt_succ` from a `simp [...]` argument — was both deprecated and (per the unused-simp-args linter) unused; the surrounding `omega` closes the goal regardless |
| `DeFinetti/ViaL2/DirectingMeasureIntegral.lean` (6 sites) | `measureReal_univ_eq_one` → `probReal_univ` |

The `measureReal_univ_eq_one` cluster wasn't on the original audit list, but it's the same character of fix and showed up in the remaining-warnings sweep. Folded in so this PR really is "zero warnings."

## Verification

| Check | Baseline (main = aefa1c7a) | This branch |
|---|---|---|
| `lake build` | clean (3528 jobs) | clean (3527 jobs) |
| Deprecation warnings in build log | many | **0** |
| Axioms (11 theorem decls) | standard only | standard only |
| Sorries (`Exchangeability`) | 0 | 0 |
| Statements / signatures | unchanged | unchanged |

## Notes

- All replacements are name swaps of equivalent lemmas/tactics; the underlying terms / proof states stay the same.
- This finishes the post-bump warning cleanup. The next planned PR is the dead-wrapper deletion sweep (`condExp_eq_kernel_integral`, `ennreal_tendsto_toReal_zero`, etc.) from the same audit.