### PR TITLE
Drop 6 stale linter.unusedSectionVars suppressions

### DIFF
--- a/Exchangeability/Core.lean
+++ b/Exchangeability/Core.lean
@@ -165,13 +165,7 @@ end Extend
 
 section Measurable
 
-variable [MeasurableSpace α]
 
--- Disable false-positive linter warnings in this section:
--- Many theorems use `Measurable (Fin n → α)` which transitively depends on
--- `[MeasurableSpace α]` via `Pi.measurableSpace`, but the linter doesn't track
--- this transitive dependency and incorrectly suggests omitting `[MeasurableSpace α]`.
-set_option linter.unusedSectionVars false
 
 @[measurability, fun_prop, nolint unusedArguments]
 lemma takePrefix_measurable {m n : ℕ} (hmn : m ≤ n) :
@@ -343,14 +337,7 @@ uniqueness result, the full measures are equal.
 
 section Probability
 
-variable [MeasurableSpace Ω] [MeasurableSpace α]
 
--- Disable false-positive linter warnings in this section:
--- Many theorems use types like `Measurable (ℕ → α → β)` or `Measure (ℕ → α)` which
--- transitively depend on `[MeasurableSpace α]` via `Pi.measurableSpace`, but the
--- linter doesn't track this transitive dependency and incorrectly suggests omitting
--- `[MeasurableSpace Ω]` or `[MeasurableSpace α]`.
-set_option linter.unusedSectionVars false
 
 /--
 Reindex a sequence by applying a permutation to the indices.
@@ -360,6 +347,7 @@ Given a permutation `π` of ℕ and a sequence `x : ℕ → α`, returns the seq
 -/
 def reindex (π : Equiv.Perm ℕ) (x : ℕ → α) : ℕ → α := fun i => x (π i)
 
+omit [MeasurableSpace α] in
 @[simp, nolint unusedArguments]
 lemma reindex_apply {π : Equiv.Perm ℕ} (x : ℕ → α) (i : ℕ) :
     reindex (α:=α) π x i = x (π i) := rfl

--- a/Exchangeability/DeFinetti/L2Helpers.lean
+++ b/Exchangeability/DeFinetti/L2Helpers.lean
@@ -48,12 +48,6 @@ variable (X : ℕ → Ω → ℝ)
 variable (hX_contract : Contractable μ X)
 variable (hX_meas : ∀ i, Measurable (X i))
 
-/-
-Note: Some lemmas in this section explicitly include type and measurability parameters that shadow
-section variables. This makes certain section variables unused for those lemmas, requiring
-`set_option linter.unusedSectionVars false` before each affected declaration.
--/
-
 /-- The unique element of Fin 1. -/
 private def fin1Zero : Fin 1 := ⟨0, by decide⟩
 /-- First element of Fin 2. -/
@@ -71,7 +65,7 @@ private lemma measurable_eval_fin2 {i : Fin 2} :
     Measurable fun g : (Fin 2 → ℝ) => g i :=
   measurable_pi_apply _
 
-set_option linter.unusedSectionVars false in
+omit [IsProbabilityMeasure μ] in
 /-- **All marginals have the same distribution in a contractable sequence.**
 
 For a contractable sequence, the law of each coordinate agrees with the law of `X 0`.
@@ -130,7 +124,7 @@ private lemma strictMono_two {i j : ℕ} (hij : i < j) :
   subst ha; subst hb
   simp [fin2Zero, fin2One, hij]
 
-set_option linter.unusedSectionVars false in
+omit [IsProbabilityMeasure μ] in
 /-- **All bivariate marginals have the same distribution in a contractable sequence.**
 
 For a contractable sequence, every increasing pair `(i,j)` with `i < j` has the same
