### PR TITLE
chore: drop four dead local have-bindings in AlphaConvergence subfiles

### DIFF
--- a/Exchangeability/DeFinetti/ViaL2/AlphaConvergence/AlphaIicEq.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaConvergence/AlphaIicEq.lean
@@ -106,12 +106,6 @@ lemma alphaIic_ae_eq_alphaIicCE
             _ = (1 / (m : ℝ)) * m := by simp
             _ = 1 := by field_simp [hm_cast.ne']
 
-    -- Since A n m ∈ [0,1], we have max 0 (min 1 (A n m)) = A n m
-    have hA_clip_eq : ∀ ω, max 0 (min 1 (A n m ω)) = A n m ω := by
-      intro ω
-      obtain ⟨h0, h1⟩ := hA_in_01 ω
-      rw [min_comm, min_eq_left h1, max_eq_right h0]
-
     -- Use the fact that clipping can only make things closer when A n m ∈ [0,1]
     -- Since A n m ∈ [0,1], we have |A - clip(alpha)| ≤ |A - alpha| for all alpha
     have h_clip_le : ∀ ω, |A n m ω - max 0 (min 1 (alpha ω))| ≤ |A n m ω - alpha ω| := by

--- a/Exchangeability/DeFinetti/ViaL2/AlphaConvergence/EndpointAtBot.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaConvergence/EndpointAtBot.lean
@@ -60,12 +60,6 @@ private lemma alphaIicCE_L1_tendsto_zero_atBot
     TailSigma.tailSigma_le X hX_meas
   haveI : Fact (TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω)) := ⟨hm_le⟩
 
-  -- For each n, alphaIicCE (-(n:ℝ)) = μ[(indIic (-(n:ℝ))) ∘ X 0 | tailSigma]
-  have h_def : ∀ n, alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ))
-      = μ[(indIic (-(n : ℝ))) ∘ (X 0) | TailSigma.tailSigma X] := by
-    intro n
-    rfl
-
   -- Step 1: Show ∫ |(indIic (-(n:ℝ))) ∘ X 0| → 0
   -- Indicator integral = measure of set {X 0 ≤ -n} → 0 by continuity
   have h_indicator_tendsto : Tendsto (fun n : ℕ =>
@@ -122,7 +116,6 @@ private lemma alphaIicCE_L1_tendsto_zero_atBot
       simp only [h_empty, measure_empty] at this
       simpa [Function.comp] using this
     -- Convert from ENNReal to Real using continuity of toReal at 0
-    have h_ne_top : ∀ n, μ (X 0 ⁻¹' Set.Iic (-(n : ℝ))) ≠ ⊤ := fun n => measure_ne_top μ _
     have h_zero_ne_top : (0 : ENNReal) ≠ ⊤ := by norm_num
     rw [← ENNReal.toReal_zero]
     exact (ENNReal.continuousAt_toReal h_zero_ne_top).tendsto.comp h_tendsto_ennreal

--- a/Exchangeability/DeFinetti/ViaL2/AlphaConvergence/EndpointAtTop.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaConvergence/EndpointAtTop.lean
@@ -110,7 +110,6 @@ private lemma alphaIicCE_L1_tendsto_one_atTop
       simp only [h_empty, measure_empty] at this
       simpa [Function.comp] using this
     -- Convert from ENNReal to Real using continuity of toReal at 0
-    have h_ne_top : ∀ n, μ (X 0 ⁻¹' Set.Ioi (n : ℝ)) ≠ ⊤ := fun n => measure_ne_top μ _
     have h_zero_ne_top : (0 : ENNReal) ≠ ⊤ := by norm_num
     rw [← ENNReal.toReal_zero]
     exact (ENNReal.continuousAt_toReal h_zero_ne_top).tendsto.comp h_tendsto_ennreal


### PR DESCRIPTION
## Summary

Bucket 1 from the post-split cleanup list. **Net −14 lines across 3 files**, all dead `have` bindings. No proof restructuring; build clean, axioms unchanged.

Repo-wide grep on each name returned count=1 (the binding itself, never referenced afterwards) — each is scaffolding the proof author wrote but didn't end up needing in the final tactic flow.

## Sites

| File | Line | Name | Why dead |
|---|---|---|---|
| `EndpointAtBot.lean` | 64 | `h_def` | `by intro n; rfl` defeq witness that nothing consumes |
| `EndpointAtBot.lean` | 125 | `h_ne_top` | `ENNReal.continuousAt_toReal` call below uses `h_zero_ne_top` directly |
| `EndpointAtTop.lean` | 113 | `h_ne_top` | same pattern with `Set.Ioi (n : ℝ)` |
| `AlphaConvergence/AlphaIicEq.lean` | 110 | `hA_clip_eq` | surrounding `h_clip_le` argument doesn't need it |

## Verification

- `lake build` clean (3527 jobs, 0 warnings).
- `#print axioms` on `deFinetti_viaL2`, `deFinetti`, `deFinetti_viaKoopman`: `[propext, Classical.choice, Quot.sound]` (unchanged).

## Test plan
- [x] `lake build` clean
- [x] `#print axioms` on the three main theorems unchanged
- [x] No proof restructuring; only dead `have`-binding deletions

## Next up

Bucket 2 from the reviewer note — real AlphaIicEq golf: the manual clip-projection inequality (`AlphaIicEq.lean:117`), the telescoping induction (`AlphaIicEq.lean:261` → `Finset.sum_range_succ_sub_sum`), and the bounded-average integrability blocks duplicated at 5 sites (L141, 389, 408, 494, 520). Real proof work.