### PR TITLE
Post-split cleanup of CesaroConvergence subfiles (reviewer items 1–5)

### DIFF
--- a/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/Cauchy.lean
+++ b/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/Cauchy.lean
@@ -4,22 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Cameron Freer
 -/
 import Exchangeability.DeFinetti.ViaL2.BlockAvgDef
-import Exchangeability.DeFinetti.ViaL2.BlockAverages
-import Exchangeability.DeFinetti.L2Helpers
-import Exchangeability.Contractability
-import Exchangeability.Probability.CondExp
-import Exchangeability.Probability.IntegrationHelpers
-import Exchangeability.Probability.LpNormHelpers
 import Exchangeability.Probability.CenteredVariables
-import Exchangeability.Probability.SigmaAlgebraHelpers
 import Exchangeability.Util.FinsetHelpers
-import Exchangeability.Tail.TailSigma
-import Exchangeability.Tail.ShiftInvariantMeasure
-import Mathlib.MeasureTheory.Function.L2Space
-import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
-import Mathlib.MeasureTheory.Function.LpSpace.Basic
-import Mathlib.MeasureTheory.Integral.Bochner.Set
-import Mathlib.Analysis.InnerProductSpace.MeanErgodic
 
 /-!
 # Cesàro Cauchy Property: `blockAvg_cauchy_in_L2`
@@ -79,43 +65,12 @@ private lemma cesaro_cauchy_rho_lt
   -- Equivalently: N > Cf / (ε.toReal)²
   -- If ε = ⊤, the property is trivial (take any N); otherwise use Archimedean property
   by_cases hε_top : ε = ⊤
-  · -- Case ε = ⊤
-    -- Any N works; take N := 0
+  · -- Case ε = ⊤: any N works (e.g. 0); the difference is in L² so its eLpNorm is finite.
     refine ⟨0, ?_⟩
     intro n n' _ _
