### PR TITLE
Drop unused DirectingMeasure scaffold (−14 net lines)

### DIFF
--- a/Exchangeability/DeFinetti.lean
+++ b/Exchangeability/DeFinetti.lean
@@ -90,26 +90,12 @@ This expresses that:
 - **Proved in ConditionallyIID.lean**: `exchangeable_of_conditionallyIID`
 - **For de Finetti**: The kernel is tail-measurable (constructed via ergodic theory)
 
-### DirectingMeasure structure
-
-An alternative bundled formulation that explicitly carries the kernel and its properties.
+The theorem-facing abstraction is the existential `ConditionallyIID` above. Each
+route builds the directing object through its own route-specific construction
+(`ViaMartingale.directingMeasure_*`, `ViaL2.directing_measure_satisfies_requirements`,
+`ViaKoopman.conditionallyIID_bind_of_contractable`); there is intentionally no
+shared bundled wrapper.
 -/
-
-/-- A directing measure for a process `X` is a tail-measurable Markov kernel.
-
-This bundles the kernel with its key properties needed for de Finetti's theorem.
-
-**Note**: This is an alternative formulation that explicitly carries the kernel.
-The main `ConditionallyIID` definition is existential and doesn't expose the kernel.
--/
-structure DirectingMeasure (μ : Measure Ω) [IsProbabilityMeasure μ] (X : ℕ → Ω → α) where
-  /-- The probability kernel -/
-  kernel : ProbabilityTheory.Kernel Ω α
-  /-- The kernel is a Markov kernel (maps to probability measures) -/
-  is_markov : ProbabilityTheory.IsMarkovKernel kernel
-  -- Tail measurability would be expressed as:
-  -- is_tail_measurable : @AEStronglyMeasurable' _ _ (tailSigmaAlgebra X) _ _ (fun ω ↦ kernel ω) μ
-  -- Note: tail measurability constraint would be added with proper tail σ-algebra infrastructure
 
 /-!
 ## Main theorem statements


### PR DESCRIPTION
## Summary

Delete the bundled `structure DirectingMeasure` in `Exchangeability/DeFinetti.lean` and the adjacent `### DirectingMeasure structure` doc block. Replace with a one-sentence pointer to the existential `ConditionallyIID` interface and the route-specific constructions that are actually used.

This is **public-API** scaffolding, but it is unused public API (no in-repo callers, no blueprint reference) and was never finished. Flagging in case external consumers exist.

## Why

The structure had:
- 2 fields (`kernel`, `is_markov`) plus a commented-out `is_tail_measurable` with an explicit TODO note.
- Zero callers in `Exchangeability/`.
- No reference in `blueprint/lean_decls` or `blueprint/src/content.tex`. (The blueprint references `ViaMartingale.directingMeasure_isProb` and `directingMeasure_measurable_eval` — concrete lemmas in the martingale route, unrelated to the deleted structure.)
- A docstring that itself called it "an alternative formulation" parallel to the main existential `ConditionallyIID`.

The three active routes each build their directing object through route-specific constructions:
- `ViaMartingale.directingMeasure_*` (concrete kernel)
- `ViaL2.directing_measure_satisfies_requirements`
- `ViaKoopman.conditionallyIID_bind_of_contractable`

There is no plan to unify them through this bundled wrapper. If a unifying API is wanted later, building on the existential `ConditionallyIID` or one of the concrete kernels is a better starting point than fixing an incomplete 2-field stub.

The lowercase `ViaMartingale.directingMeasure` is a distinct, live construction and remains.

## Verification

- `lake build` clean (3516/3516, **0 warnings**).
- `grep -rn "DirectingMeasure\b" Exchangeability/ --include="*.lean"` returns nothing.
- `lake exe checkdecls blueprint/lean_decls` exits 0.
- `#print axioms` on `deFinetti_viaL2`, `deFinetti`, `deFinetti_viaKoopman`: `[propext, Classical.choice, Quot.sound]`.

## Test plan
- [x] `lake build` clean
- [x] No live `DirectingMeasure` references remain
- [x] `lake exe checkdecls blueprint/lean_decls` exits 0
- [x] `#print axioms` on three main theorems unchanged