### PR TITLE
Drop dead re-exports + one-line alias across PathSpace / Util / Bridge

### DIFF
--- a/Exchangeability/Bridge/CesaroToCondExp.lean
+++ b/Exchangeability/Bridge/CesaroToCondExp.lean
@@ -135,18 +135,12 @@ lemma contractable_shift_invariant_law {Ω : Type*} [MeasurableSpace Ω]
   -- hX n k hk_strictMono : Measure.map (fun ω i => X (k i) ω) μ = Measure.map (fun ω i => X i.val ω) μ
   rw [hX n k hk_strictMono]
 
-/-- Measurability of `shift` on path space. -/
-@[measurability, fun_prop]
-lemma measurable_shift_real : Measurable (shift (α := ℝ)) :=
-  shift_measurable
-
 /-- **Bridge 1'.** Package the previous lemma as `MeasurePreserving` for MET. -/
 lemma measurePreserving_shift_path {Ω : Type*} [MeasurableSpace Ω]
     (μ : Measure Ω) [IsProbabilityMeasure μ]
     (X : ℕ → Ω → ℝ) (hX : Exchangeability.Contractable μ X)
     (hX_meas : ∀ n, Measurable (X n)) :
-    MeasurePreserving (shift (α := ℝ)) (μ_path μ X) (μ_path μ X) := by
-  refine ⟨measurable_shift_real, ?_⟩
-  exact contractable_shift_invariant_law μ hX hX_meas
+    MeasurePreserving (shift (α := ℝ)) (μ_path μ X) (μ_path μ X) :=
+  ⟨shift_measurable, contractable_shift_invariant_law μ hX hX_meas⟩
 
 end Exchangeability.Bridge

--- a/Exchangeability/Contractability.lean
+++ b/Exchangeability/Contractability.lean
@@ -260,8 +260,7 @@ lemma Contractable.symm {μ : Measure Ω} {X : ℕ → Ω → α}
   (hX m k hk).symm
 
 -- Re-export StrictMono utilities for backward compatibility
-open Util.StrictMono (strictMono_add_left strictMono_add_right
-                       strictMono_Fin_ge_id fin_val_strictMono)
+open Util.StrictMono (strictMono_Fin_ge_id)
 
 /--
 Any strictly increasing function can be extended to a permutation.

--- a/Exchangeability/DeFinetti/MartingaleHelpers.lean
+++ b/Exchangeability/DeFinetti/MartingaleHelpers.lean
@@ -41,9 +41,9 @@ namespace MartingaleHelpers
 -- Re-export cylinder infrastructure from PathSpace for backward compatibility
 export PathSpace (cylinder cylinder_measurable firstRMap firstRSigma firstRCylinder
   firstRCylinder_measurable_in_firstRSigma firstRCylinder_measurable_ambient
-  measurable_firstRMap firstRSigma_le_ambient firstRSigma_mono firstRCylinder_zero
+  measurable_firstRMap firstRSigma_le_ambient firstRCylinder_zero
   mem_firstRCylinder_iff firstRCylinder_univ firstRCylinder_inter mem_cylinder_iff
-  cylinder_measurable_set cylinder_zero cylinder_univ cylinder_inter)
+  cylinder_zero)
 
 open MeasureTheory
 