-    -- measurability of the two block averages and their difference
-    have h_meas_n  :
-        Measurable (fun ω => blockAvg f X 0 n  ω) :=
-      blockAvg_measurable f X hf_meas hX_meas 0 n
-    have h_meas_n' :
-        Measurable (fun ω => blockAvg f X 0 n' ω) :=
-      blockAvg_measurable f X hf_meas hX_meas 0 n'
-    have h_meas_diff :
-        Measurable (fun ω => blockAvg f X 0 n ω - blockAvg f X 0 n' ω) :=
-      h_meas_n.sub h_meas_n'
-
-    -- |A_n| ≤ 1 and |A_{n'}| ≤ 1 ⇒ |A_n − A_{n'}| ≤ 2
-    have h_bdd :
-        ∀ᵐ ω ∂μ, |blockAvg f X 0 n ω - blockAvg f X 0 n' ω| ≤ 2 := by
-      apply ae_of_all
-      intro ω
-      have hn  : |blockAvg f X 0 n  ω| ≤ 1 := blockAvg_abs_le_one f X hf_bdd 0 n  ω
-      have hn' : |blockAvg f X 0 n' ω| ≤ 1 := blockAvg_abs_le_one f X hf_bdd 0 n' ω
-      calc
-        |blockAvg f X 0 n ω - blockAvg f X 0 n' ω|
-            ≤ |blockAvg f X 0 n ω| + |blockAvg f X 0 n' ω|
-              := by
-                   have := abs_add_le (blockAvg f X 0 n ω) (-(blockAvg f X 0 n' ω))
-                   simpa [sub_eq_add_neg, abs_neg] using this
-        _ ≤ 1 + 1 := add_le_add hn hn'
-        _ = 2 := by norm_num
-
-    -- bounded ⇒ MemLp ⇒ eLpNorm < ⊤
-    have h_mem :
-        MemLp (fun ω => blockAvg f X 0 n ω - blockAvg f X 0 n' ω) 2 μ :=
-      memLp_of_abs_le_const h_meas_diff h_bdd 2 (by norm_num) (by norm_num)
-
-    -- The goal for this branch is just finiteness (ε = ⊤)
+    have h_mem : MemLp (fun ω => blockAvg f X 0 n ω - blockAvg f X 0 n' ω) 2 μ :=
+      (blockAvg_memLp_two_of_abs_le_one f X hf_meas hX_meas hf_bdd 0 n).sub
+        (blockAvg_memLp_two_of_abs_le_one f X hf_meas hX_meas hf_bdd 0 n')
     rw [hε_top]
     exact MemLp.eLpNorm_lt_top h_mem
 
@@ -578,82 +533,10 @@ private lemma cesaro_cauchy_rho_lt
   -- Step 8: Convert integral bound to eLpNorm bound
   -- Goal: eLpNorm (blockAvg f X 0 n - blockAvg f X 0 n') 2 μ < ε
 
-  -- First show blockAvg difference is in L²
-  have h_diff_memLp : MemLp (fun ω => blockAvg f X 0 n ω - blockAvg f X 0 n' ω) 2 μ := by
-    -- Strategy: blockAvg is bounded by 1, so difference is bounded by 2
-    -- Use memLp_of_abs_le_const from LpNormHelpers
-
-    -- Show measurability
-    have h_meas_n : Measurable (fun ω => blockAvg f X 0 n ω) := by fun_prop
-
-    have h_meas_n' : Measurable (fun ω => blockAvg f X 0 n' ω) := by fun_prop
-
-    have h_meas_diff : Measurable (fun ω => blockAvg f X 0 n ω - blockAvg f X 0 n' ω) :=
-      h_meas_n.sub h_meas_n'
-
-    -- Show boundedness: |blockAvg f X 0 n| ≤ 1 and |blockAvg f X 0 n'| ≤ 1
-    -- implies |diff| ≤ 2
-    have h_bdd : ∀ᵐ ω ∂μ, |blockAvg f X 0 n ω - blockAvg f X 0 n' ω| ≤ 2 := by
-      apply ae_of_all
-      intro ω
-      -- Each blockAvg is bounded by 1 (average of values bounded by 1)
-      have hn_bdd : |blockAvg f X 0 n ω| ≤ 1 := by
-        simp only [blockAvg]
-        -- Strategy: |n⁻¹ * ∑ f_i| ≤ n⁻¹ * ∑ |f_i| ≤ n⁻¹ * n = 1
-        rw [abs_mul, abs_of_nonneg (inv_nonneg.mpr (Nat.cast_nonneg n))]
-        have h_sum_bound : |(Finset.range n).sum (fun k => f (X (0 + k) ω))| ≤ n := by
-          calc |(Finset.range n).sum (fun k => f (X (0 + k) ω))|
-              ≤ (Finset.range n).sum (fun k => |f (X (0 + k) ω)|) := by
-                exact Finset.abs_sum_le_sum_abs _ _
-            _ ≤ (Finset.range n).sum (fun k => 1) := by
-                apply Finset.sum_le_sum
-                intro k _
-                simp only [zero_add]
-                exact hf_bdd (X k ω)
-            _ = n := by
-                simp only [Finset.sum_const, Finset.card_range, nsmul_one]
-        calc (n : ℝ)⁻¹ * |(Finset.range n).sum (fun k => f (X (0 + k) ω))|
-            ≤ (n : ℝ)⁻¹ * n := by
-              apply mul_le_mul_of_nonneg_left
-              · exact_mod_cast h_sum_bound
-              · exact inv_nonneg.mpr (Nat.cast_nonneg n)
-          _ = 1 := by
-              field_simp [Nat.cast_ne_zero.mpr (Nat.pos_iff_ne_zero.mp hn_pos)]
-      have hn'_bdd : |blockAvg f X 0 n' ω| ≤ 1 := by
-        simp only [blockAvg]
-        -- Same strategy as hn_bdd
-        rw [abs_mul, abs_of_nonneg (inv_nonneg.mpr (Nat.cast_nonneg n'))]
-        have h_sum_bound : |(Finset.range n').sum (fun k => f (X (0 + k) ω))| ≤ n' := by
-          calc |(Finset.range n').sum (fun k => f (X (0 + k) ω))|
-              ≤ (Finset.range n').sum (fun k => |f (X (0 + k) ω)|) := by
-                exact Finset.abs_sum_le_sum_abs _ _
-            _ ≤ (Finset.range n').sum (fun k => 1) := by
-                apply Finset.sum_le_sum
-                intro k _
-                simp only [zero_add]
-                exact hf_bdd (X k ω)
-            _ = n' := by
-                simp only [Finset.sum_const, Finset.card_range, nsmul_one]
-        calc (n' : ℝ)⁻¹ * |(Finset.range n').sum (fun k => f (X (0 + k) ω))|
-            ≤ (n' : ℝ)⁻¹ * n' := by
-              apply mul_le_mul_of_nonneg_left
-              · exact_mod_cast h_sum_bound
-              · exact inv_nonneg.mpr (Nat.cast_nonneg n')
-          _ = 1 := by
-              field_simp [Nat.cast_ne_zero.mpr (Nat.pos_iff_ne_zero.mp hn'_pos)]
-      calc |blockAvg f X 0 n ω - blockAvg f X 0 n' ω|
-          ≤ |blockAvg f X 0 n ω| + |blockAvg f X 0 n' ω| := by
-            -- Triangle inequality: |a - b| ≤ |a| + |b|
-            -- Derive from |a + b| ≤ |a| + |b| by writing a - b = a + (-b)
-            calc |blockAvg f X 0 n ω - blockAvg f X 0 n' ω|
-                = |blockAvg f X 0 n ω + (-(blockAvg f X 0 n' ω))| := by rw [sub_eq_add_neg]
-              _ ≤ |blockAvg f X 0 n ω| + |-(blockAvg f X 0 n' ω)| := abs_add_le _ _
-              _ = |blockAvg f X 0 n ω| + |blockAvg f X 0 n' ω| := by rw [abs_neg]
-        _ ≤ 1 + 1 := add_le_add hn_bdd hn'_bdd
-        _ = 2 := by norm_num
-
-    -- Apply memLp_of_abs_le_const
-    exact memLp_of_abs_le_const h_meas_diff h_bdd 2 (by norm_num) (by norm_num)
+  -- First show blockAvg difference is in L².
+  have h_diff_memLp : MemLp (fun ω => blockAvg f X 0 n ω - blockAvg f X 0 n' ω) 2 μ :=
+    (blockAvg_memLp_two_of_abs_le_one f X hf_meas hX_meas hf_bdd 0 n).sub
+      (blockAvg_memLp_two_of_abs_le_one f X hf_meas hX_meas hf_bdd 0 n')
 
   -- Now apply the conversion: eLpNorm² → integral
   -- From h_integral_lt_ε_sq: ∫ diff² < ε²
@@ -675,19 +558,19 @@ private lemma cesaro_cauchy_rho_lt
 
     This wrapper prevents expensive elaboration timeouts when `blockAvg` appears
     inside `eLpNorm` goals, by using pre-proved lemmas instead of unfolding. -/
-def blockAvgFrozen {Ω : Type*} (f : ℝ → ℝ) (X : ℕ → Ω → ℝ) (n : ℕ) : Ω → ℝ :=
+private def blockAvgFrozen {Ω : Type*} (f : ℝ → ℝ) (X : ℕ → Ω → ℝ) (n : ℕ) : Ω → ℝ :=
   fun ω => blockAvg f X 0 n ω
 
-lemma blockAvgFrozen_def {Ω : Type*} (f : ℝ → ℝ) (X : ℕ → Ω → ℝ) (n : ℕ) (ω : Ω) :
+private lemma blockAvgFrozen_def {Ω : Type*} (f : ℝ → ℝ) (X : ℕ → Ω → ℝ) (n : ℕ) (ω : Ω) :
     blockAvgFrozen f X n ω = blockAvg f X 0 n ω :=
   rfl
 
 
-/-- Helper lemma: Block averages form a Cauchy sequence in L² (Step 1 of main proof).
-
-Given contractable X and bounded f, the block averages form a Cauchy sequence in L².
-This uses the L² contractability bound and uniform covariance structure. -/
-lemma blockAvg_cauchy_in_L2
+/-- Internal version of `blockAvg_cauchy_in_L2` stated against `blockAvgFrozen`
+to keep the elaborator from unfolding `blockAvg` inside `eLpNorm` during the
+covariance bookkeeping. The public statement below restates the same fact in
+terms of `blockAvg` directly. -/
+private lemma blockAvgFrozen_cauchy_in_L2
     {μ : Measure Ω} [IsProbabilityMeasure μ]
     {X : ℕ → Ω → ℝ} (hX_contract : Contractable μ X)
     (hX_meas : ∀ i, Measurable (X i))
@@ -1070,5 +953,18 @@ lemma blockAvg_cauchy_in_L2
     rw [h_norm_zero]
     exact hε
 
+/-- **Block averages form a Cauchy sequence in L².**
+
+Given contractable `X` and bounded `f`, the block Cesàro averages
+`blockAvg f X 0 n` form a Cauchy sequence in L²(μ). The proof goes through
+the L² contractability bound (no full exchangeability assumed). -/
+lemma blockAvg_cauchy_in_L2
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → ℝ} (hX_contract : Contractable μ X)
+    (hX_meas : ∀ i, Measurable (X i))
+    (f : ℝ → ℝ) (hf_meas : Measurable f) (hf_bdd : ∀ x, |f x| ≤ 1) :
+    ∀ ε > 0, ∃ N, ∀ {n n'}, n ≥ N → n' ≥ N →
+      eLpNorm (fun ω => blockAvg f X 0 n ω - blockAvg f X 0 n' ω) 2 μ < ε :=
+  blockAvgFrozen_cauchy_in_L2 hX_contract hX_meas f hf_meas hf_bdd
 
 end Exchangeability.DeFinetti.ViaL2

--- a/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/KallenbergBound.lean
+++ b/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/KallenbergBound.lean
@@ -3,23 +3,8 @@ Copyright (c) 2025 Cameron Freer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Cameron Freer
 -/
-import Exchangeability.DeFinetti.ViaL2.BlockAvgDef
-import Exchangeability.DeFinetti.ViaL2.BlockAverages
-import Exchangeability.DeFinetti.L2Helpers
-import Exchangeability.Contractability
-import Exchangeability.Probability.CondExp
-import Exchangeability.Probability.IntegrationHelpers
-import Exchangeability.Probability.LpNormHelpers
+
 import Exchangeability.Probability.CenteredVariables
-import Exchangeability.Probability.SigmaAlgebraHelpers
-import Exchangeability.Util.FinsetHelpers
-import Exchangeability.Tail.TailSigma
-import Exchangeability.Tail.ShiftInvariantMeasure
-import Mathlib.MeasureTheory.Function.L2Space
-import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
-import Mathlib.MeasureTheory.Function.LpSpace.Basic
-import Mathlib.MeasureTheory.Integral.Bochner.Set
-import Mathlib.Analysis.InnerProductSpace.MeanErgodic
 
 /-!
 # Kallenberg's L² Bound (Lemma 1.2)

--- a/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/L1.lean
+++ b/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/L1.lean
@@ -3,24 +3,8 @@ Copyright (c) 2025 Cameron Freer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Cameron Freer
 -/
-import Exchangeability.DeFinetti.ViaL2.BlockAvgDef
-import Exchangeability.DeFinetti.ViaL2.BlockAverages
+
 import Exchangeability.DeFinetti.ViaL2.CesaroConvergence.L2
-import Exchangeability.DeFinetti.L2Helpers
-import Exchangeability.Contractability
-import Exchangeability.Probability.CondExp
-import Exchangeability.Probability.IntegrationHelpers
-import Exchangeability.Probability.LpNormHelpers
-import Exchangeability.Probability.CenteredVariables
-import Exchangeability.Probability.SigmaAlgebraHelpers
-import Exchangeability.Util.FinsetHelpers
-import Exchangeability.Tail.TailSigma
-import Exchangeability.Tail.ShiftInvariantMeasure
-import Mathlib.MeasureTheory.Function.L2Space
-import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
-import Mathlib.MeasureTheory.Function.LpSpace.Basic
-import Mathlib.MeasureTheory.Integral.Bochner.Set
-import Mathlib.Analysis.InnerProductSpace.MeanErgodic
 
 /-!
 # Cesàro L¹ Convergence: `cesaro_to_condexp_L1`
@@ -84,68 +68,17 @@ lemma cesaro_to_condexp_L1
     (blockAvg_memLp_two_of_abs_le_one f X hf_meas hX_meas hf_bdd 0 n).sub hα_L2
 
   have hL2_integral : Tendsto (fun n => ∫ ω, (blockAvg f X 0 n ω - α_f ω)^2 ∂μ) atTop (𝓝 0) := by
-    -- Define gn := blockAvg f X 0 n - α_f for notational convenience
-    -- Goal: Tendsto (fun n => ∫ ω, (gn ω)² ∂μ) atTop (𝓝 0)
-    -- From hα_conv: Tendsto (fun n => eLpNorm gn 2 μ) atTop (𝓝 0)
-
-    -- Step 1: Convert ENNReal convergence to ℝ via ENNReal.tendsto_toReal
+    -- (eLpNorm gₙ 2 μ).toReal² = ∫ gₙ² dμ on a (finite) probability measure
+    -- (`eLpNorm_two_sq_eq_integral_sq`), so squaring the L² convergence gives the
+    -- integral form directly.
     have h_toReal : Tendsto (fun n => (eLpNorm (blockAvg f X 0 n - α_f) 2 μ).toReal) atTop (𝓝 0) := by
       rw [← ENNReal.toReal_zero]
       exact (ENNReal.tendsto_toReal ENNReal.zero_ne_top).comp hα_conv
-
-    -- Step 2: Square using Tendsto.pow (0² = 0)
     have h_sq : Tendsto (fun n => (eLpNorm (blockAvg f X 0 n - α_f) 2 μ).toReal ^ 2) atTop (𝓝 0) := by
-      have h_zero_sq : (0 : ℝ) ^ 2 = 0 := by norm_num
-      rw [← h_zero_sq]
-      exact h_toReal.pow 2
-
-    -- Step 3: Relate squared toReal to integral of squared function
-    -- Key identity: For MemLp g 2 μ real-valued:
-    --   (eLpNorm g 2 μ).toReal² = ∫ g² dμ
-    suffices h_eq : ∀ n, (eLpNorm (blockAvg f X 0 n - α_f) 2 μ).toReal ^ 2 =
-        ∫ ω, (blockAvg f X 0 n ω - α_f ω)^2 ∂μ by
-      simp_rw [← h_eq]
-      exact h_sq
-
-    -- Prove the equality for each n using MemLp.eLpNorm_eq_integral_rpow_norm
-    intro n
-    have hgn_memLp : MemLp (blockAvg f X 0 n - α_f) 2 μ := h_diff_memLp n
-    -- Use MemLp.eLpNorm_eq_integral_rpow_norm:
-    -- eLpNorm g 2 μ = ENNReal.ofReal ((∫ a, ‖g a‖ ^ 2 ∂μ) ^ (1/2))
-    have hp_ne_zero : (2 : ENNReal) ≠ 0 := by norm_num
-    have hp_ne_top : (2 : ENNReal) ≠ ⊤ := by norm_num
-    have h_eq_ofReal := MemLp.eLpNorm_eq_integral_rpow_norm hp_ne_zero hp_ne_top hgn_memLp
-    simp only [ENNReal.toReal_ofNat, inv_eq_one_div] at h_eq_ofReal
-    -- Now: eLpNorm g 2 μ = ENNReal.ofReal ((∫ a, ‖g a‖² ∂μ)^(1/2))
-    -- Taking toReal: (eLpNorm g 2 μ).toReal = (∫ a, ‖g a‖² ∂μ)^(1/2) (for nonneg integral)
-    -- First, establish the integral is nonneg (needed for ofReal/toReal)
-    -- Note: Use (2 : ℝ) to match MemLp.eLpNorm_eq_integral_rpow_norm which uses p.toReal
-    have h_integral_nonneg : 0 ≤ ∫ a, ‖(blockAvg f X 0 n - α_f) a‖ ^ (2 : ℝ) ∂μ :=
-      integral_nonneg (fun _ => Real.rpow_nonneg (norm_nonneg _) _)
-    -- Key: (eLpNorm g 2 μ).toReal² = ∫ g² dμ
-    -- Compute step by step
-    have h_sqrt_nonneg : 0 ≤ (∫ a, ‖(blockAvg f X 0 n - α_f) a‖ ^ (2 : ℝ) ∂μ) ^ (1 / 2 : ℝ) :=
-      Real.rpow_nonneg h_integral_nonneg _
-    -- Step 1: First show (eLpNorm ...).toReal = (∫...)^(1/2)
-    have h_toReal_eq : (eLpNorm (blockAvg f X 0 n - α_f) 2 μ).toReal =
-        (∫ a, ‖(blockAvg f X 0 n - α_f) a‖ ^ (2 : ℝ) ∂μ) ^ (1 / 2 : ℝ) := by
-      rw [h_eq_ofReal]
-      exact ENNReal.toReal_ofReal h_sqrt_nonneg
-    -- Step 2: Square both sides: toReal² = ((∫...)^(1/2))² = ∫...
-    calc (eLpNorm (blockAvg f X 0 n - α_f) 2 μ).toReal ^ 2
-        = ((∫ a, ‖(blockAvg f X 0 n - α_f) a‖ ^ (2 : ℝ) ∂μ) ^ (1 / 2 : ℝ)) ^ 2 := by rw [h_toReal_eq]
-      _ = (∫ a, ‖(blockAvg f X 0 n - α_f) a‖ ^ (2 : ℝ) ∂μ) ^ (1 / 2 * 2 : ℝ) := by
-          rw [← Real.rpow_natCast, ← Real.rpow_mul h_integral_nonneg]
-          norm_cast
-      _ = (∫ a, ‖(blockAvg f X 0 n - α_f) a‖ ^ (2 : ℝ) ∂μ) := by norm_num
-      _ = ∫ ω, (blockAvg f X 0 n ω - α_f ω) ^ 2 ∂μ := by
-          apply integral_congr_ae
-          filter_upwards with a
-          -- LHS: ‖(f - g) a‖ ^ (2:ℝ), RHS: (f a - g a) ^ 2
-          -- Step 1: Convert ‖x‖^(2:ℝ) → |x|^2 (natural power)
-          rw [Real.rpow_two, Real.norm_eq_abs]
-          -- Step 2: |x|^2 = x^2 (sq_abs), then unfold Pi.sub
-          simp only [sq_abs, Pi.sub_apply]
+      simpa using h_toReal.pow 2
+    refine h_sq.congr fun n => ?_
+    have h_eq := MeasureTheory.eLpNorm_two_sq_eq_integral_sq (h_diff_memLp n)
+    convert h_eq using 1
 
   -- STEP 2: Apply L2_tendsto_implies_L1_tendsto_of_bounded
   have hf_meas : ∀ n, Measurable (blockAvg f X 0 n) := by

--- a/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/L2.lean
+++ b/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/L2.lean
@@ -3,24 +3,11 @@ Copyright (c) 2025 Cameron Freer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Cameron Freer
 -/
-import Exchangeability.DeFinetti.ViaL2.BlockAvgDef
-import Exchangeability.DeFinetti.ViaL2.BlockAverages
+
 import Exchangeability.DeFinetti.ViaL2.CesaroConvergence.Cauchy
-import Exchangeability.DeFinetti.L2Helpers
-import Exchangeability.Contractability
-import Exchangeability.Probability.CondExp
-import Exchangeability.Probability.IntegrationHelpers
-import Exchangeability.Probability.LpNormHelpers
-import Exchangeability.Probability.CenteredVariables
-import Exchangeability.Probability.SigmaAlgebraHelpers
-import Exchangeability.Util.FinsetHelpers
+import Exchangeability.DeFinetti.ViaL2.BlockAverages
 import Exchangeability.Tail.TailSigma
-import Exchangeability.Tail.ShiftInvariantMeasure
-import Mathlib.MeasureTheory.Function.L2Space
-import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
-import Mathlib.MeasureTheory.Function.LpSpace.Basic
-import Mathlib.MeasureTheory.Integral.Bochner.Set
-import Mathlib.Analysis.InnerProductSpace.MeanErgodic
+import Exchangeability.Probability.SigmaAlgebraHelpers
 
 /-!
 # Cesàro L² Convergence: `cesaro_to_condexp_L2`
@@ -53,11 +40,10 @@ variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
 open scoped BigOperators
 
-set_option linter.unusedVariables false in
 lemma blockAvg_measurable_tailFamily
     {Ω : Type*} [MeasurableSpace Ω]
     {f : ℝ → ℝ} (hf : Measurable f)
-    {X : ℕ → Ω → ℝ} (hX : ∀ i, Measurable (X i))
+    {X : ℕ → Ω → ℝ}
     (m n : ℕ) :
     Measurable[TailSigma.tailFamily X m] (blockAvg f X m n) := by
   -- blockAvg f X m n = (n⁻¹) * ∑_{k<n} f(X_{m+k})
@@ -273,7 +259,7 @@ private lemma tail_measurability_of_blockAvg
 
     -- Step 1a: blockAvg f X N m is Measurable[tailFamily X N] for all m
     have h_block_meas : ∀ m, @Measurable Ω ℝ (TailSigma.tailFamily X N) _ (blockAvg f X N m) :=
-      fun m => blockAvg_measurable_tailFamily hf_meas hX_meas N m
+      fun m => blockAvg_measurable_tailFamily hf_meas N m
 
     -- Step 1b: blockAvg f X N m → α_f in L² (by blockAvg_shift_tendsto)
     have h_L2_conv := blockAvg_shift_tendsto f hf_meas hf_bdd hX_meas α_f hα_memLp hα_limit N
@@ -287,7 +273,7 @@ private lemma tail_measurability_of_blockAvg
     -- Note: α_f is AEStronglyMeasurable wrt ambient from MemLp
     have h_α_aesm : AEStronglyMeasurable α_f μ := hα_memLp.aestronglyMeasurable
     have h_block_aesm : ∀ m, AEStronglyMeasurable (blockAvg f X N m) μ :=
-      fun m => (blockAvg_measurable_tailFamily hf_meas hX_meas N m).aestronglyMeasurable.mono h_tf_le
+      fun m => (blockAvg_measurable_tailFamily hf_meas N m).aestronglyMeasurable.mono h_tf_le
     have h_in_measure : TendstoInMeasure μ (blockAvg f X N) atTop α_f :=
       tendstoInMeasure_of_tendsto_eLpNorm (by norm_num) h_block_aesm h_α_aesm h_L2_conv
 
@@ -344,7 +330,7 @@ private lemma tendsto_setIntegral_of_L2_tendsto
 /-- **Cesàro averages converge in L² to a tail-measurable limit.**
 
 This is the elementary L² route to de Finetti (Kallenberg's "second proof"):
-1. Kallenberg L² bound → Cesàro averages are Cauchy in L²
+1. L² contractability bound → Cesàro averages are Cauchy in L²
 2. Completeness of L² → limit α_f exists
 3. Block averages A_{N,n} are σ(X_{>N})-measurable → α_f is tail-measurable
 4. Tail measurability + L² limit → α_f = E[f(X_1) | tail σ-algebra]
@@ -359,17 +345,7 @@ lemma cesaro_to_condexp_L2
       AEStronglyMeasurable[TailSigma.tailSigma X] α_f μ ∧
       Tendsto (fun n => eLpNorm (blockAvg f X 0 n - α_f) 2 μ) atTop (𝓝 0) ∧
       α_f =ᵐ[μ] μ[(f ∘ X 0) | TailSigma.tailSigma X] := by
-  -- Kallenberg's second proof (elementary L² approach)
-
-  -- Define Z_i := f(X_i) - E[f(X_0)] (centered variables)
-  let Z := fun i ω => f (X i ω) - ∫ ω', f (X 0 ω') ∂μ
-
-  -- Step 1: Show {A_{0,n}}_n is Cauchy in L² using Kallenberg bound
-  -- For any m, m' and large n: ‖A_{m,n} - A_{m',n}‖_L² ≤ C_f/√n
-  -- Setting m=m'=0 with different n values: need to relate A_{0,n} and A_{0,n'}
-
-  -- Step 1: Show block averages form a Cauchy sequence in L²
-  -- Extracted to helper lemma to reduce proof complexity and isolate timeout source
+  -- Step 1: Show block averages form a Cauchy sequence in L² (via `Cauchy.lean`).
   have hCauchy := blockAvg_cauchy_in_L2 hX_contract hX_meas f hf_meas hf_bdd
 
   -- Step 2: Extract L² limit using completeness of Hilbert space

--- a/blueprint/lean_decls
+++ b/blueprint/lean_decls
@@ -26,6 +26,7 @@ Exchangeability.DeFinetti.ViaL2.blockAvg
 Exchangeability.DeFinetti.ViaL2.contractable_covariance_structure
 Exchangeability.DeFinetti.L2Approach.l2_contractability_bound
 Exchangeability.DeFinetti.ViaL2.kallenberg_L2_bound
+Exchangeability.DeFinetti.ViaL2.blockAvg_cauchy_in_L2
 Exchangeability.DeFinetti.ViaL2.cesaro_to_condexp_L2
 Exchangeability.DeFinetti.ViaL2.cesaro_to_condexp_L1
 Exchangeability.DeFinetti.ViaL2.directing_measure_isProbabilityMeasure

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -299,15 +299,27 @@ with $L^2$ integrability (i.e., $\mathbb{E}[X_i^2] < \infty$ for all $i$).
   \label{lem:kallenberg_L2_bound}
   \lean{Exchangeability.DeFinetti.ViaL2.kallenberg_L2_bound}
   \leanok
+  The L$^2$ distance bound for weighted averages of an exchangeable sequence
+  (Kallenberg Lemma 1.2). Recorded here for completeness; the active proof
+  path uses the contractability-only variant \cref{lem:l2_bound} instead,
+  to avoid assuming exchangeability while proving Contractable
+  $\Rightarrow$ Exchangeable.
+\end{lemma}
+
+\begin{lemma}[Block averages are Cauchy in L$^2$]
+  \label{lem:blockAvg_cauchy_in_L2}
+  \lean{Exchangeability.DeFinetti.ViaL2.blockAvg_cauchy_in_L2}
+  \leanok
   \uses{lem:l2_bound}
-  The key L$^2$ bound that drives the Cesaro convergence.
+  For contractable $X$ and bounded $f$, the block Cesaro averages
+  $\mathrm{blockAvg}\, f\, X\, 0\, n$ form a Cauchy sequence in L$^2$.
 \end{lemma}
 
 \begin{lemma}[Cesaro to conditional expectation (L$^2$)]
   \label{lem:cesaro_L2}
   \lean{Exchangeability.DeFinetti.ViaL2.cesaro_to_condexp_L2}
   \leanok
-  \uses{lem:kallenberg_L2_bound}
+  \uses{lem:blockAvg_cauchy_in_L2}
   Block averages converge in L$^2$ to the conditional expectation given the tail.
 \end{lemma}
 


### PR DESCRIPTION
## Summary

Five small follow-ups identified by review after the PR #72 split. −197 net lines across the 4 sub-files + 2 blueprint files.

### 1. Fix the blueprint story for `kallenberg_L2_bound`

The blueprint asserted `lem:cesaro_L2 \uses lem:kallenberg_L2_bound`, but the active proof goes through `blockAvg_cauchy_in_L2` (which uses `l2_contractability_bound`), not through `kallenberg_L2_bound`. Updated `blueprint/src/content.tex`:
- `lem:kallenberg_L2_bound` becomes a parallel/expository node with no `\uses` (recorded for completeness, not on the proof path)
- New `lem:blockAvg_cauchy_in_L2` node, using `lem:l2_bound`
- `lem:cesaro_L2 \uses` now points to `lem:blockAvg_cauchy_in_L2`

Also added `Exchangeability.DeFinetti.ViaL2.blockAvg_cauchy_in_L2` to `blueprint/lean_decls`.

### 2. Hide `blockAvgFrozen` from the public API

`blockAvg_cauchy_in_L2` was stated in terms of the performance wrapper `blockAvgFrozen`. Refactored:
- `blockAvgFrozen` and `blockAvgFrozen_def` are now `private`
- The L²-Cauchy proof body (uses the wrapper to control elaboration) is now `private blockAvgFrozen_cauchy_in_L2`
- A new public `blockAvg_cauchy_in_L2` is stated using ordinary `blockAvg` and proved by appealing to the private inner version (the two statements are defeq via `blockAvgFrozen_def`)

### 3. Two concrete proof golfs

- `Cauchy.lean`: the long `h_diff_memLp : MemLp (blockAvg - blockAvg) 2 μ` proofs (at both line 582 and the ε = ⊤ branch) collapse to a single `.sub` call once `blockAvg_memLp_two_of_abs_le_one` is in scope. 75 → 3 lines, 30 → 5 lines.
- `L1.lean`: the 70-line `hL2_integral` proof relating `(eLpNorm g 2 μ).toReal ^ 2` to `∫ g² dμ` collapses via `MeasureTheory.eLpNorm_two_sq_eq_integral_sq` from `LpNormHelpers.lean`. → ~10 lines.

### 4. Clean `blockAvg_measurable_tailFamily`

The lemma's `hX : ∀ i, Measurable (X i)` argument was unused (suppressed by `set_option linter.unusedVariables false`). Now that the lemma is internal to `L2.lean` and only used from two same-file call sites, dropped the argument entirely and removed the suppression.

### 5. Comment + import cleanup

- Removed the stale "using Kallenberg bound" comment chain in `cesaro_to_condexp_L2` and the orphan `let Z := …` at `L2.lean:365`.
- Ran `minimize_imports.py` on each sub-file. The 17–18-import headers inherited from the monolithic source are mostly unnecessary. Final counts:

| File | Imports before | Imports after |
|---|---:|---:|
| `KallenbergBound.lean` | 17 | 1 |
| `Cauchy.lean` | 17 | 3 |
| `L2.lean` | 18 | 4 |
| `L1.lean` | 18 | 1 |

## Verification

- `lake build` clean (3520/3520, **0 warnings**).
- `lake exe checkdecls blueprint/lean_decls` exits 0 (including the new `blockAvg_cauchy_in_L2` entry).
- `#print axioms` on `deFinetti_viaL2`, `deFinetti`, `deFinetti_viaKoopman`: `[propext, Classical.choice, Quot.sound]`.

## Test plan
- [x] `lake build` clean
- [x] `lake exe checkdecls blueprint/lean_decls` exits 0
- [x] `#print axioms` on three main theorems unchanged