### PR TITLE
chore(ViaL2): drop dead cdf_from_alpha delegation + packaged lemma (−178 lines)

### DIFF
--- a/Exchangeability/DeFinetti/ViaL2/BlockAverages.lean
+++ b/Exchangeability/DeFinetti/ViaL2/BlockAverages.lean
@@ -1526,8 +1526,3 @@ theorem subseq_ae_of_L1
   -- Step 3: Extract almost-everywhere convergent subsequence
   exact h_tendstoInMeasure.exists_seq_tendsto_ae
 
-/-! Note: The complete `alpha_is_conditional_expectation_packaged` is in
-`MoreL2Helpers.lean` (at the `ViaL2` namespace level, not `Helpers`).
-A stub was previously here but has been removed since it wasn't used
-in the critical path. -/
-

--- a/Exchangeability/DeFinetti/ViaL2/DirectingMeasureCore.lean
+++ b/Exchangeability/DeFinetti/ViaL2/DirectingMeasureCore.lean
@@ -20,12 +20,12 @@ This file defines the core components of the directing measure construction:
 
 ## Main results
 
-* `cdf_from_alpha_mono`: F(ω,·) is monotone nondecreasing
-* `cdf_from_alpha_rightContinuous`: F(ω,·) is right-continuous
-* `cdf_from_alpha_bounds`: 0 ≤ F(ω,t) ≤ 1
 * `alphaIic_ae_tendsto_zero_at_bot`: a.e. limit 0 at -∞ for alphaIic
 * `alphaIic_ae_tendsto_one_at_top`: a.e. limit 1 at +∞ for alphaIic
 * `directing_measure_isProbabilityMeasure`: ν(ω) is a probability measure for each ω
+
+Monotonicity, right-continuity, and bounds on the CDF are inherited directly from
+mathlib's `stieltjesOfMeasurableRat`; no project-local wrappers are needed.
 
 ## References
 
@@ -64,133 +64,6 @@ noncomputable def cdf_from_alpha
       (alphaIicRat X hX_contract hX_meas hX_L2)
       (measurable_alphaIicRat X hX_contract hX_meas hX_L2)
       ω) t
