### PR TITLE
chore: drop dead MartingaleHelpers re-export + clarify MeasureKernels compatibility note

### DIFF
--- a/Exchangeability/DeFinetti/MartingaleHelpers.lean
+++ b/Exchangeability/DeFinetti/MartingaleHelpers.lean
@@ -18,9 +18,6 @@ These are general-purpose utilities for:
 - Sequence shifting and manipulation
 - Finset ordering and monotonicity
 - Indicator algebra
-- Re-exports from PathSpace.CylinderHelpers for backward compatibility
-
-All lemmas are complete (no sorries) and have been validated for code quality.
 
 ## Main sections
 
@@ -28,7 +25,6 @@ All lemmas are complete (no sorries) and have been validated for code quality.
 * `SequenceShift`: Sequence shifting operations
 * `FinsetOrder`: Finset ordering and strict monotonicity lemmas
 * `IndicatorAlgebra`: Helper lemmas for indicator functions
-* Re-exports from `PathSpace.CylinderHelpers` for compatibility
 -/
 
 noncomputable section
@@ -37,13 +33,6 @@ open scoped MeasureTheory
 namespace Exchangeability
 namespace DeFinetti
 namespace MartingaleHelpers
-
--- Re-export cylinder infrastructure from PathSpace for backward compatibility
-export PathSpace (cylinder cylinder_measurable firstRMap firstRSigma firstRCylinder
-  firstRCylinder_measurable_in_firstRSigma firstRCylinder_measurable_ambient
-  measurable_firstRMap firstRSigma_le_ambient firstRCylinder_zero
-  mem_firstRCylinder_iff firstRCylinder_univ firstRCylinder_inter mem_cylinder_iff
-  cylinder_zero)
 
 open MeasureTheory
 

--- a/Exchangeability/DeFinetti/ViaMartingale/FutureRectangles.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/FutureRectangles.lean
@@ -30,7 +30,7 @@ open MeasureTheory
 
 namespace Exchangeability.DeFinetti.ViaMartingale
 
-open MartingaleHelpers
+open MartingaleHelpers Exchangeability.PathSpace
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
@@ -267,16 +267,16 @@ lemma measure_ext_of_future_rectangles
         refine ⟨0, A, hA, (fun _ => Set.univ), (fun _ => MeasurableSet.univ), ?_⟩
         ext ⟨a, f⟩
         simp only [Set.mem_prod, Set.mem_univ, and_true]
-        show a ∈ A ↔ a ∈ A ∧ f ∈ MartingaleHelpers.cylinder 0 (fun _ => Set.univ)
-        rw [MartingaleHelpers.cylinder]
+        show a ∈ A ↔ a ∈ A ∧ f ∈ PathSpace.cylinder 0 (fun _ => Set.univ)
+        rw [PathSpace.cylinder]
         simp
 
       have h_snd : ∀ (r : ℕ) (C : Fin r → Set α),
           (∀ i, MeasurableSet (C i)) →
