### PR TITLE
fix(blueprint): use \ref instead of \cref

### DIFF
--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -301,7 +301,7 @@ with $L^2$ integrability (i.e., $\mathbb{E}[X_i^2] < \infty$ for all $i$).
   \leanok
   The L$^2$ distance bound for weighted averages of an exchangeable sequence
   (Kallenberg Lemma 1.2). Recorded here for completeness; the active proof
-  path uses the contractability-only variant \cref{lem:l2_bound} instead,
+  path uses the contractability-only variant \ref{lem:l2_bound} instead,
   to avoid assuming exchangeability while proving Contractable
   $\Rightarrow$ Exchangeable.
 \end{lemma}


### PR DESCRIPTION
## Summary

PR #73 introduced `\cref{lem:l2_bound}` in the prose for `lem:kallenberg_L2_bound`. The blueprint LaTeX setup doesn't load `cleveref`, so `pdflatex` halted on `! Undefined control sequence` during the documentation deploy. All other blueprint references in this file use plain `\ref{...}`; switch to match.

The cascade of "Reference \`...' undefined" warnings in the failing log was just the second pass running on stale auxiliary state after pdflatex bailed — not pre-existing missing labels (verified each named label exists at the expected location).

## Verification

- `lake build` clean (3520/3520, 0 warnings).
- All targeted labels exist:
  - `\label{lem:l2_bound}` at line 289.

## Test plan
- [x] `lake build` clean
- [ ] CI documentation build passes