### PR TITLE
chore: delete dead cylinder defs from PathSpace + CondExp (−85 lines)

### DIFF
--- a/Exchangeability/DeFinetti/MartingaleHelpers.lean
+++ b/Exchangeability/DeFinetti/MartingaleHelpers.lean
@@ -39,14 +39,11 @@ namespace DeFinetti
 namespace MartingaleHelpers
 
 -- Re-export cylinder infrastructure from PathSpace for backward compatibility
-export PathSpace (tailCylinder tailCylinder_measurable cylinder finCylinder
-  finCylinder_measurable cylinder_measurable firstRMap firstRSigma firstRCylinder
-  firstRCylinder_eq_preimage_finCylinder firstRCylinder_measurable_in_firstRSigma
-  firstRCylinder_measurable_ambient measurable_firstRMap firstRSigma_le_ambient
-  firstRSigma_mono firstRCylinder_zero mem_firstRCylinder_iff firstRCylinder_univ
-  firstRCylinder_inter tailCylinder_eq_preimage_cylinder
-  mem_cylinder_iff mem_tailCylinder_iff cylinder_measurable_set cylinder_zero
-  tailCylinder_zero' cylinder_univ tailCylinder_univ cylinder_inter)
+export PathSpace (cylinder cylinder_measurable firstRMap firstRSigma firstRCylinder
+  firstRCylinder_measurable_in_firstRSigma firstRCylinder_measurable_ambient
+  measurable_firstRMap firstRSigma_le_ambient firstRSigma_mono firstRCylinder_zero
+  mem_firstRCylinder_iff firstRCylinder_univ firstRCylinder_inter mem_cylinder_iff
+  cylinder_measurable_set cylinder_zero cylinder_univ cylinder_inter)
 
 open MeasureTheory
 

--- a/Exchangeability/PathSpace/CylinderHelpers.lean
+++ b/Exchangeability/PathSpace/CylinderHelpers.lean
@@ -42,30 +42,6 @@ open scoped MeasureTheory
 namespace Exchangeability
 namespace PathSpace
 
-section TailCylinders
-
-variable {α : Type*} [MeasurableSpace α]
-
-/-- Cylinder on the first `r` tail coordinates (shifted by one). -/
-def tailCylinder (r : ℕ) (C : Fin r → Set α) : Set (ℕ → α) :=
-  {f | ∀ i : Fin r, f (i.1 + 1) ∈ C i}
-
-set_option linter.unusedSectionVars false in
-/-- Basic measurability for tail cylinders. -/
-@[measurability]
-lemma tailCylinder_measurable {r : ℕ} {C : Fin r → Set α}
-    (hC : ∀ i, MeasurableSet (C i)) :
-    MeasurableSet (tailCylinder (α:=α) r C) := by
-  classical
-  simp only [tailCylinder, Set.setOf_forall]
-  exact MeasurableSet.iInter fun i => by
-    have : (fun f : ℕ → α => f (i.val + 1)) ⁻¹' C i = {f | f (i.1 + 1) ∈ C i} := by
-      ext f; simp [Set.mem_preimage]
-    rw [← this]
-    exact (hC i).preimage (measurable_pi_apply (i.val + 1))
-
-end TailCylinders
-
 section FutureCylinders
 
 variable {α : Type*}
@@ -74,23 +50,7 @@ variable {α : Type*}
 def cylinder (r : ℕ) (C : Fin r → Set α) : Set (ℕ → α) :=
   {f | ∀ i : Fin r, f i ∈ C i}
 
-/-- Cylinder for functions with domain Fin r. -/
-def finCylinder (r : ℕ) (C : Fin r → Set α) : Set (Fin r → α) :=
-  {f | ∀ i : Fin r, f i ∈ C i}
-
 variable [MeasurableSpace α]
-
-@[measurability]
-lemma finCylinder_measurable {r : ℕ} {C : Fin r → Set α}
-    (hC : ∀ i, MeasurableSet (C i)) :
-    MeasurableSet (finCylinder r C) := by
-  classical
-  simp only [finCylinder, Set.setOf_forall]
-  exact MeasurableSet.iInter fun i => by
-    have : (fun f : Fin r → α => f i) ⁻¹' C i = {f | f i ∈ C i} := by
-      ext f; simp [Set.mem_preimage]
-    rw [← this]
-    exact (hC i).preimage (measurable_pi_apply i)
 
 @[measurability]
 lemma cylinder_measurable {r : ℕ} {C : Fin r → Set α}
@@ -122,14 +82,6 @@ abbrev firstRSigma (X : ℕ → Ω → α) (r : ℕ) : MeasurableSpace Ω :=
 def firstRCylinder (X : ℕ → Ω → α) (r : ℕ) (C : Fin r → Set α) : Set Ω :=
   {ω | ∀ i : Fin r, X i ω ∈ C i}
 
-omit [MeasurableSpace Ω] [MeasurableSpace α] in
-/-- As expected, the block cylinder is the preimage of a finite cylinder
-   under the `firstRMap`. -/
-lemma firstRCylinder_eq_preimage_finCylinder
-    (X : ℕ → Ω → α) (r : ℕ) (C : Fin r → Set α) :
-    firstRCylinder X r C
-      = (firstRMap X r) ⁻¹' (finCylinder (α:=α) r C) := rfl
-
 omit [MeasurableSpace Ω] in
 /-- **Measurable in the first-`r` σ‑algebra.**
 If each `C i` is measurable in `α`, then the block cylinder is measurable in
@@ -139,10 +91,11 @@ lemma firstRCylinder_measurable_in_firstRSigma
     (X : ℕ → Ω → α) (r : ℕ) (C : Fin r → Set α)
     (hC : ∀ i, MeasurableSet (C i)) :
     MeasurableSet[firstRSigma X r] (firstRCylinder X r C) := by
-  -- firstRSigma X r = comap (firstRMap X r)
-  -- A set is measurable in the comap iff it's a preimage of a measurable set
-  rw [firstRCylinder_eq_preimage_finCylinder]
-  exact ⟨_, finCylinder_measurable hC, rfl⟩
+  -- firstRSigma X r = comap (firstRMap X r); express firstRCylinder as a preimage.
+  refine ⟨{f : Fin r → α | ∀ i, f i ∈ C i}, ?_, rfl⟩
+  classical
+  rw [Set.setOf_forall]
+  exact MeasurableSet.iInter fun i => (hC i).preimage (measurable_pi_apply i)
 
 /-- **Measurable in the ambient σ‑algebra.**
 If each coordinate `X i` is measurable, then the block cylinder is measurable
@@ -233,23 +186,8 @@ section CylinderBridge
 variable {α : Type*} [MeasurableSpace α]
 
 omit [MeasurableSpace α] in
-/-- `tailCylinder` is the preimage of a standard cylinder under `shift`. -/
-lemma tailCylinder_eq_preimage_cylinder
-    {r : ℕ} {C : Fin r → Set α} :
-    tailCylinder (α:=α) r C
-      = (shift : (ℕ → α) → (ℕ → α)) ⁻¹' (cylinder (α:=α) r C) := by
-  ext f
-  constructor <;> intro hf
-  · simpa [tailCylinder, shift, cylinder]
-  · simpa [tailCylinder, shift, cylinder]
-
-omit [MeasurableSpace α] in
 @[simp] lemma mem_cylinder_iff {r : ℕ} {C : Fin r → Set α} {f : ℕ → α} :
     f ∈ cylinder (α:=α) r C ↔ ∀ i : Fin r, f i ∈ C i := Iff.rfl
-
-omit [MeasurableSpace α] in
-@[simp] lemma mem_tailCylinder_iff {r : ℕ} {C : Fin r → Set α} {f : ℕ → α} :
-    f ∈ tailCylinder (α:=α) r C ↔ ∀ i : Fin r, f (i.1 + 1) ∈ C i := Iff.rfl
 
 /-- The cylinder set is measurable when each component set is measurable. -/
 lemma cylinder_measurable_set {r : ℕ} {C : Fin r → Set α}
@@ -263,19 +201,9 @@ omit [MeasurableSpace α] in
   ext f; simp [cylinder]
 
 omit [MeasurableSpace α] in
-/-- Empty tail cylinder is the whole space. -/
-@[simp] lemma tailCylinder_zero' : tailCylinder (α:=α) 0 (fun _ => Set.univ) = Set.univ := by
-  ext f; simp [tailCylinder]
-
-omit [MeasurableSpace α] in
 /-- Cylinder on universal sets is the whole space. -/
 lemma cylinder_univ {r : ℕ} : cylinder (α:=α) r (fun _ => Set.univ) = Set.univ := by
   ext f; simp [cylinder]
-
-omit [MeasurableSpace α] in
-/-- Tail cylinder on universal sets is the whole space. -/
-lemma tailCylinder_univ {r : ℕ} : tailCylinder (α:=α) r (fun _ => Set.univ) = Set.univ := by
-  ext f; simp [tailCylinder]
 
 omit [MeasurableSpace α] in
 /-- Cylinders form intersections coordinate-wise. -/

--- a/Exchangeability/Probability/CondExp.lean
+++ b/Exchangeability/Probability/CondExp.lean
@@ -130,16 +130,6 @@ lemma integrable_indicator_comp
   -- Bounded measurable function on finite measure space is integrable
   exact Integrable.of_bound h_meas.aestronglyMeasurable 1 h_bound
 
-/-! ### Cylinder helper for pair-law arguments -/
-
-/-- Standard cylinder on the first `r` coordinates starting at index 0.
-
-**NOTE**: This is intentionally duplicated from `PathSpace.CylinderHelpers.cylinder` to
-avoid a circular import. CondExp is a low-level module that cannot import PathSpace,
-but needs this definition for working with product measures on sequence spaces. -/
-def cylinder (α : Type*) (r : ℕ) (C : Fin r → Set α) : Set (ℕ → α) :=
-  {f | ∀ i : Fin r, f i ∈ C i}
-
 -- NOTE: AgreeOnFutureRectangles was removed - it was just wrapping measure equality.
 -- The real AgreeOnFutureRectangles definition (rectangle agreement implies equality)
 -- is in ViaMartingale.lean where it's actually used to prove measure equality from


### PR DESCRIPTION
## Summary

Surveyed the local cylinder API surface for the planned cylinder/product-measure refactor and found that a substantial chunk of it is dead code — defs and lemmas with zero callers anywhere in the repo, sitting alongside the actively-used `cylinder` / `firstRCylinder` machinery. Deleted before tackling the bigger mathlib-alignment question.

**Net diff:** 3 files, +10 / −95 (**−85 lines**).

## What changed

### Deleted (all verified zero callers by grep)

| Item | Where | Notes |
|---|---|---|
| `cylinder` (local duplicate) | `Probability/CondExp.lean:140` | 2-line duplicate of `PathSpace.CylinderHelpers.cylinder`. Docstring claimed it was needed to avoid a circular import, but no caller existed so the workaround was moot. |
| `tailCylinder` + supporting lemmas | `PathSpace/CylinderHelpers.lean` | `tailCylinder`, `tailCylinder_measurable`, `tailCylinder_eq_preimage_cylinder`, `mem_tailCylinder_iff`, `tailCylinder_zero'`, `tailCylinder_univ`. Whole `section TailCylinders` removed. |
| `finCylinder` + `finCylinder_measurable` | `PathSpace/CylinderHelpers.lean` | only referenced internally by `firstRCylinder_eq_preimage_finCylinder` |
| `firstRCylinder_eq_preimage_finCylinder` | `PathSpace/CylinderHelpers.lean` | only used by the inlined proof of `firstRCylinder_measurable_in_firstRSigma` |

### Rewritten

`firstRCylinder_measurable_in_firstRSigma` (still used externally) — old proof routed through `firstRCylinder_eq_preimage_finCylinder` + `finCylinder_measurable`. New proof constructs the witness set directly:

```lean
refine ⟨{f : Fin r → α | ∀ i, f i ∈ C i}, ?_, rfl⟩
classical
rw [Set.setOf_forall]
exact MeasurableSet.iInter fun i => (hC i).preimage (measurable_pi_apply i)
```

### Export list trimmed

`DeFinetti/MartingaleHelpers.lean:42` — the `export PathSpace (...)` line is updated to drop the deleted names.

### Survivors (real callers, kept as-is)

`cylinder` (51 external uses), `cylinder_measurable` (3), `firstRMap` (3), `firstRSigma` (11), `firstRCylinder` (14), `firstRCylinder_measurable_in_firstRSigma` (1), `firstRCylinder_measurable_ambient`, `mem_cylinder_iff`, `cylinder_univ`, `cylinder_inter`, `cylinder_zero`, `cylinder_measurable_set`.

## Verification

| Check | Baseline (main = ff7ac9f3) | This branch |
|---|---|---|
| `lake build` | clean (3527 jobs) | clean (3527 jobs) |
| Axioms (11 theorem decls) | standard only | standard only |
| Sorries (`Exchangeability`) | 0 | 0 |

## What's still ahead in the cylinder area

This is the "low-hanging fruit" portion of the cylinder refactor docket item. The bigger questions — aligning the local `cylinder (r : ℕ) (C : Fin r → Set α)` (rectangular, ℕ-indexed) with mathlib's `MeasureTheory.cylinder (s : Finset ι) (S : Set (∀ i : s, α i))` (general, Finset-indexed) — are *not* a clean LoC-saving move: the local API's rectangular convenience keeps proofs concise where they otherwise would need explicit `Set.univ.pi C'`-style translations. Recommend deferring or splitting differently. Will update the docket.