### PR TITLE
chore: LSP-vetted proof golf batch (−29 lines)

### DIFF
--- a/Exchangeability/Core.lean
+++ b/Exchangeability/Core.lean
@@ -222,15 +222,7 @@ lemma cylinder_subset_prefixCylinders {s : Finset ℕ} {S : Set (∀ _ : s, α)}
   have hpull_meas : Measurable pull := by fun_prop
   have hs_eq :
       MeasureTheory.cylinder (α:=fun _ : ℕ => α) s S =
-        prefixCylinder (α:=α) (pull ⁻¹' S) := by
-    ext x
-    classical
-    have hpull : pull (prefixProj (α:=α) N x) = s.restrict x := by
-      funext y
-      rcases y with ⟨y, hy⟩
-      simp only [pull, prefixProj, Finset.restrict]
-      rfl
-    simp [MeasureTheory.cylinder, prefixCylinder, hpull]
+        prefixCylinder (α:=α) (pull ⁻¹' S) := rfl
   refine hs_eq ▸ prefixCylinder_mem_prefixCylinders (α:=α) ?_
   exact hpull_meas hS
 

--- a/Exchangeability/DeFinetti/ViaKoopman/CesaroL2ToL1.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/CesaroL2ToL1.lean
@@ -463,12 +463,7 @@ lemma optionB_Step4c_triangle
             _ = Cg := by field_simp
         -- Bounded + Measurable → Integrable on finite measure space
         have hB_meas : Measurable (B n) := by
-          rw [hB_def]
-          simp [hn]
-          -- (1/n) * ∑_{j < n} g(ω j) is measurable
-          refine Measurable.const_mul ?_ _
-          refine Finset.measurable_sum (Finset.range n) (fun j _ => ?_)
-          exact Measurable.comp hg_meas (measurable_pi_apply j)
+          rw [hB_def]; simp [hn]; fun_prop
         have hB_bd_ae : ∀ᵐ ω ∂μ, ‖B n ω‖ ≤ Cg := ae_of_all μ (fun ω => le_trans (Real.norm_eq_abs _).le (hB_bd ω))
         exact ⟨hB_meas.aestronglyMeasurable, HasFiniteIntegral.of_bounded hB_bd_ae⟩
     -- |B n - Y| is integrable as difference of integrable functions
@@ -530,20 +525,12 @@ lemma optionB_Step4c_triangle
               ≤ |A n ω| + |B n ω| := abs_sub _ _
             _ ≤ Cg + Cg := by gcongr
             _ = 2 * Cg := by ring
-      have hA_meas : Measurable (A n) := by
-        rw [hA_def]
-        simp
-        refine Measurable.const_mul ?_ _
-        refine Finset.measurable_sum (Finset.range (n + 1)) (fun j _ => ?_)
-        exact Measurable.comp hg_meas (measurable_pi_apply j)
+      have hA_meas : Measurable (A n) := by rw [hA_def]; simp; fun_prop
       have hB_meas : Measurable (B n) := by
         rw [hB_def]
         by_cases hn : n = 0
         · simp [hn]
-        · simp [hn]
-          refine Measurable.const_mul ?_ _
-          refine Finset.measurable_sum (Finset.range n) (fun j _ => ?_)
-          exact Measurable.comp hg_meas (measurable_pi_apply j)
+        · simp [hn]; fun_prop
       have hAB_bd_ae : ∀ᵐ ω ∂μ, ‖|A n ω - B n ω|‖ ≤ 2 * Cg :=
         ae_of_all μ (fun ω => by simp [Real.norm_eq_abs]; exact hAB_bd ω)
       exact ⟨(hA_meas.sub hB_meas).norm.aestronglyMeasurable, HasFiniteIntegral.of_bounded hAB_bd_ae⟩

--- a/Exchangeability/DeFinetti/ViaKoopman/CesaroL2ToL1.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/CesaroL2ToL1.lean
@@ -463,7 +463,9 @@ lemma optionB_Step4c_triangle
             _ = Cg := by field_simp
         -- Bounded + Measurable → Integrable on finite measure space
         have hB_meas : Measurable (B n) := by
-          rw [hB_def]; simp [hn]; fun_prop
+          rw [hB_def]
+          simp [hn]
+          fun_prop
         have hB_bd_ae : ∀ᵐ ω ∂μ, ‖B n ω‖ ≤ Cg := ae_of_all μ (fun ω => le_trans (Real.norm_eq_abs _).le (hB_bd ω))
         exact ⟨hB_meas.aestronglyMeasurable, HasFiniteIntegral.of_bounded hB_bd_ae⟩
     -- |B n - Y| is integrable as difference of integrable functions
@@ -530,7 +532,8 @@ lemma optionB_Step4c_triangle
         rw [hB_def]
         by_cases hn : n = 0
         · simp [hn]
-        · simp [hn]; fun_prop
+        · simp [hn]
+          fun_prop
       have hAB_bd_ae : ∀ᵐ ω ∂μ, ‖|A n ω - B n ω|‖ ≤ 2 * Cg :=
         ae_of_all μ (fun ω => by simp [Real.norm_eq_abs]; exact hAB_bd ω)
       exact ⟨(hA_meas.sub hB_meas).norm.aestronglyMeasurable, HasFiniteIntegral.of_bounded hAB_bd_ae⟩

--- a/Exchangeability/DeFinetti/ViaKoopman/DirectingKernel.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/DirectingKernel.lean
@@ -88,9 +88,7 @@ lemma ν_eval_measurable
 instance ν_isProbabilityMeasure
     {μ : Measure (Ω[α])} [IsProbabilityMeasure μ] [StandardBorelSpace α]
     (ω : Ω[α]) : IsProbabilityMeasure (ν (μ := μ) ω) := by
-  simp only [ν]
-  -- rcdKernel is a Markov kernel (composition of map and comap preserves this)
-  exact IsMarkovKernel.isProbabilityMeasure ω
+  unfold ν; infer_instance
 
 /-! ## Bridge lemmas -/
 
@@ -103,15 +101,9 @@ lemma integral_ν_eq_integral_condExpKernel
     {μ : Measure (Ω[α])} [IsProbabilityMeasure μ] [StandardBorelSpace α]
     (ω : Ω[α]) {f : α → ℝ} (hf : Measurable f) :
     ∫ x, f x ∂(ν (μ := μ) ω) = ∫ y, f (y 0) ∂(condExpKernel μ (shiftInvariantSigma (α := α)) ω) := by
-  -- By definition: ν ω = Kernel.comap (Kernel.map (condExpKernel μ ...) π₀) id ... ω
-  -- Kernel.comap with id is just evaluation, so: ν ω = (Kernel.map (condExpKernel μ ...) π₀) ω
-  -- Kernel.map_apply gives: (Kernel.map κ f) a = (κ a).map f
-  -- So: ν ω = ((condExpKernel μ ...) ω).map π₀
-  -- Then integral_map gives: ∫ f d(μ.map g) = ∫ (f ∘ g) dμ
   unfold ν rcdKernel
   rw [Kernel.comap_apply]
   rw [Kernel.map_apply _ (measurable_pi0 (α := α))]
-  -- Now: ∫ x, f x ∂((condExpKernel ... ω).map π₀) = ∫ y, f (y 0) ∂(condExpKernel ... ω)
   unfold π0
   rw [MeasureTheory.integral_map (measurable_pi_apply 0).aemeasurable hf.aestronglyMeasurable]
   rfl

--- a/Exchangeability/DeFinetti/ViaKoopman/DirectingKernel.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/DirectingKernel.lean
@@ -88,7 +88,8 @@ lemma ν_eval_measurable
 instance ν_isProbabilityMeasure
     {μ : Measure (Ω[α])} [IsProbabilityMeasure μ] [StandardBorelSpace α]
     (ω : Ω[α]) : IsProbabilityMeasure (ν (μ := μ) ω) := by
-  unfold ν; infer_instance
+  unfold ν
+  infer_instance
 
 /-! ## Bridge lemmas -/
 


### PR DESCRIPTION
## Summary

Small safe proof-simplification batch from the reviewer's list. Each change verified to compile via Lean LSP before committing.

| File | Change |
|---|---|
| `Core.lean` | `cylinder_subset_prefixCylinders`: the `hs_eq` cylinder equality closes by `rfl` (was an 11-line `ext` / `funext` / `simp` argument unfolding the same defeq the closure already performs). |
| `ViaKoopman/CesaroL2ToL1.lean` | Three explicit `Measurable.const_mul` / `Finset.measurable_sum` chains for block-average measurability collapse to `fun_prop`. |
| `ViaKoopman/DirectingKernel.lean` | `ν_isProbabilityMeasure`: body simplified from `simp only [ν]; exact IsMarkovKernel.isProbabilityMeasure ω` to `unfold ν; infer_instance`. |

## Reviewer candidates that did NOT pan out

Kept the original proofs for these three — included for transparency:

- `rcdKernel_isMarkovKernel` with `infer_instance` alone fails instance synthesis on the `comap`-wrapped form (`IsMarkovKernel (((condExpKernel μ shiftInvariantSigma).map π0).comap id ⋯)`). The original explicit `Kernel.IsMarkovKernel.map ∘ Kernel.IsMarkovKernel.comap` chain stays.
- `integral_ν_eq_integral_condExpKernel` one-liner `simpa [ν, rcdKernel, π0] using integral_map ...` hits a type mismatch in `aestronglyMeasurable` elaboration. The original unfold+rewrite chain stays.
- `blockAvg_measurable_tailFamily` (`unfold blockAvg; fun_prop`) — `fun_prop` can't discharge the `tailFamily`-conditioned measurability claim. The original `iSup`/`comap` chain stays.

## Verification

- `lake build` clean (3516/3516 jobs).
- `#print axioms deFinetti_viaL2` / `deFinetti_viaKoopman` → `[propext, Classical.choice, Quot.sound]`.
- `lake exe checkdecls blueprint/lean_decls` exits **0**.
- 0 sorries in touched files.
- **Net −29 lines across 3 files.**

## Diff stat

```
3 files changed, 5 insertions(+), 34 deletions(-)
```

## Test plan

- [x] `lake build` clean from a fresh state
- [x] Axiom check on top-level theorems
- [x] LSP verified each surviving change before commit
- [x] `lake exe checkdecls blueprint/lean_decls` exits 0
- [x] User review