### PR TITLE
Prune Axiom-era historical commentary in ViaMartingale

### DIFF
--- a/Exchangeability/DeFinetti/ViaMartingale/CondExpConvergence.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/CondExpConvergence.lean
@@ -176,20 +176,6 @@ def M (hX_meas : ∀ n, Measurable (X n)) (k : ℕ) (B : Set α) (_hB : Measurab
     (futureFiltration_le X m hX_meas)
     (B.indicator (fun _ => (1 : ℝ)) ∘ X k)
 
--- CondExp.lean milestones (completed):
--- (1) `0 ≤ M k B m ω ≤ 1` a.s.
---     API: `condexp_indicator_bounds`.
--- (2) For `m ≤ n`, `M k B n` is `𝔽 n`-measurable and
---     `μ[fun ω => M k B n ω | 𝔽 m] =ᵐ[μ] M k B m`.
---     API: `condexp_tower`, `condexp_stronglyMeasurable`.
--- (3) If `(X m, θₘ X) =^d (X k, θₘ X)`, then
---     `M m B m =ᵐ[μ] M k B m`.
---     API: `condexp_indicator_eq_of_dist_eq_and_le`.
--- (4) `(fun n => M k B n ω)` is a reverse martingale that converges
---     to `μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ (X k) | tailSigma X] ω`.
---     API: `condexp_tendsto_condexp_iInf` (Lévy's downward theorem) together with
---     `filtration_antitone` and `tailSigmaFuture_eq_iInf`.
-
 end reverse_martingale
 
 end Exchangeability.DeFinetti.ViaMartingale

--- a/Exchangeability/DeFinetti/ViaMartingale/Factorization.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/Factorization.lean
@@ -66,24 +66,12 @@ with σ(θ_{m+1} X) ⊆ σ(X_r, θ_{m+1} X).
 By Kallenberg's Lemma 1.3: if (U, η) =ᵈ (U, ζ) and σ(η) ⊆ σ(ζ), then U ⊥⊥_η ζ.
 Taking U = (X₀,...,X_{r-1}), η = θ_{m+1} X, ζ = (X_r, θ_{m+1} X) gives the result.
 
-**This replaces the old broken `coordinate_future_condIndep` which incorrectly claimed
-Y ⊥⊥_{σ(Y)} Y.**
-
----
-
-**SIMPLIFIED PROOF PATH (using Kallenberg 1.3 infrastructure):**
-
-The proof now uses `condExp_Xr_indicator_eq_of_contractable` which directly applies
-Kallenberg 1.3 with the true contraction structure:
-- W = shiftRV X (m+1) (far future)
-- W' = (U, W) where U = firstRMap X r (first r coords)
-- Contraction: σ(W) ⊆ σ(U, W) = σ(W')
-- Pair law: (X_r, W) =^d (X_r, W') from contractability
-
-This gives: E[1_{X_r ∈ B} | σ(U, W)] = E[1_{X_r ∈ B} | σ(W)]
-which is the indicator characterization of X_r ⊥⊥ U | W.
-
-The old finite-level approximation approach is now deprecated. -/
+The proof goes through `condExp_Xr_indicator_eq_of_contractable`, which packages
+the Kallenberg 1.3 input
+```
+E[1_{X_r ∈ B} | σ(U, W)] = E[1_{X_r ∈ B} | σ(W)]
+```
+with `U = firstRMap X r`, `W = shiftRV X (m+1)`. -/
 lemma block_coord_condIndep
     {Ω α : Type*} [MeasurableSpace Ω] [StandardBorelSpace Ω]
     [MeasurableSpace α] [StandardBorelSpace α]
@@ -98,19 +86,6 @@ lemma block_coord_condIndep
     (MeasurableSpace.comap (X r) inferInstance)   -- single coord: σ(X_r)
     (futureFiltration_le X m hX_meas)             -- witness: σ(θ_{m+1} X) ≤ ambient
     μ := by
-  -- ═══════════════════════════════════════════════════════════════════════════════
-  -- SIMPLIFIED PROOF using Kallenberg 1.3 infrastructure (condExp_Xr_indicator_eq_of_contractable)
-  -- ═══════════════════════════════════════════════════════════════════════════════
-  --
-  -- This bypasses the old finite-level approximation which used the broken chain:
-  --   condexp_indicator_eq_on_join_of_triple_law → condExp_eq_of_triple_law
-  --     → condIndep_of_triple_law_INVALID
-  --
-  -- Instead, we use the correct Kallenberg 1.3 approach with true contraction:
-  --   condExp_Xr_indicator_eq_of_contractable (at infinite level)
-  --
-  -- ═══════════════════════════════════════════════════════════════════════════════
-
   -- We use the "indicator projection" criterion for conditional independence.
   apply Exchangeability.Probability.condIndep_of_indicator_condexp_eq
   · exact firstRSigma_le_ambient X r hX_meas
@@ -143,10 +118,6 @@ lemma block_coord_condIndep
   -- Thus the result follows from condExp_Xr_indicator_eq_of_contractable.
   exact condExp_Xr_indicator_eq_of_contractable hX hX_meas (Nat.le_of_lt hrm) hB
 
-  -- NOTE: The previous proof used a finite-level approximation + Lévy upward convergence
-  -- approach, but that depended on a broken chain (condIndep_of_triple_law_INVALID).
-  -- The current proof via Kallenberg 1.3 is mathematically correct.
-
 
 /-- **Product formula for conditional expectations under conditional independence.**
 
@@ -156,8 +127,7 @@ independence given `m`, the conditional expectation of the intersection indicato
 μ[1_{A∩B} | m] = μ[1_A | m] · μ[1_B | m]   a.e.
 ```
 
-Now proven using `condexp_indicator_inter_bridge` from CondExp.lean, eliminating the
-previous `: True` stub. -/
+Proven using `condexp_indicator_inter_bridge` from CondExp.lean. -/
 lemma condexp_indicator_inter_of_condIndep
     {Ω : Type*} {m₀ : MeasurableSpace Ω} [StandardBorelSpace Ω]
     {μ : @Measure Ω m₀} [IsProbabilityMeasure μ]
@@ -171,7 +141,7 @@ lemma condexp_indicator_inter_of_condIndep
      μ[B.indicator (fun _ => (1 : ℝ)) | m]) :=
   Exchangeability.Probability.condexp_indicator_inter_bridge hm hmF hmH hCI hA hB
 
-/-- **Finite-level factorization builder (formerly Axiom 3).**
+/-- **Finite-level factorization builder.**
 
 For a contractable sequence, at any future level `m ≥ r`, the conditional expectation
 of the product indicator factors:
@@ -348,7 +318,7 @@ lemma finite_level_factorization
           rw [Fin.prod_univ_castSucc]
           simp only [Cinit, Clast, Fin.last]
 
-/-- **Tail factorization on finite cylinders (formerly Axiom 4).**
+/-- **Tail factorization on finite cylinders.**
 
 Assume you have, for all large enough `m`, the finite‑level factorization
 at the future filtration:


### PR DESCRIPTION
## Summary

Audit of `ViaMartingale/*` for the reviewer-flagged "stale Axiom 3/4 wording" and other historical-commentary leftovers.

**Net −44 lines across 2 files**, all comment / docstring. No declarations changed.

Confirmed via repo-wide grep that the names referenced in the comments — `condIndep_of_triple_law_INVALID`, `coordinate_future_condIndep`, the `` : True `` stub — exist nowhere outside the comments themselves.

### `Factorization.lean`

- Drop "formerly Axiom 3" / "formerly Axiom 4" parentheticals on `finite_level_factorization` and `tail_factorization_from_future`.
- Drop the "SIMPLIFIED PROOF using Kallenberg 1.3 infrastructure" `═══` block inside `block_coord_condIndep` (16 lines) and the trailing "previous proof used a broken chain (condIndep_of_triple_law_INVALID)" note (3 lines).
- Replace the docstring preamble's "This replaces the old broken `coordinate_future_condIndep` …" + "SIMPLIFIED PROOF PATH" passage (~17 lines) with a 7-line summary of the actual current proof.
- On `condexp_indicator_inter_of_condIndep`: drop "Now proven … , eliminating the previous `` : True `` stub" — the stub is gone.

### `CondExpConvergence.lean`

- Drop the 14-line "CondExp.lean milestones (completed):" planning comment that sat after `M`. The four "milestones" it listed (`condexp_indicator_bounds`, `condexp_tower`, etc.) are real declarations with their own documentation now.

### Items I considered and left alone

- 15 `@[nolint unusedArguments]` sites across ViaMartingale: each one is on a real lemma whose statement uses every argument (e.g. typeclass slots, hypothesis args). Removing the annotation would require per-site build probes — better as a focused future PR rather than mechanical sweep.
- Other ViaMartingale files (`PairLawEquality.lean`, `FutureRectangles.lean`, etc.): no stale "Axiom" / "broken" / "removed" patterns surfaced in the grep.

## Verification

- `lake build` clean (3525/3525, no new warnings).
- `#print axioms` on `deFinetti_viaL2`, `deFinetti`, `deFinetti_viaKoopman`: `[propext, Classical.choice, Quot.sound]` (unchanged).

## Test plan
- [x] `lake build` clean
- [x] `#print axioms` on the three main theorems unchanged
- [x] No decl signatures or proof bodies changed