### PR TITLE
chore: ring → ring_nf at 4 sites (silence the only build warnings)

### DIFF
--- a/Exchangeability/DeFinetti/ViaKoopman/BlockAverage.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/BlockAverage.lean
@@ -81,7 +81,7 @@ lemma blockAvg_eq_cesaro_shifted {m n : ℕ} (hn : 0 < n) (k : Fin m) (f : α �
   rw [shift_iterate_apply]
   congr 1
   -- j + k.val * n = k.val * n + j
-  ring
+  ring_nf
 
 /-! ### Measurability of Block Averages -/
 

--- a/Exchangeability/DeFinetti/ViaKoopman/CesaroL2ToL1.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/CesaroL2ToL1.lean
@@ -295,8 +295,8 @@ lemma optionB_Step4b_AB_close
     -- A n ω - B n ω = S/(n+1) + g(ω n)/(n+1) - S/n
     --               = -S/(n(n+1)) + g(ω n)/(n+1)
     calc |1 / (↑n + 1) * (S + g (ω n)) - 1 / ↑n * S|
-        = |S / (↑n + 1) + g (ω n) / (↑n + 1) - S / ↑n| := by ring
-      _ = |-S / (↑n * (↑n + 1)) + g (ω n) / (↑n + 1)| := by field_simp; ring
+        = |S / (↑n + 1) + g (ω n) / (↑n + 1) - S / ↑n| := by ring_nf
+      _ = |-S / (↑n * (↑n + 1)) + g (ω n) / (↑n + 1)| := by field_simp; ring_nf
       _ ≤ |-S / (↑n * (↑n + 1))| + |g (ω n) / (↑n + 1)| := by
             -- triangle inequality |x + y| ≤ |x| + |y|
             exact abs_add_le _ _

--- a/Exchangeability/DeFinetti/ViaL2/BlockAverages/LongVsTail.lean
+++ b/Exchangeability/DeFinetti/ViaL2/BlockAverages/LongVsTail.lean
@@ -333,7 +333,7 @@ lemma l2_bound_long_vs_tail
               · congr 1
                 ext j
                 simp only
-                ring
+                ring_nf
               -- Prove injectivity
               · intro j₁ _ j₂ _ h
                 simp only [Fin.mk.injEq] at h


### PR DESCRIPTION
## Summary

PR A from the cleanup queue. **+4 / −4 lines across 3 files**, all proof bodies.

`lake build` had been emitting four "Try this: ring_nf — The ring tactic failed to close the goal" info messages — these are the only warnings the build emits. Each is a single tactic in a longer chain; swapping `ring` → `ring_nf` closes all four.

## Sites

| File | Line | Context |
|---|---|---|
| `ViaL2/BlockAverages/LongVsTail.lean` | 336 | `simp only; ring` ending a `congr; ext` block |
| `ViaKoopman/CesaroL2ToL1.lean` | 298 | `:= by ring` on a ℝ-division equality |
| `ViaKoopman/CesaroL2ToL1.lean` | 299 | inner `ring` of `field_simp; ring` |
| `ViaKoopman/BlockAverage.lean` | 84 | `congr 1; ring` for `j + k.val * n = k.val * n + j` on ℕ |

## Verification

- `lake build` **fully clean** — 0 warnings, 0 errors (was 4 info messages before this PR).
- `#print axioms` on `deFinetti_viaL2`, `deFinetti`, `deFinetti_viaKoopman`: `[propext, Classical.choice, Quot.sound]` (unchanged).

## Test plan
- [x] `lake build` clean and warning-free
- [x] `#print axioms` on the three main theorems unchanged