-
-/-- F(ω,·) is monotone nondecreasing. -/
-lemma cdf_from_alpha_mono
-    {μ : Measure Ω} [IsProbabilityMeasure μ]
-    (X : ℕ → Ω → ℝ) (hX_contract : Contractable μ X)
-    (hX_meas : ∀ i, Measurable (X i))
-    (hX_L2 : ∀ i, MemLp (X i) 2 μ)
-    (ω : Ω) :
-    Monotone (cdf_from_alpha X hX_contract hX_meas hX_L2 ω) := fun s t hst =>
-  (ProbabilityTheory.stieltjesOfMeasurableRat
-      (alphaIicRat X hX_contract hX_meas hX_L2)
-      (measurable_alphaIicRat X hX_contract hX_meas hX_L2)
-      ω).mono hst
-
-/-- Right-continuity in t: F(ω,t) = lim_{u↘t} F(ω,u). -/
-lemma cdf_from_alpha_rightContinuous
-    {μ : Measure Ω} [IsProbabilityMeasure μ]
-    (X : ℕ → Ω → ℝ) (hX_contract : Contractable μ X)
-    (hX_meas : ∀ i, Measurable (X i))
-    (hX_L2 : ∀ i, MemLp (X i) 2 μ)
-    (ω : Ω) :
-    ∀ t, Filter.Tendsto (cdf_from_alpha X hX_contract hX_meas hX_L2 ω)
-      (𝓝[>] t) (𝓝 (cdf_from_alpha X hX_contract hX_meas hX_L2 ω t)) := by
-  intro t
-  -- StieltjesFunction.right_continuous gives ContinuousWithinAt at Ici t
-  -- We need Tendsto at 𝓝[>] t = 𝓝[Ioi t] t
-  -- continuousWithinAt_Ioi_iff_Ici provides the equivalence
-  let f := ProbabilityTheory.stieltjesOfMeasurableRat
-      (alphaIicRat X hX_contract hX_meas hX_L2)
-      (measurable_alphaIicRat X hX_contract hX_meas hX_L2)
-      ω
-  have h_rc : ContinuousWithinAt f (Set.Ici t) t := f.right_continuous t
-  -- Convert ContinuousWithinAt (Ici) to ContinuousWithinAt (Ioi)
-  rw [← continuousWithinAt_Ioi_iff_Ici] at h_rc
-  exact h_rc
-
-/-- Bounds 0 ≤ F ≤ 1 (pointwise in ω,t). -/
-lemma cdf_from_alpha_bounds
-    {μ : Measure Ω} [IsProbabilityMeasure μ]
-    (X : ℕ → Ω → ℝ) (hX_contract : Contractable μ X)
-    (hX_meas : ∀ i, Measurable (X i))
-    (hX_L2 : ∀ i, MemLp (X i) 2 μ)
-    (ω : Ω) (t : ℝ) :
-    0 ≤ cdf_from_alpha X hX_contract hX_meas hX_L2 ω t
-    ∧ cdf_from_alpha X hX_contract hX_meas hX_L2 ω t ≤ 1 := by
-  -- The stieltjesOfMeasurableRat construction produces a function with limits 0 at -∞ and 1 at +∞.
-  -- By monotonicity, all values are in [0,1].
-  let f := ProbabilityTheory.stieltjesOfMeasurableRat
-      (alphaIicRat X hX_contract hX_meas hX_L2)
-      (measurable_alphaIicRat X hX_contract hX_meas hX_L2)
-      ω
-  have h_tendsto_bot : Filter.Tendsto (f ·) Filter.atBot (𝓝 0) :=
-    ProbabilityTheory.tendsto_stieltjesOfMeasurableRat_atBot
-      (measurable_alphaIicRat X hX_contract hX_meas hX_L2) ω
-  have h_tendsto_top : Filter.Tendsto (f ·) Filter.atTop (𝓝 1) :=
-    ProbabilityTheory.tendsto_stieltjesOfMeasurableRat_atTop
-      (measurable_alphaIicRat X hX_contract hX_meas hX_L2) ω
-  have h_mono : Monotone (f ·) := f.mono
-  constructor
-  · -- Lower bound: f(t) ≥ 0
-    -- For any s < t, f(s) ≤ f(t) by monotonicity.
-    -- As s → -∞, f(s) → 0, so 0 ≤ f(t).
-    -- Proof by contradiction: if f(t) < 0, pick ε = -f(t)/2 > 0.
-    -- Then eventually f(s) ∈ (-ε, ε), so f(s) > -ε = f(t)/2.
-    -- But also f(s) ≤ f(t) for s ≤ t, contradicting f(s) > f(t)/2 > f(t).
-    by_contra h_neg
-    push Not at h_neg
-    -- f(t) < 0, so ε := -f(t)/2 > 0
-    set ε := -cdf_from_alpha X hX_contract hX_meas hX_L2 ω t / 2 with hε_def
-    have hε_pos : 0 < ε := by simp [hε_def]; linarith
-    -- Eventually f(s) ∈ (-ε, ε)
-    have h_nhds : Set.Ioo (-ε) ε ∈ 𝓝 (0 : ℝ) := Ioo_mem_nhds (by linarith) hε_pos
-    have h_preimage := h_tendsto_bot h_nhds
-    rw [Filter.mem_map, Filter.mem_atBot_sets] at h_preimage
-    obtain ⟨N, hN⟩ := h_preimage
-    -- Take s = min N t, then s ≤ N and s ≤ t
-    let s := min N t
-    have hs_le_N : s ≤ N := min_le_left N t
-    have hs_le_t : s ≤ t := min_le_right N t
-    -- f(s) ∈ (-ε, ε)
-    have hs_in : f s ∈ Set.Ioo (-ε) ε := hN s hs_le_N
-    simp only [Set.mem_Ioo] at hs_in
-    -- f(s) ≤ f(t) by monotonicity
-    have hs_mono : f s ≤ f t := h_mono hs_le_t
-    -- Connect f t with cdf_from_alpha
-    have h_eq_t : (f : ℝ → ℝ) t = cdf_from_alpha X hX_contract hX_meas hX_L2 ω t := rfl
-    -- Now we have: f(s) > -ε = f(t)/2 and f(s) ≤ f(t) < 0
-    have h1 : f s > -ε := hs_in.1
-    have h2 : -ε = cdf_from_alpha X hX_contract hX_meas hX_L2 ω t / 2 := by
-      simp [hε_def]; ring
-    -- f(s) > f(t)/2 and f(s) ≤ f(t) < 0
-    -- If f(t) < 0, then f(t)/2 > f(t), so f(s) > f(t)/2 > f(t) contradicts f(s) ≤ f(t).
-    have h_contra : cdf_from_alpha X hX_contract hX_meas hX_L2 ω t / 2 >
-                    cdf_from_alpha X hX_contract hX_meas hX_L2 ω t := by linarith
-    linarith [h1, h2, hs_mono, h_eq_t, h_contra]
-  · -- Upper bound: f(t) ≤ 1
-    -- Similar argument: for any s > t, f(t) ≤ f(s) by monotonicity.
-    -- As s → +∞, f(s) → 1, so f(t) ≤ 1.
-    by_contra h_gt
-    push Not at h_gt
-    -- f(t) > 1, so ε := (f(t) - 1)/2 > 0
-    set ε := (cdf_from_alpha X hX_contract hX_meas hX_L2 ω t - 1) / 2 with hε_def
-    have hε_pos : 0 < ε := by simp [hε_def]; linarith
-    -- Eventually f(s) ∈ (1-ε, 1+ε)
-    have h_nhds : Set.Ioo (1 - ε) (1 + ε) ∈ 𝓝 (1 : ℝ) := Ioo_mem_nhds (by linarith) (by linarith)
-    have h_preimage := h_tendsto_top h_nhds
-    rw [Filter.mem_map, Filter.mem_atTop_sets] at h_preimage
-    obtain ⟨N, hN⟩ := h_preimage
-    -- Take s = max N t, then s ≥ N and s ≥ t
-    let s := max N t
-    have hs_ge_N : N ≤ s := le_max_left N t
-    have hs_ge_t : t ≤ s := le_max_right N t
-    -- f(s) ∈ (1-ε, 1+ε)
-    have hs_in : f s ∈ Set.Ioo (1 - ε) (1 + ε) := hN s hs_ge_N
-    simp only [Set.mem_Ioo] at hs_in
-    -- f(t) ≤ f(s) by monotonicity
-    have hs_mono : f t ≤ f s := h_mono hs_ge_t
-    -- Connect f t with cdf_from_alpha
-    have h_eq_t : (f : ℝ → ℝ) t = cdf_from_alpha X hX_contract hX_meas hX_L2 ω t := rfl
-    -- f(s) < 1 + ε = 1 + (f(t) - 1)/2 = (f(t) + 1)/2
-    have h1 : f s < 1 + ε := hs_in.2
-    have h2 : 1 + ε = (cdf_from_alpha X hX_contract hX_meas hX_L2 ω t + 1) / 2 := by
-      simp [hε_def]; ring
-    -- f(t) ≤ f(s) < (f(t) + 1)/2
-    -- So f(t) < (f(t) + 1)/2, which means 2*f(t) < f(t) + 1, i.e., f(t) < 1.
-    -- But we assumed f(t) > 1, contradiction.
-    linarith [h1, h2, hs_mono, h_eq_t, h_gt]
 
 /-!
 ## A.e. endpoint limits for alphaIic

