### PR TITLE
chore: stale-doc cleanup — wrong default-proof / axiomatized / sorry / axiom claims

### DIFF
--- a/Exchangeability/DeFinetti.lean
+++ b/Exchangeability/DeFinetti.lean
@@ -23,22 +23,28 @@ including the tail σ-algebra definition and the main theorem statements.
 
 ## Three proof approaches (Kallenberg 2005)
 
-This formalization keeps track of all three proofs of Theorem 1.1 highlighted by
-Kallenberg. The **complete proofs** are in separate files to manage dependencies:
+All three proofs of Theorem 1.1 from Kallenberg are formalized. They differ in
+machinery and target type:
 
-1. **First proof** (`ViaKoopman.lean`): Uses the Mean Ergodic Theorem via the
-   Koopman operator on L²(μ). Heavy dependencies (ergodic theory).
+1. **Martingale proof** (`ViaMartingale.lean`, re-exported by `DeFinetti.Theorem`
+   as the default): Aldous' reverse martingale argument with tail σ-algebra
+   factorization. The directing kernel is built via mathlib's `condExpKernel`.
+   Handles general standard Borel target spaces.
 
-2. **Second proof** (`ViaL2.lean`): Uses an elementary L² contractability bound
-   (Lemma 1.2). **Lightest dependencies** - this is the default.
+2. **L² proof** (`ViaL2.lean`): Uses the elementary L² contractability bound
+   (Kallenberg Lemma 1.2). Lightest dependencies among the three. Currently
+   stated for real-valued sequences via the Stieltjes-based directing-measure
+   construction.
 
-3. **Third proof** (`ViaMartingale.lean`) ✅ **COMPLETE**: Follows Aldous' 
-   martingale argument with reverse martingale convergence and tail σ-algebra 
-   factorization. Medium dependencies (directing measure axiomatized).
+3. **Koopman proof** (`ViaKoopman.lean`): Uses the Mean Ergodic Theorem via the
+   Koopman operator on L²(μ). Heavier ergodic-theory dependencies. Currently
+   stated for real-valued sequences.
 
-**To use the theorem**: `import Exchangeability.DeFinetti.Theorem` (gets the default proof).
+**To use the theorem**: `import Exchangeability.DeFinetti.Theorem` (gets the
+martingale proof).
 
-**To see a specific proof**: `import Exchangeability.DeFinetti.ViaL2` (or `ViaKoopman`, `ViaMartingale`).
+**To see a specific proof**: `import Exchangeability.DeFinetti.ViaL2`,
+`ViaKoopman`, or `ViaMartingale`.
 
 ## References
 
@@ -120,8 +126,8 @@ automatically.
 - **(iii) → (ii)**: `exchangeable_of_conditionallyIID` ✓ **PROVED** in `ConditionallyIID.lean`
 - **(ii) → (i)**: `contractable_of_exchangeable` ✓ **PROVED** in `Contractability.lean`
 
-**Main theorems are proved in `Exchangeability.DeFinetti.Theorem`** (default L² proof).
-Import that file to use the completed theorems.
+**Main theorems are proved in `Exchangeability.DeFinetti.Theorem`** (which re-exports
+the martingale proof as the default). Import that file to use the completed theorems.
 -/
 
 end Probability

--- a/Exchangeability/DeFinetti/ViaKoopman/ContractableFactorization.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/ContractableFactorization.lean
@@ -808,21 +808,13 @@ end KernelIndependence
 
 /-! ### Bridge to CommonEnding
 
-The bridge lemma `indicator_product_bridge_contractable` would connect the CE-based
-factorization in this file to the `ConditionallyIID` definition required by
-`CommonEnding.conditional_iid_from_directing_measure`.
-
-The key insight is:
-- For injective k, sort to get StrictMono ρ with permutation σ such that k = ρ ∘ σ
-- Apply contractability to get integral equality
-- Use CE factorization and the ν ↔ CE relationship
-
-This bridge is needed to complete the sorry at line 178 of TheoremViaKoopman.lean,
-which proves `Contractable μ X → Exchangeable μ X ∧ ConditionallyIID μ X`.
-
-**Status**: Incomplete. The path-space proof in `ViaKoopman.lean` is complete;
-the original-space bridge requires additional work to match the `ConditionallyIID`
-definition's bind-based formula.
+The CE-based factorization above feeds `indicator_product_bridge_contractable`
+(in `Exchangeability/DeFinetti/BridgeProperty.lean`), which converts it into the
+shape consumed by `CommonEnding.conditional_iid_from_directing_measure`. The
+construction is: for injective `k`, sort to obtain a strictly-monotone `ρ` with
+permutation `σ` such that `k = ρ ∘ σ`, apply contractability to get integral
+equality, and combine with the CE factorization via the `ν` ↔ conditional
+expectation identification.
 -/
 
 end Exchangeability.DeFinetti.ViaKoopman

--- a/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/L2.lean
+++ b/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/L2.lean
@@ -664,7 +664,7 @@ lemma cesaro_to_condexp_L2
     -- Step (i): Exchangeability implies equal set integrals on tail events
     --   Claim: ∀ A ∈ tailSigma, ∀ j, ∫_A f(X_j) dμ = ∫_A f(X_0) dμ
     --   Proof: Use Exchangeability.Contractable + tail invariance under permutations
