### PR TITLE
Inline trivial metProjectionShift_*_fixedSubspace wrappers (−16 lines)

### DIFF
--- a/Exchangeability/Ergodic/InvariantSigma.lean
+++ b/Exchangeability/Ergodic/InvariantSigma.lean
@@ -363,22 +363,6 @@ lemma metProjectionShift_tendsto
   have hlimit := ContinuousLinearMap.tendsto_birkhoffAverage_orthogonalProjection K hnorm f
   convert hlimit using 1
 
-/-- The range of `metProjectionShift` equals the fixed subspace. -/
-lemma metProjectionShift_range_fixedSubspace
-    {μ : Measure (Ω[α])} [IsProbabilityMeasure μ]
-    (hσ : MeasurePreserving shift μ μ) :
-    Set.range (metProjectionShift (μ := μ) hσ) =
-      (fixedSubspace hσ : Set (Lp ℝ 2 μ)) :=
-  metProjectionShift_range (μ := μ) hσ
-
-/-- `metProjectionShift` fixes elements of the fixed subspace. -/
-lemma metProjectionShift_fixes_fixedSubspace
-    {μ : Measure (Ω[α])} [IsProbabilityMeasure μ]
-    (hσ : MeasurePreserving shift μ μ) {g : Lp ℝ 2 μ}
-    (hg : g ∈ fixedSubspace hσ) :
-    metProjectionShift (μ := μ) hσ g = g :=
-  metProjectionShift_fixed (μ := μ) hσ hg
-
 /-- Conditional expectation on L² with respect to the shift-invariant σ-algebra.
 
 This is the orthogonal projection onto the subspace of shift-invariant L² functions,
@@ -552,9 +536,9 @@ theorem proj_eq_condexp {μ : Measure (Ω[α])} [IsProbabilityMeasure μ]
   have h_symm_MET : (metProjectionShift hσ).IsSymmetric :=
     metProjectionShift_isSymmetric hσ
   have h_range_MET : Set.range (metProjectionShift hσ) = (fixedSubspace hσ : Set (Lp ℝ 2 μ)) :=
-    metProjectionShift_range_fixedSubspace hσ
+    metProjectionShift_range hσ
   have h_fixes_MET : ∀ g ∈ fixedSubspace hσ, metProjectionShift hσ g = g :=
-    fun g hg => metProjectionShift_fixes_fixedSubspace hσ hg
+    fun _ hg => metProjectionShift_fixed hσ hg
 
   -- Establish condexpL2 properties (via helper)
   obtain ⟨h_idem_cond, h_symm_cond, h_range_cond, h_fixes_cond⟩ :=


### PR DESCRIPTION
## Summary

`metProjectionShift_range_fixedSubspace` and `metProjectionShift_fixes_fixedSubspace` in `Exchangeability/Ergodic/InvariantSigma.lean` are one-line aliases:

```lean
metProjectionShift_range_fixedSubspace hσ
  := metProjectionShift_range hσ
metProjectionShift_fixes_fixedSubspace hσ hg
  := metProjectionShift_fixed hσ hg
```

PR #63 removed the last external caller (`KoopmanCommutation.lean`). The only remaining uses lived inside the same file, in `proj_eq_condexp`. Inline those two calls and drop the wrappers.

## Changes

`Exchangeability/Ergodic/InvariantSigma.lean`: −18 / +2 lines, one file.
- Delete the two wrapper lemmas (~15 lines incl. docstrings).
- In `proj_eq_condexp`, replace `metProjectionShift_range_fixedSubspace hσ` with `metProjectionShift_range hσ` and `fun g hg => metProjectionShift_fixes_fixedSubspace hσ hg` with `fun _ hg => metProjectionShift_fixed hσ hg`.

## Verification

- `lake build` clean (3516/3516, **0 warnings**).
- `lake exe checkdecls blueprint/lean_decls` exits 0.
- `#print axioms` on `deFinetti_viaL2`, `deFinetti`, `deFinetti_viaKoopman`: `[propext, Classical.choice, Quot.sound]`.

## Test plan
- [x] `lake build` clean
- [x] `lake exe checkdecls blueprint/lean_decls` exits 0
- [x] `#print axioms` on the three main theorems unchanged