--- a/Exchangeability/DeFinetti/ViaL2/MainConvergence.lean
+++ b/Exchangeability/DeFinetti/ViaL2/MainConvergence.lean
@@ -802,9 +802,3 @@ theorem reverse_martingale_subsequence_convergence
   classical
   exact Helpers.subseq_ae_of_L1 alpha alpha_inf h_alpha_meas h_alpha_inf_meas h_integrable h_L1_conv
 
-/-! The critical path of the L² proof uses
-`directing_measure_satisfies_requirements` from `MoreL2Helpers.lean`; earlier
-`alpha_is_reverse_martingale` / `contractability_conditional_expectation` /
-`alpha_is_conditional_expectation_packaged` placeholders are not on that path
-and have been removed. -/
-

--- a/Exchangeability/DeFinetti/ViaL2/MoreL2Helpers.lean
+++ b/Exchangeability/DeFinetti/ViaL2/MoreL2Helpers.lean
@@ -1152,46 +1152,6 @@ lemma directing_measure_integral
   -- Use the simplified identification chain approach (Kallenberg-aligned)
   directing_measure_integral_via_chain X hX_contract hX_meas hX_L2 f hf_meas hf_bdd
 
-/-- **Packaged directing measure theorem:** Existence of a directing kernel with all
-key properties bundled together.
-
-For a contractable sequence X on ℝ, there exists:
-1. A limit function α ∈ L¹ that is the L¹ limit of Cesàro averages
-2. A random probability measure ν(·) on ℝ (the directing measure)
-3. The identification α = ∫ f dν a.e.
-
-This packages the outputs of `directing_measure` and `directing_measure_integral`
-into a single existential statement that is convenient for applications.
-
-**Proof:** Follows directly from `directing_measure_integral` which provides
-the limit α and its identification with ∫ f dν, combined with
-`directing_measure_isProbabilityMeasure` and `directing_measure_measurable`.
--/
-lemma alpha_is_conditional_expectation_packaged
-  {Ω : Type*} [MeasurableSpace Ω] [StandardBorelSpace Ω]
-  {μ : Measure Ω} [IsProbabilityMeasure μ]
-  (X : ℕ → Ω → ℝ) (hX_contract : Contractable μ X)
-  (hX_meas : ∀ i, Measurable (X i))
-  (hX_L2 : ∀ i, MemLp (X i) 2 μ)
-  (f : ℝ → ℝ) (hf_meas : Measurable f)
-  (hf_bdd : ∃ C, ∀ x, |f x| ≤ C) :
-  ∃ (alpha : Ω → ℝ) (nu : Ω → Measure ℝ),
-    Measurable alpha ∧
-    MemLp alpha 1 μ ∧
-    (∀ ω, IsProbabilityMeasure (nu ω)) ∧
-    (∀ s, MeasurableSet s → Measurable (fun ω => nu ω s)) ∧
-    -- L¹ convergence: Cesàro averages converge to alpha
-    (∀ n, ∀ ε > 0, ∃ M : ℕ, ∀ m : ℕ, m ≥ M →
-      ∫ ω, |(1/(m:ℝ)) * ∑ k : Fin m, f (X (n + k.val + 1) ω) - alpha ω| ∂μ < ε) ∧
-    -- Identification: alpha equals the integral against nu
-    (∀ᵐ ω ∂μ, alpha ω = ∫ x, f x ∂(nu ω)) := by
-  -- Use directing_measure for nu and directing_measure_integral for alpha
-  obtain ⟨alpha, hα_meas, hα_L1, hα_conv, hα_eq⟩ :=
-    directing_measure_integral X hX_contract hX_meas hX_L2 f hf_meas hf_bdd
-  refine ⟨alpha, directing_measure X hX_contract hX_meas hX_L2, hα_meas, hα_L1, ?_, ?_, hα_conv, hα_eq⟩
-  · exact directing_measure_isProbabilityMeasure X hX_contract hX_meas hX_L2
-  · exact fun s hs => directing_measure_measurable X hX_contract hX_meas hX_L2 s hs
-
 /-- The integral of `alphaIic` equals the marginal probability.
 
 By the L¹ convergence property of the Cesàro averages and contractability