@@ -173,7 +167,7 @@ lemma contractable_map_pair (hX_contract : Contractable μ X) (hX_meas : ∀ i, 
     simp [eval, fin2Zero, fin2One]
   simpa [Function.comp, h_comp_simp, h_comp_simp'] using h_comp
 
-set_option linter.unusedSectionVars false in
+omit [IsProbabilityMeasure μ] in
 /-- **Contractability is preserved under measurable postcomposition.**
 
 If X is a contractable sequence and f is measurable, then `f ∘ X` is also contractable.

--- a/Exchangeability/DeFinetti/ViaKoopman/CesaroPairFactorization.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/CesaroPairFactorization.lean
@@ -37,7 +37,6 @@ open Exchangeability.Ergodic
 open Exchangeability.PathSpace
 open scoped BigOperators RealInnerProductSpace
 
-set_option linter.unusedSectionVars false
 
 variable {α : Type*} [MeasurableSpace α]
 

--- a/Exchangeability/DeFinetti/ViaKoopman/InfraLagConstancy.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/InfraLagConstancy.lean
@@ -154,6 +154,7 @@ private lemma shift_iterate_apply (j n : ℕ) (ξ : ℕ → α) :
   | succ j ih =>
     simp only [Function.iterate_succ', Function.comp_apply, shift_apply, ih]; ring_nf
 
+omit [MeasurableSpace α] in
 private lemma shift_iterate_reindex_swap_eq (k m : ℕ) (hm : k + 1 < m) (ω : ℕ → α) :
     shift^[m] (Exchangeability.reindex (Equiv.swap k (k + 1)) ω) = shift^[m] ω := by
   ext n; rw [shift_iterate_apply, shift_iterate_apply, Exchangeability.reindex_apply,

--- a/Exchangeability/DeFinetti/ViaL2/BlockAverages.lean
+++ b/Exchangeability/DeFinetti/ViaL2/BlockAverages.lean
@@ -886,7 +886,7 @@ lemma get_covariance_constant
       -1 ≤ ρf ∧ ρf ≤ 1 := by
   -- Step 1: Show f∘X is contractable
   have hfX_contract : Contractable μ (fun n ω => f (X n ω)) :=
-    @contractable_comp Ω _ μ _ X hX_contract hX_meas f hf_meas
+    @contractable_comp Ω _ μ X hX_contract hX_meas f hf_meas
 
   -- Step 2: Get covariance structure (m, σ², ρ) of f∘X
   obtain ⟨M, hM⟩ := hf_bdd


### PR DESCRIPTION
## Summary

Continuing the option audit from PR #67: after the recent `omit […] in` and factoring work, none of the `set_option linter.unusedSectionVars false` overrides is still load-bearing. Removed all six and replaced with surgical fixes where actually needed.

## Changes

### `Exchangeability/Core.lean` — 2 file-wide suppressions

Both came with explanatory comments claiming "the linter doesn't track this transitive dependency [`Pi.measurableSpace`] and incorrectly suggests omitting `[MeasurableSpace α]`." The root cause was simpler:

- `section Measurable` had a redundant inner `variable [MeasurableSpace α]` redeclaration shadowing the outer one at line 60. Dropping it cleared the warning batch entirely.
- `section Probability` had the same redundant `[MeasurableSpace Ω] [MeasurableSpace α]` redeclaration. Same fix.
- One genuine omission surfaced: `reindex_apply` truly doesn't use `[MeasurableSpace α]`; added a targeted `omit [MeasurableSpace α] in`.
- Removed both stale "Disable false-positive linter warnings…" comment blocks.

### `Exchangeability/DeFinetti/L2Helpers.lean` — 3 scoped suppressions

`contractable_map_single`, `contractable_map_pair`, `contractable_comp` each replaced `set_option linter.unusedSectionVars false in` with the surgical `omit [IsProbabilityMeasure μ] in`. Also dropped the stale doc paragraph explaining the suppressions.

One caller-side update: `BlockAverages.lean:889` passed the `IsProbabilityMeasure μ` instance explicitly to `@contractable_comp` (positional `_`); removed the now-extra `_`.

### `Exchangeability/DeFinetti/ViaKoopman/CesaroPairFactorization.lean` — 1 file-wide suppression

Removing it surfaced one warning in a neighbouring file (`InfraLagConstancy.lean:157`, `shift_iterate_reindex_swap_eq`), addressed by a targeted `omit [MeasurableSpace α] in`.

## Verification

- `lake build` clean (3516/3516, **0 warnings**).
- `grep -rn "linter.unusedSectionVars" Exchangeability/` returns no live suppressions.
- `lake exe checkdecls blueprint/lean_decls` exits 0.
- `#print axioms` on `deFinetti_viaL2`, `deFinetti`, `deFinetti_viaKoopman`: `[propext, Classical.choice, Quot.sound]`.

## Test plan
- [x] `lake build` clean
- [x] No remaining `linter.unusedSectionVars` suppressions
- [x] `lake exe checkdecls blueprint/lean_decls` exits 0
- [x] `#print axioms` on three main theorems unchanged