### PR TITLE
chore: small fun_prop / measurability sweep (−3 lines)

### DIFF
--- a/Exchangeability/DeFinetti/ViaKoopman/CesaroPairFactorization.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/CesaroPairFactorization.lean
@@ -142,8 +142,7 @@ private theorem h_tower_of_lagConst_from_one
       -- Using integral_map: ∫ h d(μ.map shift) = ∫ (h ∘ shift) dμ
       -- Since hσ.map_eq : μ.map shift = μ, we get ∫ h dμ = ∫ (h ∘ shift) dμ
       have hh_asm : AEStronglyMeasurable (fun ω => |A n ω - Y ω|) μ := by
-        have hA_meas : Measurable (A n) :=
-          measurable_const.mul (Finset.measurable_sum _ fun j _ => hg_meas.comp (measurable_pi_apply j))
+        have hA_meas : Measurable (A n) := by fun_prop
         have h_diff : AEStronglyMeasurable (fun ω => A n ω - Y ω) μ :=
           hA_meas.aestronglyMeasurable.sub integrable_condExp.aestronglyMeasurable
         exact continuous_abs.comp_aestronglyMeasurable h_diff

--- a/Exchangeability/PathSpace/CylinderHelpers.lean
+++ b/Exchangeability/PathSpace/CylinderHelpers.lean
@@ -87,11 +87,9 @@ lemma firstRCylinder_measurable_in_firstRSigma
     (X : ℕ → Ω → α) (r : ℕ) (C : Fin r → Set α)
     (hC : ∀ i, MeasurableSet (C i)) :
     MeasurableSet[firstRSigma X r] (firstRCylinder X r C) := by
-  -- firstRSigma X r = comap (firstRMap X r); express firstRCylinder as a preimage.
   refine ⟨{f : Fin r → α | ∀ i, f i ∈ C i}, ?_, rfl⟩
   classical
-  rw [Set.setOf_forall]
-  exact MeasurableSet.iInter fun i => (hC i).preimage (measurable_pi_apply i)
+  measurability
 
 /-- **Measurable in the ambient σ‑algebra.**
 If each coordinate `X i` is measurable, then the block cylinder is measurable


### PR DESCRIPTION
## Summary

LSP-vetted sweep of reviewer-flagged candidates. Per the pattern with earlier such reviews, most candidates didn't actually compile despite optimistic LSP claims; this PR commits only the two that survived a real `lake build`.

## Applied

| Site | Change |
|---|---|
| `PathSpace/CylinderHelpers.lean` `firstRCylinder_measurable_in_firstRSigma` | 4-line `rw`/`exact` chain (`Set.setOf_forall` + `MeasurableSet.iInter`) → 1-line `measurability` after the `refine` step |
| `ViaKoopman/CesaroPairFactorization.lean:145` local `hA_meas` | 2-line explicit `measurable_const.mul (Finset.measurable_sum ...)` chain → `by fun_prop` |

## Not applied (LSP suggestions that failed on actual build)

For transparency:

- **`cylinder_measurable`** (`PathSpace/CylinderHelpers.lean:56`) — `fun_prop` errors with `MeasurableSet (cylinder r C) is not a fun_prop goal`, and `measurability` exits with `aesop failed`. Kept the original 3-line `simp only` + `exact` chain.
- **`firstRCylinder_measurable_ambient`** (`PathSpace/CylinderHelpers.lean:100`) — `unfold firstRCylinder; measurability` works but doesn't shorten; net change 0 LoC. Kept original.
- **`measurable_blockAvg`** (`ViaKoopman/BlockAverage.lean:86`) — `unfold blockAvg; fun_prop` fails on the dependent `if hn : n = 0` shape. Kept the original `by_cases hn` + explicit measurability chain.
- **`blockAvg_measurable_tailFamily`** (`ViaL2/CesaroConvergence.lean:1816`) — `fun_prop` can't discharge the `TailSigma.tailFamily X m`-conditioned claim (the same site failed in #53). Kept the `iSup` / `comap` chain.

`AlphaConvergence.lean:414` skipped per upcoming AlphaConvergence factoring PR — would touch the same lines twice.

## Verification

- `lake build` clean (3516/3516 jobs).
- `#print axioms` on `deFinetti_viaL2` / `deFinetti_viaKoopman` → standard.
- `lake exe checkdecls blueprint/lean_decls` exits **0**.
- 0 sorries in touched files.
- **Net −3 lines across 2 files.**

## Diff stat

```
2 files changed, 2 insertions(+), 5 deletions(-)
```

## Test plan

- [x] `lake build` clean from a fresh state
- [x] Each applied change verified by `lake env lean <file>` per-site
- [x] Each not-applied candidate explicitly tested and documented as failing
- [x] `lake exe checkdecls blueprint/lean_decls` exits 0
- [x] User review