### PR TITLE
Add blueprint consistency script + PR-triggered CI check

### DIFF
--- a/.github/workflows/blueprint-check.yml
+++ b/.github/workflows/blueprint-check.yml
@@ -1,0 +1,23 @@
+name: Blueprint consistency
+
+on:
+  pull_request:
+    paths:
+      - 'blueprint/src/content.tex'
+      - 'blueprint/lean_decls'
+      - 'blueprint/check_blueprint.py'
+      - '.github/workflows/blueprint-check.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run blueprint consistency check
+        run: |
+          python3 blueprint/check_blueprint.py

--- a/.github/workflows/blueprint-check.yml
+++ b/.github/workflows/blueprint-check.yml
@@ -7,6 +7,7 @@ on:
       - 'blueprint/lean_decls'
       - 'blueprint/check_blueprint.py'
       - '.github/workflows/blueprint-check.yml'
+      - '.github/workflows/blueprint.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -41,6 +41,10 @@ jobs:
         run: |
           ~/.elan/bin/lake exe checkdecls blueprint/lean_decls
 
+      - name: Check blueprint consistency
+        run: |
+          python3 blueprint/check_blueprint.py
+
       - name: Free up disk space
         run: |
           sudo rm -rf /usr/share/dotnet

--- a/blueprint/check_blueprint.py
+++ b/blueprint/check_blueprint.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Blueprint consistency checks.
+
+Runs three checks against `blueprint/src/content.tex` and `blueprint/lean_decls`:
+
+  1. Every `\\lean{X}` in content.tex has X listed in `blueprint/lean_decls`.
+  2. Every entry in `blueprint/lean_decls` is `\\lean{}`-cited from content.tex.
+  3. Every `\\ref{Y}` / `\\uses{Y, Z, ...}` target resolves to a `\\label{Y}`
+     defined in content.tex.
+
+Plus a duplicate-label check.
+
+Exits 0 on clean, 1 on any drift. Designed to run in CI alongside
+`lake exe checkdecls blueprint/lean_decls`.
+
+Run with no args from any directory; resolves files relative to this script.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+CONTENT = ROOT / "src" / "content.tex"
+DECLS = ROOT / "lean_decls"
+
+LEAN_RE = re.compile(r"\\lean\{([^}]+)\}")
+LABEL_RE = re.compile(r"\\label\{([^}]+)\}")
+REF_RE = re.compile(r"\\ref\{([^}]+)\}")
+USES_RE = re.compile(r"\\uses\{([^}]+)\}")
+COMMENT_RE = re.compile(r"(?<!\\)%.*$", re.MULTILINE)
+
+
+def strip_comments(text: str) -> str:
+    """Drop LaTeX `%`-comments, respecting `\\%` escapes."""
+    return COMMENT_RE.sub("", text)
+
+
+def parse_content(text: str) -> tuple[set[str], set[str], list[str], set[str]]:
+    """Return (lean_cites, labels_defined, label_dups, label_refs).
+
+    `label_dups` is a list (not set) so the report can show duplicates verbatim.
+    `label_refs` is the union of `\\ref{...}` and the comma-separated entries
+    inside each `\\uses{...}`.
+    """
+    text = strip_comments(text)
+    lean_cites = {m.strip() for m in LEAN_RE.findall(text)}
+
+    label_list = [m.strip() for m in LABEL_RE.findall(text)]
+    labels_defined = set(label_list)
+    seen: set[str] = set()
+    label_dups: list[str] = []
+    for lbl in label_list:
+        if lbl in seen and lbl not in label_dups:
+            label_dups.append(lbl)
+        seen.add(lbl)
+
+    refs: set[str] = set(m.strip() for m in REF_RE.findall(text))
+    for group in USES_RE.findall(text):
+        for part in group.split(","):
+            part = part.strip()
+            if part:
+                refs.add(part)
+
+    return lean_cites, labels_defined, label_dups, refs
+
+
+def parse_decls(text: str) -> set[str]:
+    return {line.strip() for line in text.splitlines() if line.strip()}
+
+
+def report(title: str, items: list[str] | set[str]) -> None:
+    items = sorted(items)
+    print(f"  {title} ({len(items)}):")
+    for x in items:
+        print(f"    - {x}")
+
+
+def main() -> int:
+    if not CONTENT.exists():
+        print(f"error: {CONTENT} not found", file=sys.stderr)
+        return 2
+    if not DECLS.exists():
+        print(f"error: {DECLS} not found", file=sys.stderr)
+        return 2
+
+    content_text = CONTENT.read_text()
+    decls_text = DECLS.read_text()
+
+    lean_cites, labels_defined, label_dups, refs = parse_content(content_text)
+    decls = parse_decls(decls_text)
+
+    cited_not_in_decls = sorted(lean_cites - decls)
+    in_decls_not_cited = sorted(decls - lean_cites)
+    refs_without_label = sorted(refs - labels_defined)
+
+    failures = 0
+
+    if cited_not_in_decls:
+        failures += 1
+        print("FAIL: \\lean{...} citations missing from blueprint/lean_decls:")
+        report("missing", cited_not_in_decls)
+        print("  (add these to blueprint/lean_decls, or remove the \\lean{} citation)")
+        print()
+
+    if in_decls_not_cited:
+        failures += 1
+        print("FAIL: blueprint/lean_decls entries with no \\lean{} citation in content.tex:")
+        report("orphan", in_decls_not_cited)
+        print("  (cite them in content.tex, or remove them from lean_decls)")
+        print()
+
+    if refs_without_label:
+        failures += 1
+        print("FAIL: \\ref{} or \\uses{} targets with no matching \\label{}:")
+        report("dangling", refs_without_label)
+        print()
+
+    if label_dups:
+        failures += 1
+        print("FAIL: duplicate \\label{} definitions:")
+        report("duplicate", label_dups)
+        print()
+
+    if failures == 0:
+        n_lean = len(lean_cites)
+        n_labels = len(labels_defined)
+        n_refs = len(refs)
+        n_decls = len(decls)
+        print(
+            f"OK: {n_lean} \\lean cites, {n_labels} labels, "
+            f"{n_refs} refs/uses, {n_decls} lean_decls — all consistent."
+        )
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/blueprint/check_blueprint.py
+++ b/blueprint/check_blueprint.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
 """Blueprint consistency checks.
 
-Runs three checks against `blueprint/src/content.tex` and `blueprint/lean_decls`:
+Runs four checks against `blueprint/src/content.tex` and `blueprint/lean_decls`:
 
   1. Every `\\lean{X}` in content.tex has X listed in `blueprint/lean_decls`.
   2. Every entry in `blueprint/lean_decls` is `\\lean{}`-cited from content.tex.
   3. Every `\\ref{Y}` / `\\uses{Y, Z, ...}` target resolves to a `\\label{Y}`
      defined in content.tex.
-
-Plus a duplicate-label check.
+  4. No duplicate `\\label{}` definitions.
 
 Exits 0 on clean, 1 on any drift. Designed to run in CI alongside
 `lake exe checkdecls blueprint/lean_decls`.


### PR DESCRIPTION
## Summary

Follow-up to the PR #89 blueprint hygiene work. PR #89 needed manual cross-referencing between `content.tex` and `lean_decls` (`checkdecls` only checks one direction); this PR automates the four checks and runs them on every PR that touches blueprint files.

**Net +168 lines, all new files:** one Python script + one new CI workflow + one new step in the existing workflow.

## What's in it

### `blueprint/check_blueprint.py` (Python 3 stdlib, ~140 lines)

Four checks against `blueprint/src/content.tex` and `blueprint/lean_decls`:

1. Every `\lean{X}` cite in content.tex has X listed in `lean_decls`.
2. Every entry in `lean_decls` is `\lean{}`-cited somewhere in content.tex (catches orphans left behind after a node is removed).
3. Every `\ref{Y}` / `\uses{Y, Z, ...}` target resolves to a `\label{Y}` defined in content.tex.
4. No duplicate `\label{}` definitions.

Strips LaTeX `%`-comments (respecting `\%` escapes) before scanning, so commented-out citations and labels don't trip false positives. Each failure prints a labelled list of offending names plus a one-line fix hint. Exits 0 on clean, 1 on any drift. Designed to complement `lake exe checkdecls`, not replace it.

**Smoke-tested all four failure modes** (missing cite, orphan decl, dangling `\ref`, duplicate `\label`) — each produces a labelled report with exit 1, and removing the perturbation restores exit 0.

### `.github/workflows/blueprint-check.yml` (new, ~25 lines)

PR-triggered, path-filtered to fire only when one of the blueprint files (`content.tex` / `lean_decls` / `check_blueprint.py`) or this workflow itself changes. Runs the Python script directly — no Lean toolchain, no mathlib cache, no `lake build`. Catches drift in seconds, before merge.

### `.github/workflows/blueprint.yml` (one new step)

Added the same `python3 blueprint/check_blueprint.py` step to the existing main-push deployment workflow as a backstop after `lake exe checkdecls`. Effectively free — the Lean build is the expensive part; this script runs in <1 second.

## Initial state on current main

```
OK: 52 \lean cites, 53 labels, 50 refs/uses, 52 lean_decls — all consistent.
```

## Test plan
- [x] Script exits 0 on clean tree
- [x] All four failure modes detected (manual perturbation tests)
- [x] CI workflow fires on this PR (run #26346876990, success in 3s)