### PR TITLE
Drop 7 stale set_option maxHeartbeats overrides

### DIFF
--- a/Exchangeability/DeFinetti/ViaKoopman/CesaroL1Bounded.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/CesaroL1Bounded.lean
@@ -29,7 +29,6 @@ variable {α : Type*} [MeasurableSpace α]
 -- Short notation for shift-invariant σ-algebra (used throughout this file)
 local notation "mSI" => shiftInvariantSigma (α := α)
 
-set_option maxHeartbeats 8000000
 
 section CesaroL1Bounded
 

--- a/Exchangeability/DeFinetti/ViaKoopman/CesaroL2ToL1.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/CesaroL2ToL1.lean
@@ -41,7 +41,6 @@ local notation "mSI" => shiftInvariantSigma (α := α)
 These lemmas implement the bounded and general cases for L¹ convergence of Cesàro averages
 using the cylinder function approach (Option B). This avoids MET and sub-σ-algebra typeclass issues. -/
 
-set_option maxHeartbeats 8000000
 
 section OptionB_L2ToL1
 

--- a/Exchangeability/DeFinetti/ViaKoopman/CesaroPairFactorization.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/CesaroPairFactorization.lean
@@ -288,7 +288,6 @@ private theorem h_tower_of_lagConst_from_one
 
   exact h_ae_eq
 
-set_option maxHeartbeats 1000000
 
 /-- **Pair factorization via MET + Exchangeability** (Kallenberg's approach).
 

--- a/Exchangeability/DeFinetti/ViaKoopman/InfraLagConstancy.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/InfraLagConstancy.lean
@@ -260,7 +260,6 @@ lemma condExp_ae_eq_of_setIntegral_diff_eq_zero
   have h_eq := h_ce_sub.symm.trans h_ce_diff_zero
   exact h_eq.mono fun ω hω => sub_eq_zero.mp hω
 
-set_option maxHeartbeats 600000 in
 /-- **Lag-constancy from exchangeability via transpositions** (Kallenberg's approach).
 
 For EXCHANGEABLE measures μ on path space, the conditional expectation

--- a/Exchangeability/DeFinetti/ViaL2/AlphaConvergence.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaConvergence.lean
@@ -45,7 +45,6 @@ The key results that solve the endpoint limit problem:
 3. **A.e. endpoint limits**: Monotonicity + boundedness + L¹ limits ⇒ a.e. pointwise limits
 -/
 
-set_option maxHeartbeats 400000 in
 /-- **Identification lemma**: alphaIic equals alphaIicCE almost everywhere.
 
 **Proof strategy:**

--- a/Exchangeability/DeFinetti/ViaL2/CesaroConvergence.lean
+++ b/Exchangeability/DeFinetti/ViaL2/CesaroConvergence.lean
@@ -2100,7 +2100,6 @@ private lemma tendsto_setIntegral_of_L2_tendsto
   exact tendsto_setIntegral_of_L1' f (hf.integrable one_le_two)
     (Filter.univ_mem' hfn_int) h1 A
 
-set_option maxHeartbeats 2000000
 
 /-- **Cesàro averages converge in L² to a tail-measurable limit.**
 

--- a/Exchangeability/Probability/CondIndep/Bounded/Projection.lean
+++ b/Exchangeability/Probability/CondIndep/Bounded/Projection.lean
@@ -37,7 +37,6 @@ open MeasureTheory ProbabilityTheory Set Exchangeability.Probability
 variable {Ω α β γ : Type*}
 variable [MeasurableSpace Ω] [MeasurableSpace α] [MeasurableSpace β] [MeasurableSpace γ]
 
-set_option maxHeartbeats 500000 in
 /-- **Conditional expectation projection from conditional independence (helper).**
 
 When Y ⊥⊥_W Z, conditioning on (Z,W) gives the same result as conditioning on W alone


### PR DESCRIPTION
## Summary

After the recent factoring and golf PRs (PR #55–#65), none of the elevated heartbeat budgets in the project is still required. Audited all 7 sites by removing each and rebuilding the affected module; full project rebuild confirmed clean.

## Sites removed

| File | Budget | Form |
|---|---:|---|
| `Probability/CondIndep/Bounded/Projection.lean` | 500_000 | scoped (`in`) |
| `DeFinetti/ViaKoopman/CesaroL1Bounded.lean` | 8_000_000 | file-wide |
| `DeFinetti/ViaKoopman/InfraLagConstancy.lean` | 600_000 | scoped (`in`) |
| `DeFinetti/ViaKoopman/CesaroL2ToL1.lean` | 8_000_000 | file-wide |
| `DeFinetti/ViaKoopman/CesaroPairFactorization.lean` | 1_000_000 | file-wide |
| `DeFinetti/ViaL2/CesaroConvergence.lean` | 2_000_000 | file-wide |
| `DeFinetti/ViaL2/AlphaConvergence.lean` | 400_000 | scoped (`in`) |

Two of the seven were `set_option maxHeartbeats 8000000` (≈40× the default), which were the clearest smells.

## Verification

- `lake build` clean (3516/3516, **0 warnings**).
- `grep -rn "set_option maxHeartbeats" Exchangeability/` returns nothing.
- `lake exe checkdecls blueprint/lean_decls` exits 0.
- `#print axioms` on `deFinetti_viaL2`, `deFinetti`, `deFinetti_viaKoopman`: `[propext, Classical.choice, Quot.sound]`.

## Test plan
- [x] `lake build` clean
- [x] No remaining `set_option maxHeartbeats` lines
- [x] `lake exe checkdecls blueprint/lean_decls` exits 0
- [x] `#print axioms` on three main theorems unchanged