### PR TITLE
docs: clear the last three stale-text sites (−31 lines)

### DIFF
--- a/Exchangeability/DeFinetti/ViaL2/CesaroConvergence.lean
+++ b/Exchangeability/DeFinetti/ViaL2/CesaroConvergence.lean
@@ -1089,28 +1089,11 @@ private lemma cesaro_cauchy_rho_lt
     have hn_ne_zero : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.pos_iff_ne_zero.mp hn_pos)
     have hn'_ne_zero : (n' : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.pos_iff_ne_zero.mp hn'_pos)
     field_simp [hn_ne_zero, hn'_ne_zero]
-    -- Now: (∑ k ∈ range n, Z k ω) / n - (∑ k ∈ range n', Z k ω) / n'
-    -- After field_simp cleared denominators, goal has form:
-    -- (n * m_mean + ∑ k ∈ range n, Z k) * n' + n * (-(m_mean * n') - ∑ k ∈ range n', Z k)
-    --   = n * n' * (∑ i, p i * ξ i - ∑ i, q i * ξ i)
-    -- Step 6: Convert both sides to use sums over Fin m with indicators, then simplify
-    -- This is straightforward algebra but requires careful tactic sequencing
-    -- Note: algebraic manipulation to complete
-    -- The goal is to show:
-    -- (∑ k ∈ range n, Z k ω) / n - (∑ k ∈ range n', Z k ω) / n'
-    --   = ∑ i : Fin m, p i * ξ i ω - ∑ i : Fin m, q i * ξ i ω
-    -- where p i = (if i < n then 1/n else 0), q i = (if i < n' then 1/n' else 0), ξ i = Z i.val
-    --
-    -- Strategy (partially implemented):
-    -- 1. ✅ Convert ∑ k ∈ Finset.range n to ∑ i : Fin n via Finset.sum_range
-    -- 2. ✅ Extend from Fin n to Fin m with indicators via Finset.sum_bij
-    -- 3. ❌ Simplify the resulting algebraic expression
-    --
-    -- The bijection proof works but requires careful handling of the exact goal state
-    -- after field_simp. The key lemmas needed:
-    -- - Finset.sum_range: converts between Finset.range and Fin
-    -- - Finset.sum_bij: establishes bijection for sum conversion
-    -- - Field arithmetic to show n * n' * (if i < n then 1/n else 0) = (if i < n then n' else 0)
+    -- Convert both sides to sums over `Fin m` with indicators, then simplify.
+    -- Goal: `(∑ k ∈ range n, Z k ω) / n - (∑ k ∈ range n', Z k ω) / n' =`
+    --   `∑ i : Fin m, p i * ξ i ω - ∑ i : Fin m, q i * ξ i ω`
+    -- where `p i = if i < n then 1/n else 0`, `q i = if i < n' then 1/n' else 0`,
+    -- `ξ i = Z i.val`.
     simp only [ξ, p, q]
     -- Expand LHS: (n * m_mean + ∑_{i<n} Z_i) * n' + n * (-(m_mean * n') - ∑_{j<n'} Z_j)
     -- Should simplify to: n' * ∑_{i<n} Z_i - n * ∑_{j<n'} Z_j

--- a/Exchangeability/DeFinetti/ViaL2/DirectingMeasureIntegral.lean
+++ b/Exchangeability/DeFinetti/ViaL2/DirectingMeasureIntegral.lean
@@ -383,10 +383,10 @@ lemma directing_measure_integral_Iic_ae_eq_alphaIicCE
     -- This follows from h_mono_t_rat!
     exact h_mono_t_rat q hq
 
-/-! ### Helper Lemmas for Monotone Class Extension
+/-! ### Helper lemmas for monotone class extension
 
-The following lemmas build up the π-λ argument needed for `directing_measure_integral_eq_condExp`.
-Each phase is factored out as a separate lemma with its own sorry to be filled.
+These lemmas build up the π-λ argument used by `directing_measure_integral_eq_condExp`,
+factored into three phases:
 
 **Phase A**: Indicators of Borel sets → tail-AEStronglyMeasurable
 **Phase B**: Simple functions → tail-AEStronglyMeasurable (via linearity)

--- a/Exchangeability/DeFinetti/ViaL2/MoreL2Helpers.lean
+++ b/Exchangeability/DeFinetti/ViaL2/MoreL2Helpers.lean
@@ -1831,20 +1831,6 @@ lemma directing_measure_bridge
           rw [h_tail_eq]
   exact indicator_product_bridge X hX_contract hX_meas ν hν_prob hν_meas hν_law k hk B hB
 
-/-! ### Original proof structure (commented out due to incomplete lemmas)
-
-The original proof attempted to show:
-1. Reduce injective k to strictly monotone via permutation
-2. Use contractability for distributional equality
-3. Apply U-statistic expansion for product expectations
-4. Conclude via L¹ convergence of block averages
-
-Key intermediate lemmas that need completion:
-- h_pblock_vs_shifted: Bound on shifted averages
-- h_L1_shifted_ref: L¹ bound from L² via Cauchy-Schwarz
-- h_block_L1: Product L¹ convergence
--/
-
 /-- **Main packaging theorem for L² proof.**
 
 This theorem packages all the directing measure properties needed by


### PR DESCRIPTION
## Summary

Final stale-text cleanup pass — clears the three sticky sites that survived the #27 / #28 sweeps. After this, the codebase shouldn't have any \"to be filled\", \"partially implemented\", \"Original proof structure\", or sorries-remaining language outside `WorkPlans/Deprecated/` archival docs.

**Net diff:** 3 files, +8 / −39 (**−31 lines**).

## What changed

| Site | Old text | New text |
|---|---|---|
| `DeFinetti/ViaL2/MoreL2Helpers.lean:1834` | 13-line `/-! ### Original proof structure (commented out due to incomplete lemmas) -/` header describing an abandoned proof attempt + its missing pieces | deleted (no commented-out code beneath it, the next theorem builds cleanly) |
| `DeFinetti/ViaL2/DirectingMeasureIntegral.lean:389` | `Each phase is factored out as a separate lemma with its own sorry to be filled.` (in the `Helper Lemmas for Monotone Class Extension` docstring) | rewritten in past tense to describe the three phases |
| `DeFinetti/ViaL2/CesaroConvergence.lean:1093-1113` | 20-line in-proof comment cluster: `Step 6: Convert both sides…` / `Strategy (partially implemented):` / `1. ✅ … 2. ✅ … 3. ❌ Simplify the resulting algebraic expression` / list of "key lemmas needed" | replaced with 5-line statement of the goal (the proof following the comment already does the work) |

## Verification

| Check | Baseline (main = 37d1f240) | This branch |
|---|---|---|
| `lake build` | clean (3527 jobs) | clean (3527 jobs) |
| Axioms (11 theorem decls) | standard only | standard only |
| Sorries (`Exchangeability`) | 0 | 0 |