### PR TITLE
chore: drop dead exchangeable_path_of_exchangeable + small cylinder golf (−26 lines)

### DIFF
--- a/Exchangeability/DeFinetti/TheoremViaKoopman.lean
+++ b/Exchangeability/DeFinetti/TheoremViaKoopman.lean
@@ -72,28 +72,6 @@ exchangeability implies full exchangeability (via `exchangeable_iff_fullyExchang
 gives path measure exchangeability needed for the ergodic machinery.
 -/
 
-/-- Exchangeability of X implies exchangeability of the path measure μ_path.
-
-This follows from `exchangeable_iff_fullyExchangeable` and `fullyExchangeable_iff_pathLaw_invariant`.
--/
-lemma exchangeable_path_of_exchangeable
-    (μ : Measure Ω) [IsProbabilityMeasure μ]
-    (X : ℕ → Ω → ℝ) (hX_meas : ∀ i, Measurable (X i))
-    (hExch : Exchangeable μ X) :
-    ∀ π : Equiv.Perm ℕ,
-      Measure.map (reindex π) (μ_path μ X) = μ_path μ X := by
-  -- Exchangeable → FullyExchangeable (via π-system uniqueness)
-  have hFull : FullyExchangeable μ X :=
-    (exchangeable_iff_fullyExchangeable hX_meas).mp hExch
-  -- FullyExchangeable → path law is permutation-invariant
-  have hPathInv := (fullyExchangeable_iff_pathLaw_invariant hX_meas).mp hFull
-  -- μ_path μ X = pathLaw μ X (same definition)
-  intro π
-  -- pathLaw μ X = Measure.map (fun ω i => X i ω) μ
-  -- μ_path μ X = Measure.map (pathify X) μ where pathify X ω n = X n ω
-  -- These are definitionally equal
-  convert hPathInv π using 2
-
 @[nolint unusedArguments]
 lemma deFinetti_RyllNardzewski_equivalence_viaKoopman
     (μ : Measure Ω) [IsProbabilityMeasure μ]

--- a/Exchangeability/PathSpace/CylinderHelpers.lean
+++ b/Exchangeability/PathSpace/CylinderHelpers.lean
@@ -58,11 +58,7 @@ lemma cylinder_measurable {r : ℕ} {C : Fin r → Set α}
     MeasurableSet (cylinder (α:=α) r C) := by
   classical
   simp only [cylinder, Set.setOf_forall]
-  exact MeasurableSet.iInter fun i => by
-    have : (fun f : ℕ → α => f i.val) ⁻¹' C i = {f | f i ∈ C i} := by
-      ext f; simp [Set.mem_preimage]
-    rw [← this]
-    exact (hC i).preimage (measurable_pi_apply i.val)
+  exact MeasurableSet.iInter fun i => (hC i).preimage (measurable_pi_apply i.val)
 
 end FutureCylinders
 


### PR DESCRIPTION
## Summary

Reviewer-flagged leftover cleanup after the post-#50 sweep.

### `DeFinetti/TheoremViaKoopman.lean`

- **`exchangeable_path_of_exchangeable`** (22 lines + docstring): only declaration-only references; the path-measure exchangeability fact is already consumed inline at the one site that needed it (`deFinetti_RyllNardzewski_equivalence_viaKoopman`).

### `PathSpace/CylinderHelpers.lean`

- **`cylinder_measurable`**: drops a 5-line `have`/`rw` step that re-derived the trivial preimage equality `(fun f => f i.val) ⁻¹' C i = {f | f i ∈ C i}`. The closing `(hC i).preimage (measurable_pi_apply i.val)` already produces the measurable set the goal asks for after the `setOf_forall` rewrite.

### Skipped from the reviewer's list

- `firstRCylinder_measurable_ambient` at `CylinderHelpers.lean:107` — current body is already a tight one-step idiom via `setOf_forall` + `iInter`; `measurability` / `fun_prop` close it too but don't shorten the proof.

## Verification

- `lake build` clean (3516/3516 jobs).
- `#print axioms deFinetti_viaKoopman` → `[propext, Classical.choice, Quot.sound]`.
- `lake exe checkdecls blueprint/lean_decls` exits **0**.
- 0 sorries in touched files.
- **Net −26 lines across 2 files.**

## Diff stat

```
2 files changed, 1 insertion(+), 27 deletions(-)
```

## Test plan

- [x] `lake build` clean from a fresh state
- [x] Axiom check on `deFinetti_viaKoopman`
- [x] LSP verified `cylinder_measurable` simplification before commit
- [x] `lake exe checkdecls blueprint/lean_decls` exits 0
- [x] User review