### PR TITLE
Koopman theorem signatures: drop unused hX_L2 hypothesis

### DIFF
--- a/Exchangeability/DeFinetti/TheoremViaKoopman.lean
+++ b/Exchangeability/DeFinetti/TheoremViaKoopman.lean
@@ -72,12 +72,9 @@ exchangeability implies full exchangeability (via `exchangeable_iff_fullyExchang
 gives path measure exchangeability needed for the ergodic machinery.
 -/
 
-set_option linter.unusedVariables false in
-@[nolint unusedArguments]
 lemma deFinetti_RyllNardzewski_equivalence_viaKoopman
     (μ : Measure Ω) [IsProbabilityMeasure μ]
-    (X : ℕ → Ω → ℝ) (hX_meas : ∀ i, Measurable (X i))
-    (hX_L2 : ∀ i, MemLp (X i) 2 μ) :
+    (X : ℕ → Ω → ℝ) (hX_meas : ∀ i, Measurable (X i)) :
     Contractable μ X ↔ Exchangeable μ X ∧ ConditionallyIID μ X := by
   constructor
   · -- Forward: Contractable → Exchangeable ∧ ConditionallyIID
@@ -121,10 +118,9 @@ lemma deFinetti_RyllNardzewski_equivalence_viaKoopman
 theorem deFinetti_viaKoopman
     (μ : Measure Ω) [IsProbabilityMeasure μ]
     (X : ℕ → Ω → ℝ) (hX_meas : ∀ i, Measurable (X i))
-    (hX_exch : Exchangeable μ X)
-    (hX_L2 : ∀ i, MemLp (X i) 2 μ) :
+    (hX_exch : Exchangeable μ X) :
     ConditionallyIID μ X :=
-  ((deFinetti_RyllNardzewski_equivalence_viaKoopman μ X hX_meas hX_L2).mp
+  ((deFinetti_RyllNardzewski_equivalence_viaKoopman μ X hX_meas).mp
     (contractable_of_exchangeable hX_exch hX_meas)).2
 
 /-- **Contractable implies conditionally i.i.d.** (via Koopman).
@@ -136,9 +132,8 @@ theorem deFinetti_viaKoopman
 theorem conditionallyIID_of_contractable_viaKoopman
     (μ : Measure Ω) [IsProbabilityMeasure μ]
     (X : ℕ → Ω → ℝ) (hX_meas : ∀ i, Measurable (X i))
-    (hContract : Contractable μ X)
-    (hX_L2 : ∀ i, MemLp (X i) 2 μ) :
-    ConditionallyIID μ X := by
-  exact ((deFinetti_RyllNardzewski_equivalence_viaKoopman μ X hX_meas hX_L2).mp hContract).2
+    (hContract : Contractable μ X) :
+    ConditionallyIID μ X :=
+  ((deFinetti_RyllNardzewski_equivalence_viaKoopman μ X hX_meas).mp hContract).2
 
 end Exchangeability.DeFinetti


### PR DESCRIPTION
## Summary

The Koopman proof does not use the L² hypothesis. Carrying `hX_L2 : ∀ i, MemLp (X i) 2 μ` in the public theorem signatures was a parity-with-ViaL2 convenience, not a mathematical requirement. Drop it.

The proof chain in `TheoremViaKoopman.lean` runs:

```
hContract
→ pathSpace_contractable_of_contractable
→ pathSpace_shift_preserving_of_contractable
→ conditionallyIID_bind_of_contractable
→ conditionallyIID_transfer
```

No step consumes `hX_L2`; previously it was kept only to silence by being passed through, with a `set_option linter.unusedVariables false in` + `@[nolint unusedArguments]` suppression on the equivalence lemma.

## Changes

Three signatures updated in `Exchangeability/DeFinetti/TheoremViaKoopman.lean`:

| Theorem | Before | After |
|---|---|---|
| `deFinetti_RyllNardzewski_equivalence_viaKoopman` | … `(hX_meas) (hX_L2)` | … `(hX_meas)` |
| `deFinetti_viaKoopman` | … `(hX_meas) (hX_exch) (hX_L2)` | … `(hX_meas) (hX_exch)` |
| `conditionallyIID_of_contractable_viaKoopman` | … `(hX_meas) (hContract) (hX_L2)` | … `(hX_meas) (hContract)` |

Both linter-suppression lines on the equivalence lemma are removed with the hypothesis.

## Callers

- No in-repo callers (search across `Exchangeability/` returned only the definitions).
- `blueprint/lean_decls` and `blueprint/src/content.tex` only name `conditionallyIID_of_contractable_viaKoopman` as a declaration; both still resolve.

## Verification

- `lake build` clean (3516/3516, **0 warnings**).
- `lake exe checkdecls blueprint/lean_decls` exits 0.
- `#print axioms` on all three theorems: `[propext, Classical.choice, Quot.sound]`.

## Test plan
- [x] `lake build` clean
- [x] `lake exe checkdecls blueprint/lean_decls` exits 0
- [x] `#print axioms` on `deFinetti_viaKoopman` / `deFinetti_RyllNardzewski_equivalence_viaKoopman` / `conditionallyIID_of_contractable_viaKoopman` unchanged