### PR TITLE
Kill condExp_L1_lipschitz' duplicate + dead compat shims + stale CondExp doc

### DIFF
--- a/Exchangeability/Bridge/CesaroToCondExp.lean
+++ b/Exchangeability/Bridge/CesaroToCondExp.lean
@@ -59,12 +59,6 @@ def μ_path {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
     (μ : Measure Ω) (X : ℕ → Ω → α) : Measure (PathSpace α) :=
   Measure.map (pathify X) μ
 
-/-- Alternate definition of process law without explicit μ for compatibility.
-Equivalent to `μ_path` but with μ as an implicit argument. -/
-def μ_path' {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
-    {α : Type*} [MeasurableSpace α] (X : ℕ → Ω → α) : Measure (PathSpace α) :=
-  Measure.map (pathify X) μ
-
 lemma isProbabilityMeasure_μ_path {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
     (μ : Measure Ω) [IsProbabilityMeasure μ]
     (X : ℕ → Ω → α) (hX : ∀ n, Measurable (X n)) :

--- a/Exchangeability/DeFinetti/ViaKoopman/CesaroL1Bounded.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/CesaroL1Bounded.lean
@@ -430,7 +430,8 @@ lemma ce_lipschitz_convergence
   have h₁ : ∀ n, ∫ ω, |μ[(fun ω' => f (ω' 0) * A n ω') | mSI] ω
                      - μ[(fun ω' => f (ω' 0) * Y ω') | mSI] ω| ∂μ
                ≤ ∫ ω, |f (ω 0) * A n ω - f (ω 0) * Y ω| ∂μ := fun n =>
-    condExp_L1_lipschitz' (hZ_int n) hW_int
+    Exchangeability.Probability.condExp_L1_lipschitz
+      (μ := μ) (m := mSI) (hZ_int n) hW_int
 
   have h₂ : ∀ n, ∫ ω, |f (ω 0) * A n ω - f (ω 0) * Y ω| ∂μ
                ≤ Cf * ∫ ω, |A n ω - Y ω| ∂μ := fun n => by

--- a/Exchangeability/DeFinetti/ViaKoopman/CesaroPairFactorization.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/CesaroPairFactorization.lean
@@ -191,7 +191,8 @@ private theorem h_tower_of_lagConst_from_one
       have h1 : ∫ ω, |μ[(fun ω' => f (ω' 0) * A' (n + 1) ω') | mSI] ω
                     - μ[(fun ω' => f (ω' 0) * Y ω') | mSI] ω| ∂μ
               ≤ ∫ ω, |f (ω 0) * A' (n + 1) ω - f (ω 0) * Y ω| ∂μ :=
-        condExp_L1_lipschitz' hfA_int hfY_int
+        Exchangeability.Probability.condExp_L1_lipschitz
+          (μ := μ) (m := mSI) hfA_int hfY_int
       -- Factor bound
       have h2 : ∫ ω, |f (ω 0) * A' (n + 1) ω - f (ω 0) * Y ω| ∂μ
               ≤ Cf * ∫ ω, |A' (n + 1) ω - Y ω| ∂μ := by

--- a/Exchangeability/DeFinetti/ViaKoopman/InfraGeneralized.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/InfraGeneralized.lean
@@ -393,34 +393,6 @@ lemma integrable_mul_of_ae_bdd_left
     rwa [Real.norm_eq_abs]
   exact Integrable.bdd_mul hY hZ.aestronglyMeasurable hZ_norm
 
-/-- Path-space-specialised L¹-Lipschitz bound for conditional expectation
-against `shiftInvariantSigma`.
-
-This is the `shiftInvariantSigma`-specific variant of the generic
-`Exchangeability.Probability.condExp_L1_lipschitz`; the prime distinguishes
-it from that central lemma. It is preserved as a separate declaration
-because the central form declares its sub-σ-algebra hypothesis as
-`_hm : m ≤ ‹_›`, and at the call sites in `CesaroPairFactorization.lean`
-/ `CesaroL1Bounded.lean` the elaborator resolves `‹_›` to
-`shiftInvariantSigma` rather than the ambient `MeasurableSpace.pi`,
-producing a `shiftInvariantSigma ≤ shiftInvariantSigma` hypothesis that
-no obvious workaround discharges. -/
-@[nolint unusedArguments]
-lemma condExp_L1_lipschitz'
-    {μ : Measure (Ω[α])} [IsProbabilityMeasure μ]
-    {Z W : Ω[α] → ℝ} (hZ : Integrable Z μ) (hW : Integrable W μ) :
-    ∫ ω, |μ[Z | shiftInvariantSigma (α := α)] ω - μ[W | shiftInvariantSigma (α := α)] ω| ∂μ
-      ≤ ∫ ω, |Z ω - W ω| ∂μ := by
-  have h_sub : μ[(Z - W) | shiftInvariantSigma]
-              =ᵐ[μ] μ[Z | shiftInvariantSigma] - μ[W | shiftInvariantSigma] :=
-    condExp_sub hZ hW shiftInvariantSigma
-  calc ∫ ω, |μ[Z | shiftInvariantSigma] ω - μ[W | shiftInvariantSigma] ω| ∂μ
-      = ∫ ω, |μ[(Z - W) | shiftInvariantSigma] ω| ∂μ := by
-          refine integral_congr_ae ?_
-          filter_upwards [h_sub] with ω hω
-          simp [hω]
-    _ ≤ ∫ ω, |Z ω - W ω| ∂μ := integral_abs_condExp_le (Z - W)
-
 /-- Pull-out property: if Z is measurable w.r.t. the conditioning σ-algebra and a.e.-bounded,
 then CE[Z·Y | mSI] = Z·CE[Y | mSI] a.e. This is the standard "taking out what is known". -/
 lemma condExp_mul_pullout

--- a/Exchangeability/DeFinetti/ViaMartingale/FiniteProduct.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/FiniteProduct.lean
@@ -392,23 +392,4 @@ lemma finite_product_formula
     = μ.bind (fun ω => Measure.pi fun _ : Fin m => ν ω) :=
   finite_product_formula_strictMono X hX hX_meas ν hν_prob hν_meas hν_law m k hk
 
-/-- **Convenience identity case** (useful for tests and bridging). -/
-lemma finite_product_formula_id'
-    [StandardBorelSpace Ω]
-    {μ : Measure Ω} [IsProbabilityMeasure μ]
-    {α : Type*} [MeasurableSpace α] [StandardBorelSpace α] [Nonempty α]
-    (X : ℕ → Ω → α)
-    (hX : Contractable μ X)
-    (hX_meas : ∀ n, Measurable (X n))
-    (ν : Ω → Measure α)
-    (hν_prob : ∀ ω, IsProbabilityMeasure (ν ω))
-    (hν_meas : ∀ B : Set α, MeasurableSet B → Measurable (fun ω => ν ω B))
-    (hν_law : ∀ n B, MeasurableSet B →
-        (fun ω => (ν ω B).toReal) =ᵐ[μ] μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ (X n) | tailSigma X])
-    (m : ℕ) :
-  Measure.map (fun ω => fun i : Fin m => X i ω) μ
-    = μ.bind (fun ω => Measure.pi fun _ : Fin m => ν ω) :=
-  finite_product_formula X hX hX_meas ν hν_prob hν_meas hν_law m (fun i => (i : ℕ))
-    fun _ _ => id
-
 end Exchangeability.DeFinetti.ViaMartingale

--- a/Exchangeability/Probability/CondExp.lean
+++ b/Exchangeability/Probability/CondExp.lean
@@ -68,17 +68,9 @@ This file centralizes these patterns to keep the main proofs clean and maintaina
 4. Encode reusable probabilistic insights
 
 **Keep in main proofs:**
-- Domain-specific constructions (finFutureSigma, tailSigma, etc.)
+- Domain-specific constructions (`tailSigma`, etc.)
 - Proof-specific calculations
 - High-level proof architecture
-
-## Related Files
-
-- **CondExpBasic.lean**: Basic conditional expectation utilities
-- **CondProb.lean**: Conditional probability definitions
-- **ViaMartingale.lean**: Main consumer of this API
-- **ViaL2.lean**: Uses integrability lemmas
-- **ViaKoopman.lean**: Uses integrability and independence lemmas
 
 ## References
 
@@ -444,9 +436,8 @@ For integrable functions f, g, the conditional expectation is contractive in L¹
   ‖E[f|m] - E[g|m]‖₁ ≤ ‖f - g‖₁
 
 This is the key operator-theoretic property that makes CE well-behaved. -/
-@[nolint unusedArguments]
 lemma condExp_L1_lipschitz [IsFiniteMeasure μ]
-    {m : MeasurableSpace Ω} (_hm : m ≤ ‹_›)
+    {m : MeasurableSpace Ω}
     {f g : Ω → ℝ} (hf : Integrable f μ) (hg : Integrable g μ) :
     ∫ ω, |μ[f|m] ω - μ[g|m] ω| ∂μ ≤ ∫ ω, |f ω - g ω| ∂μ := by
   -- Use the mathlib lemma integral_abs_condExp_le which gives ∫|E[f|m]| ≤ ∫|f|


### PR DESCRIPTION
## Summary

Three reviewer-flagged cleanups from the fresh-cascades list, bundled.

**Net −60 lines across 6 files.** No public API broken; `tailSigma_eq_iInf_rev` left alone (blueprint-cited — reviewer's caution flag was right).

## 1. Unify on the central `condExp_L1_lipschitz`

PR #80 kept a Koopman-local `condExp_L1_lipschitz'` wrapper because the central `Exchangeability.Probability.condExp_L1_lipschitz` declared its sub-σ-algebra hypothesis as `_hm : m ≤ ‹_›`, and at the path-space call sites the elaborator resolved `‹_›` to `shiftInvariantSigma` instead of `MeasurableSpace.pi`. Plumbing `(shiftInvariantSigma_le)` through explicit args (LSP's suggested pattern) didn't pan out at build time — same instance-pollution error.

**Root cause:** `_hm` carries `@[nolint unusedArguments]` because nothing in the proof body actually consumes it — `condExp_sub` and `integral_abs_condExp_le` both take `m` directly. The cleanest fix is to drop the dead hypothesis from the central signature; that removes the `‹_›` resolution point entirely.

- `Probability/CondExp.lean`: removed `(_hm : m ≤ ‹_›)` and the now-redundant `@[nolint unusedArguments]` from `condExp_L1_lipschitz`.
- `ViaKoopman/InfraGeneralized.lean`: deleted the local `condExp_L1_lipschitz'` wrapper (12-line doc + 14-line body).
- `ViaKoopman/CesaroPairFactorization.lean:194` and `ViaKoopman/CesaroL1Bounded.lean:433`: now call `Exchangeability.Probability.condExp_L1_lipschitz (μ := μ) (m := mSI) …` directly.

## 2. Delete two dead one-reference compatibility shims

Both have zero in-repo references (code + blueprint).

- `Bridge/CesaroToCondExp.lean:64` — `μ_path'` (alternate form of `μ_path` with μ implicit).
- `ViaMartingale/FiniteProduct.lean:442` — `finite_product_formula_id'` ("convenience identity case useful for tests and bridging").

## 3. Stale module-doc in `Probability/CondExp.lean`

- Dropped `finFutureSigma` from "Domain-specific constructions" — that module was deleted in PR #85.
- Dropped the `## Related Files` section: listed `CondExpBasic.lean` and `CondProb.lean`, neither of which exists anywhere in the repo.

## Items left for follow-up

- `RevFiltration.lean:60 tailSigma_eq_iInf_rev` — reviewer flagged as potentially dead but it's in `blueprint/lean_decls:8`, so leaving alone.

## Verification

- `lake build` clean (3524/3524, no new warnings).
- `lake exe checkdecls blueprint/lean_decls` exit 0.
- `#print axioms` on `deFinetti_viaL2`, `deFinetti`, `deFinetti_viaKoopman`: `[propext, Classical.choice, Quot.sound]` (unchanged).

## Test plan
- [x] `lake build` clean
- [x] `lake exe checkdecls blueprint/lean_decls` passes
- [x] `#print axioms` on the three main theorems unchanged
- [x] No remaining decl-signature changes beyond `_hm` drop on `condExp_L1_lipschitz` (which is positional + underscored, so no named-arg breakage)