-    --   Alternative: Use condExp_shift_eq_condExp axiom from ShiftInvariance.lean
+    --   Alternative: Use condExp_shift_eq_condExp lemma from CondExpShiftInvariance.lean
     --
     -- Step (ii): Block averages have constant set integral on tail events
     --   Claim: ∀ A ∈ tailSigma, ∫_A blockAvg_n dμ = ∫_A f(X_0) dμ for all n
@@ -687,7 +687,7 @@ lemma cesaro_to_condexp_L2
     --
     -- INFRASTRUCTURE REQUIREMENTS:
     -- 1. Contractable/Exchangeable → set integral invariance on tail events
-    --    Key: Use condExp_shift_eq_condExp axiom from ShiftInvariance.lean
+    --    Key: Use condExp_shift_eq_condExp lemma from CondExpShiftInvariance.lean
     --    ∫_A f(X_j) dμ = ∫ 1_A · μ[f(X_j)|tail] dμ = ∫ 1_A · μ[f(X_0)|tail] dμ = ∫_A f(X_0) dμ
     -- 2. L² → set integral convergence (Hölder: |∫_A g dμ| ≤ μ(A)^{1/2} · ‖g‖₂)
     --    Use: tendsto_setIntegral_of_L1 or norm_setIntegral_le_of_norm_le_const_ae

--- a/Exchangeability/DeFinetti/ViaL2/DirectingMeasureCore.lean
+++ b/Exchangeability/DeFinetti/ViaL2/DirectingMeasureCore.lean
@@ -136,16 +136,6 @@ lemma alphaIic_ae_tendsto_one_at_top
   filter_upwards [h_ae_eq, h_CE_conv] with ω h_eq h_conv
   exact h_conv.congr (fun n => (h_eq n).symm)
 
--- **Note on `cdf_from_alpha_limits`:**
--- The axiom in MoreL2Helpers.lean requires the CDF limits to hold for ALL ω.
--- However, from the L¹ construction, we can only prove a.e. convergence:
--- - `alphaIic_ae_tendsto_zero_at_bot`: a.e. convergence to 0 as t → -∞
--- - `alphaIic_ae_tendsto_one_at_top`: a.e. convergence to 1 as t → +∞
---
--- The axiom should be weakened to an a.e. statement, and the `directing_measure`
--- construction should handle the null set by using a default probability measure
--- for ω outside the "good" set. This is a standard technique in probability theory.
-
 /-!
 ## Directing Measure Definition
 


### PR DESCRIPTION
## Summary

PR B from the cleanup queue. **Net −12 lines across 4 files**, all docstrings/comments. No Lean code changed; build clean, axioms unchanged.

Four stale claims in module docstrings / inline comments fixed. One was worse than the original reviewer note flagged.

## Sites

### 1. `Exchangeability/DeFinetti.lean` — wrong "default proof"

The header said the **L²** proof was "the default" (three separate claims at L33, L39, L123) and called the martingale directing measure "**axiomatized**". Both wrong:

- `Exchangeability.DeFinetti.Theorem` re-exports the **martingale** proof as the default (Theorem.lean:11/22/44 already says so).
- The martingale directing measure is built via mathlib's `condExpKernel`, not axiomatized.

Rewrote the "Three proof approaches" section to describe all three routes accurately (martingale = default, general standard Borel; L² and Koopman currently real-valued). Also fixed the trailing "default L² proof" caption.

### 2. `ViaKoopman/ContractableFactorization.lean` — "sorry" reference in a 0-sorry project

A 17-line trailing block said "**Status**: Incomplete. ... needed to complete the sorry at line 178 of TheoremViaKoopman.lean". But:

- `TheoremViaKoopman.lean` is **139 lines** — line 178 doesn't exist.
- `grep -r '\bsorry\b' Exchangeability/` shows **zero** sorries in the entire project. The only matching string was this comment itself.
- The Koopman route is complete: `conditionallyIID_of_contractable_viaKoopman` builds without sorry and discharges the bridge through `indicator_product_bridge_contractable`.

Replaced with a 7-line description of the actual current pipeline.

### 3. `ViaL2/DirectingMeasureCore.lean` — "axiom in MoreL2Helpers" that's a lemma

A 9-line "Note on cdf_from_alpha_limits" said the axiom in MoreL2Helpers should be weakened to a.e. But `cdf_from_alpha_limits` is now a real `lemma` proved via `tendsto_stieltjesOfMeasurableRat_atBot`/`_atTop`. Deleted.

### 4. `ViaL2/CesaroConvergence/L2.lean` — "axiom from ShiftInvariance.lean" × 2

Two inline planning comments said "the `condExp_shift_eq_condExp` **axiom** from **ShiftInvariance.lean**". Wrong on both counts:

- It's a `lemma` (Tail/CondExpShiftInvariance.lean:50).
- The file is `CondExpShiftInvariance.lean`, not `ShiftInvariance.lean`.

Narrow s/.../.../  for both. Did not touch the surrounding implementation-plan comments — those still document the proof structure faithfully.

## Verification

- `lake build` clean (3524/3524, 0 warnings).
- `#print axioms` on `deFinetti_viaL2`, `deFinetti`, `deFinetti_viaKoopman`: `[propext, Classical.choice, Quot.sound]` (unchanged).
- `grep` confirms no surviving instances of `"axiom from ShiftInvariance"`, `"sorry at line 178"`, `"directing measure axiomatized"`, `"default L² proof"`, or `"this is the default"` (when describing L²).

## Test plan
- [x] `lake build` clean
- [x] `#print axioms` on the three main theorems unchanged
- [x] No surviving stale strings (grep verified)