--- a/Exchangeability/PathSpace/CylinderHelpers.lean
+++ b/Exchangeability/PathSpace/CylinderHelpers.lean
@@ -13,27 +13,17 @@ This file contains infrastructure for working with cylinder sets on path space `
 Cylinder sets are fundamental objects in probability theory on sequence spaces,
 consisting of events determined by finitely many coordinates.
 
-Originally extracted from `MartingaleHelpers.lean` for broader reusability.
-
 ## Main definitions
 
-* `tailCylinder r C`: Cylinder on the first `r` tail coordinates (shifted by one)
 * `cylinder r C`: Standard cylinder on the first `r` coordinates starting at index 0
-* `finCylinder r C`: Cylinder for functions with domain `Fin r`
 * `firstRMap X r`: Map collecting the first `r` coordinates of a process
 * `firstRCylinder X r C`: Finite block cylinder event on the first `r` coordinates
 
 ## Main results
 
-* Measurability lemmas for all cylinder types
+* Measurability lemmas for cylinder types
 * Extensionality properties (universal sets, intersections)
 * Bridge lemmas connecting different cylinder formulations
-
-## Implementation notes
-
-This file is designed to be general-purpose infrastructure, not specific to any
-particular proof approach (martingale, Koopman, L²). It only imports mathlib
-and has no project dependencies.
 -/
 
 noncomputable section
@@ -120,27 +110,6 @@ lemma firstRSigma_le_ambient
   obtain ⟨t, ht, rfl⟩ := hs
   exact (measurable_firstRMap X r hX) ht
 
-omit [MeasurableSpace Ω] in
-/-- Stronger version: firstRSigma increases with r. -/
-lemma firstRSigma_mono
-    (X : ℕ → Ω → α) {r s : ℕ} (hrs : r ≤ s) :
-    firstRSigma X r ≤ firstRSigma X s := by
-  -- Strategy: firstRMap X r factors through firstRMap X s via projection
-  simp only [firstRSigma]
-  intro t ht
-  obtain ⟨u, hu, rfl⟩ := ht
-  -- Define projection π : (Fin s → α) → (Fin r → α) taking first r coords
-  let π : (Fin s → α) → (Fin r → α) := fun f i => f ⟨i.val, Nat.lt_of_lt_of_le i.isLt hrs⟩
-  -- Show firstRMap X r = π ∘ firstRMap X s
-  have h_comp : firstRMap X r = π ∘ firstRMap X s := by
-    funext ω i
-    simp [firstRMap, π]
-  -- π is measurable (composition of coordinate projections)
-  have hπ : Measurable π := by fun_prop
-  -- Preimage factors through composition
-  rw [h_comp, Set.preimage_comp]
-  exact ⟨π ⁻¹' u, hπ hu, rfl⟩
-
 omit [MeasurableSpace Ω] [MeasurableSpace α] in
 /-- The empty cylinder (r = 0) is the whole space. -/
 @[simp]
@@ -183,33 +152,10 @@ omit [MeasurableSpace α] in
 @[simp] lemma mem_cylinder_iff {r : ℕ} {C : Fin r → Set α} {f : ℕ → α} :
     f ∈ cylinder (α:=α) r C ↔ ∀ i : Fin r, f i ∈ C i := Iff.rfl
 
-/-- The cylinder set is measurable when each component set is measurable. -/
-lemma cylinder_measurable_set {r : ℕ} {C : Fin r → Set α}
-    (hC : ∀ i, MeasurableSet (C i)) :
-    MeasurableSet (cylinder (α:=α) r C) :=
-  cylinder_measurable hC
-
 omit [MeasurableSpace α] in
 /-- Empty cylinder is the whole space. -/
 @[simp] lemma cylinder_zero : cylinder (α:=α) 0 (fun _ => Set.univ) = Set.univ := by
   ext f; simp [cylinder]
-
-omit [MeasurableSpace α] in
-/-- Cylinder on universal sets is the whole space. -/
-lemma cylinder_univ {r : ℕ} : cylinder (α:=α) r (fun _ => Set.univ) = Set.univ := by
-  ext f; simp [cylinder]
-
-omit [MeasurableSpace α] in
-/-- Cylinders form intersections coordinate-wise. -/
-lemma cylinder_inter {r : ℕ} {C D : Fin r → Set α} :
-    cylinder (α:=α) r C ∩ cylinder (α:=α) r D = cylinder (α:=α) r (fun i => C i ∩ D i) := by
-  ext f
-  simp [cylinder, Set.mem_inter_iff]
-  constructor
-  · intro ⟨hC, hD⟩ i
-    exact ⟨hC i, hD i⟩
-  · intro h
-    exact ⟨fun i => (h i).1, fun i => (h i).2⟩
 
 end CylinderBridge
 

--- a/Exchangeability/Util/StrictMono.lean
+++ b/Exchangeability/Util/StrictMono.lean
@@ -15,8 +15,6 @@ in subsequence selection and permutation construction arguments.
 ## Main Results
 
 * `strictMono_Fin_ge_id`: For strictly monotone `k : Fin m → ℕ`, values dominate indices
-* `strictMono_add_left`, `strictMono_add_right`: Addition preserves strict monotonicity
-* `fin_val_strictMono`: The identity `Fin n → ℕ` is strictly monotone
 * `injective_implies_strictMono_perm`: Any injective `k : Fin m → ℕ` can be composed with
   a permutation to become strictly monotone
 
@@ -32,22 +30,6 @@ All lemmas are general-purpose utilities for `Fin` and strict monotonicity.
 namespace Exchangeability.Util.StrictMono
 
 variable {m n : ℕ}
-
-/-- Composing strictly monotone functions with left addition preserves strict monotonicity.
-
-For any strictly monotone `k : Fin m → ℕ` and constant `c`, the function
-`i ↦ c + k(i)` is also strictly monotone. -/
-lemma strictMono_add_left (k : Fin m → ℕ) (hk : StrictMono k) (c : ℕ) :
-    StrictMono (fun i => c + k i) :=
-  fun ⦃_ _⦄ hab ↦ Nat.add_lt_add_left (hk hab) c
-
-/-- Composing strictly monotone functions with right addition preserves strict monotonicity.
-
-For any strictly monotone `k : Fin m → ℕ` and constant `c`, the function
-`i ↦ k(i) + c` is also strictly monotone. -/
-lemma strictMono_add_right (k : Fin m → ℕ) (hk : StrictMono k) (c : ℕ) :
-    StrictMono (fun i => k i + c) :=
-  fun ⦃_ _⦄ hab ↦ Nat.add_lt_add_right (hk hab) c
 
 /--
 For a strictly monotone function `k : Fin m → ℕ`, the values dominate the indices.
@@ -87,15 +69,6 @@ lemma strictMono_Fin_ge_id {k : Fin m → ℕ} (hk : StrictMono k) (i : Fin m) :
           _ ≤ k j + 1 := Nat.add_le_add_right ih' 1
           _ ≤ k j_succ := Nat.succ_le_of_lt hk_lt
   exact this i.val i.isLt
-
-/--
-The identity function `Fin n → ℕ` is strictly monotone.
-
-The canonical embedding of `Fin n` into `ℕ` preserves the order structure.
--/
-lemma fin_val_strictMono : StrictMono (fun i : Fin n => i.val) := by
-  intro i j hij
-  exact hij
 
 /-- Any injective function `k : Fin m → ℕ` can be composed with a permutation
 to become strictly monotone.


### PR DESCRIPTION
## Summary

Bundle 1 of the fresh-cascades audit. **Net −88 lines across 5 files.** No public callers broken — repo-wide grep showed each candidate had `ext_refs=1` and the single reference was an `export`/`open` list, never invoked by name from any real caller.

## 1. `PathSpace/CylinderHelpers.lean` (−50 lines)

Deleted four dead re-exports (`firstRSigma_mono`, `cylinder_measurable_set`, `cylinder_univ`, `cylinder_inter`). Trimmed the corresponding names from the `export PathSpace (...)` list in `DeFinetti/MartingaleHelpers.lean`.

Also fixed the module-doc header:
- Dropped fictional `tailCylinder` / `finCylinder` from "Main definitions" (neither has ever existed in this file).
- Dropped the "no project dependencies" claim (false — the file imports `Exchangeability.PathSpace.Shift`).
- Removed the "Originally extracted from `MartingaleHelpers.lean`" historical note.

## 2. `Util/StrictMono.lean` (−27 lines)

Same pattern. Deleted three dead decls (`strictMono_add_left`, `strictMono_add_right`, `fin_val_strictMono`). Trimmed them from the `open Util.StrictMono (...)` line in `Contractability.lean`. Updated the file's "Main Results" header.

Kept: `strictMono_Fin_ge_id` (one real call at `Contractability.lean:339`) and `injective_implies_strictMono_perm` (two real calls in `BridgeProperty.lean` and `ViaKoopman.lean`).

## 3. `Bridge/CesaroToCondExp.lean` (−6 lines)

`measurable_shift_real` was a one-line alias for `shift_measurable` with a single caller (`measurePreserving_shift_path`). Inlined `shift_measurable` directly and collapsed `measurePreserving_shift_path`'s body from a `refine ⟨…, ?_⟩; exact …` block to a single `⟨…, …⟩` constructor.

## Verification

- `lake build` clean (3524/3524, no new warnings).
- `lake exe checkdecls blueprint/lean_decls` exit 0.
- `#print axioms` on `deFinetti_viaL2`, `deFinetti`, `deFinetti_viaKoopman`: `[propext, Classical.choice, Quot.sound]` (unchanged).

## Test plan
- [x] `lake build` clean
- [x] `lake exe checkdecls blueprint/lean_decls` passes
- [x] `#print axioms` on the three main theorems unchanged
- [x] No remaining decl bodies or kept-decl signatures changed