-          MeasurableSet[MeasurableSpace.generateFrom S] (Prod.snd ⁻¹' MartingaleHelpers.cylinder r C) := by
+          MeasurableSet[MeasurableSpace.generateFrom S] (Prod.snd ⁻¹' PathSpace.cylinder r C) := by
         intro r C hC
-        have : (Prod.snd : α × (ℕ → α) → ℕ → α) ⁻¹' MartingaleHelpers.cylinder r C
-            = Set.univ ×ˢ MartingaleHelpers.cylinder r C := by
+        have : (Prod.snd : α × (ℕ → α) → ℕ → α) ⁻¹' PathSpace.cylinder r C
+            = Set.univ ×ˢ PathSpace.cylinder r C := by
           ext ⟨a, f⟩
           simp only [Set.mem_preimage, Set.mem_prod, Set.mem_univ, true_and]
         rw [this]
@@ -304,9 +304,9 @@ lemma measure_ext_of_future_rectangles
               let C : Fin r → Set α := fun j => if j.val = i then A else Set.univ
               have hC_meas : ∀ j, MeasurableSet (C j) := fun j => by
                 simp only [C]; split_ifs <;> [exact hA; exact MeasurableSet.univ]
-              have h_eq : ((fun f : ℕ → α => f i) ⁻¹' A) = MartingaleHelpers.cylinder r C := by
+              have h_eq : ((fun f : ℕ → α => f i) ⁻¹' A) = PathSpace.cylinder r C := by
                 ext f
-                simp only [C, r, Set.mem_preimage, MartingaleHelpers.cylinder]
+                simp only [C, r, Set.mem_preimage, PathSpace.cylinder]
                 constructor
                 · intro hf j
                   by_cases h : j.val = i
@@ -359,7 +359,7 @@ lemma measure_ext_of_future_rectangles
     refine ⟨0, Set.univ, MeasurableSet.univ,
       (fun _ => Set.univ), (fun _ => MeasurableSet.univ), ?_⟩
     ext ⟨a, f⟩
-    simp only [Bseq, Set.mem_prod, Set.mem_univ, true_and, MartingaleHelpers.cylinder]
+    simp only [Bseq, Set.mem_prod, Set.mem_univ, true_and, PathSpace.cylinder]
     simp
   have hμB : ∀ n, μ (Bseq n) ≠ ⊤ := fun n => by simp only [Bseq]; exact measure_ne_top μ Set.univ
 

--- a/Exchangeability/Probability/MeasureKernels.lean
+++ b/Exchangeability/Probability/MeasureKernels.lean
@@ -194,9 +194,12 @@ lemma measurable_measure_pi {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpac
 
 /-- AE-measurable version of `measurable_measure_pi`.
 
-This is the version originally proved in `CommonEnding.lean`. The measurable version
-`measurable_measure_pi` is stronger and generally more useful, but this AE version
-is kept for compatibility.
+`measurable_measure_pi` is the stronger result; this AE form is what the
+`Measure.bind_apply` consumers actually want (see
+`CommonEnding.conditional_iid_from_directing_measure`,
+`ViaMartingale/FiniteProduct.bind_apply_univ_pi`, and
+`BridgeProperty.indicator_product_bridge_contractable`). Not a compatibility
+shim — these call sites need the AE form directly.
 
 Note: The hypothesis only requires measurability for **measurable** sets, matching
 what `Kernel.measurable_coe` provides. This is the standard requirement in measure theory.


### PR DESCRIPTION
## Summary

Items 5(a) and 5(b) bundled. **Net −8 lines across 3 files**, no decl signatures changed.

## 5(b) Drop the dead `MartingaleHelpers.lean` `export PathSpace (...)` block

The 14-name re-export was labeled "for backward compatibility". Audit showed it's *almost* dead: of the 7 files importing `MartingaleHelpers` without `CylinderHelpers`, **only one** (`ViaMartingale/FutureRectangles.lean`) actually relied on it — via a mix of unqualified access (through `open MartingaleHelpers`) and 8 explicit `MartingaleHelpers.cylinder` calls. The other 6 files either don't reference the names or import `PathSpace.CylinderHelpers` directly.

Rather than keep the indirection alive for one caller, this PR routes that file straight at `PathSpace`:
- `open MartingaleHelpers Exchangeability.PathSpace` (adds the second namespace; unqualified `cylinder` etc. now resolve through PathSpace)
- 8× `MartingaleHelpers.cylinder` → `PathSpace.cylinder`

Then dropped the `export PathSpace (...)` block (5 lines) and the matching "Re-exports from PathSpace.CylinderHelpers for backward compatibility" bullets in the MartingaleHelpers module doc (2 lines).

### Audit caveat (recorded for future reference)

My initial fully-qualified `grep MartingaleHelpers.X` reported `cylinder qualified_refs=1` for this. The real cost turned out to be 27 line-hits in `FutureRectangles.lean` (mix of unqualified + qualified). Lesson: `export` lines need a second-pass audit of unqualified usage in files that have `open <re-exporting namespace>`, since `export` brings the names in unqualified through `open`.

## 5(a) Clarify `MeasureKernels.lean` "kept for compatibility" docstring

`aemeasurable_measure_pi` was labeled "kept for compatibility" — misleading. Repo grep shows 5 active callers:

- `CommonEnding.conditional_iid_from_directing_measure` (×2)
- `ViaMartingale/FiniteProduct.bind_apply_univ_pi` (×3)
- `BridgeProperty.indicator_product_bridge_contractable`

These call sites need the AE form directly (consumed by `Measure.bind_apply` / `Measure.bind`). Rewrote the docstring to point at the real consumers and explicitly note "not a compatibility shim".

No behavioural change — just the comment.

## Verification

- `lake build` clean (3524/3524, 0 warnings).
- `lake exe checkdecls blueprint/lean_decls` exit 0.
- `python3 blueprint/check_blueprint.py` exit 0.
- `#print axioms` on `deFinetti_viaL2`, `deFinetti`, `deFinetti_viaKoopman`: `[propext, Classical.choice, Quot.sound]` (unchanged).

## Test plan
- [x] `lake build` clean
- [x] `checkdecls` and `check_blueprint.py` pass
- [x] `#print axioms` on the three main theorems unchanged
- [x] No public decl signatures changed