### PR DESCRIPTION
## Summary

Follow-up cleanup after #37 / #38. Four decls have zero callers anywhere in the codebase and are removed.

| File | Decl | Why dead |
|---|---|---|
| `DirectingMeasureCore.lean` | `cdf_from_alpha_mono` | `(stieltjesOfMeasurableRat …).mono` suffices directly |
| `DirectingMeasureCore.lean` | `cdf_from_alpha_rightContinuous` | `(stieltjesOfMeasurableRat …).right_continuous` suffices |
| `DirectingMeasureCore.lean` | `cdf_from_alpha_bounds` | 100+ lines manually deriving `0 ≤ F ≤ 1`; never used |
| `MoreL2Helpers.lean` | `alpha_is_conditional_expectation_packaged` | bundle never consumed; critical path uses `directing_measure_satisfies_requirements` |

Two stale notes referencing the deleted packaged lemma (in `BlockAverages.lean` and `MainConvergence.lean`) also removed.

Module docstring in `DirectingMeasureCore.lean` updated: monotonicity, right-continuity, and bounds on the CDF are now noted as inherited from mathlib's `stieltjesOfMeasurableRat`.

## Verification

- `lake build` clean (3526/3526 jobs).
- `#print axioms deFinetti_viaL2` → `[propext, Classical.choice, Quot.sound]`.
- 0 sorries in touched files.
- Net **−178 lines** (3 insertions, 181 deletions across 4 files).

## Test plan

- [x] `lake build` clean from a fresh state
- [x] Axiom check on top-level `deFinetti_viaL2`
- [x] Zero-caller verification on all four deleted decls
- [x] User review