### PR TITLE
Prune historical / never-written entries from Ergodic doc headers

### DIFF
--- a/Exchangeability/Ergodic/InvariantSigma.lean
+++ b/Exchangeability/Ergodic/InvariantSigma.lean
@@ -14,9 +14,6 @@ import Mathlib.MeasureTheory.Function.ConditionalExpectation.CondexpL2
 import Exchangeability.Ergodic.ShiftInvariantSigma
 import Exchangeability.Ergodic.ShiftInvariantRepresentatives
 
--- NOTE: shift was moved from KoopmanMeanErgodic to PathSpace.Shift in Oct 2025
--- to avoid duplication with CommonEnding. See commit 57890e9.
-
 /-!
 # Shift-invariant σ-algebra and conditional expectation
 

--- a/Exchangeability/Ergodic/KoopmanMeanErgodic.lean
+++ b/Exchangeability/Ergodic/KoopmanMeanErgodic.lean
@@ -47,8 +47,7 @@ For the **left shift** `T(ω₀, ω₁, ω₂, ...) = (ω₁, ω₂, ω₃, ...)
 
 ## Main results
 
-* `measurable_shift`: The shift map is measurable
-* `measurePreserving_shift_pi`: For product measures, the shift is measure-preserving
+* `measurable_shift`: The shift map is measurable (re-exported from `PathSpace.Shift`)
 * `birkhoffAverage_tendsto_metProjection`: **Birkhoff averages converge in L² to the
   projection onto the fixed-point subspace** (via Mean Ergodic Theorem)
 
@@ -84,15 +83,7 @@ variable {α : Type*} [MeasurableSpace α]
 -- Ensure Lp spaces work with p = 2
 attribute [local instance] fact_one_le_two_ennreal
 
--- NOTE: PathSpace and Ω[α] notation are now defined in PathSpace.Shift
--- The shift operator (shift ω) n = ω(n+1) is fundamental to ergodic theory and
--- is defined there along with shift_measurable.
-
 variable {Ω : Type*} [MeasurableSpace Ω]
-
--- Product measure setup will need specific API from mathlib
--- For now we work with abstract measure-preserving assumptions
--- lemma measurePreserving_shift_pi : ... (requires Measure.pi API)
 
 /--
 The Koopman operator: composition with a measure-preserving transformation.


### PR DESCRIPTION
## Summary

Audit of `Exchangeability/Ergodic/*` per the reviewer's next-batch list (small wrapper / stale-assumption cleanup zone). **Net −12 lines across 2 files**, all comment hygiene.

The Ergodic tree turns out to be in good shape — substantive math headers, no "Axiom" wording surviving, no broken-chain references. Three concrete things still worth pruning:

### `KoopmanMeanErgodic.lean`

- **Drop dead "Main results" bullet** for `measurePreserving_shift_pi`. Repo-wide grep shows that name was never written — only referenced in this bullet and a planning stub inside the body. The stub goes too.
- **Drop "NOTE: PathSpace and Ω[α] notation are now defined in PathSpace.Shift"** + adjacent "Product measure setup will need specific API from mathlib / lemma measurePreserving_shift_pi : ... (requires Measure.pi API)" planning comments.

### `InvariantSigma.lean`

- **Drop the "NOTE: shift was moved from KoopmanMeanErgodic to PathSpace.Shift in Oct 2025 / See commit 57890e9"** git-archaeology comment. CLAUDE.md flags "describe what code is, not what it was" as the style to keep.

### Items I considered and left alone

- 6 `@[nolint unusedArguments]` sites across Ergodic (`ProjectionLemmas`, `KoopmanMeanErgodic`, `ShiftInvariantRepresentatives`, `InvariantSigma`). Each one's args appear in the statement; auditing whether the annotation is still load-bearing needs per-site build probes — better as a focused PR than mechanical.
- `BirkhoffAvgCLM.lean`'s "CLM-level entry point `birkhoffAvgCLM` was removed" header note — it actually explains why the file has only `powCLM` + Lp-coercion helpers now, which is the kind of "what this file is" doc CLAUDE.md endorses.
- FMP 10.4 textbook citation block in `InvariantSigma.lean` — real reference content.
- The "Axiom of Choice avoidance" note in `ShiftInvariantRepresentatives.lean` — real mathematical content about the construction, not stale historical clutter.

## Verification

- `lake build` clean (3525/3525).
- `#print axioms` on `deFinetti_viaL2`, `deFinetti`, `deFinetti_viaKoopman`: `[propext, Classical.choice, Quot.sound]` (unchanged).

## Test plan
- [x] `lake build` clean
- [x] `#print axioms` on the three main theorems unchanged
- [x] No decl signatures or proof bodies changed