### PR TITLE
golf(AlphaConvergence): extract shared a.e. endpoint helper (−170 net lines)

### DIFF
--- a/Exchangeability/DeFinetti/ViaL2/AlphaConvergence.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaConvergence.lean
@@ -11,7 +11,7 @@ import Exchangeability.DeFinetti.ViaL2.AlphaConvergence.EndpointAtTop
 # Alpha Convergence: Endpoint Limits for `alphaIicCE`
 
 Umbrella module re-exporting the endpoint-limit results for `alphaIicCE`.
-Contents are split across three subfiles, grouped by natural proof topic:
+Contents are split across topic-named subfiles:
 
 * `AlphaConvergence/AlphaIicEq.lean` — identification
   (`alphaIic_ae_eq_alphaIicCE`).
@@ -19,6 +19,9 @@ Contents are split across three subfiles, grouped by natural proof topic:
   (`alphaIicCE_ae_tendsto_zero_atBot`, plus a private L¹ stepping stone).
 * `AlphaConvergence/EndpointAtTop.lean` — limit at `+∞`
   (`alphaIicCE_ae_tendsto_one_atTop`, plus a private L¹ stepping stone).
+* `AlphaConvergence/EndpointCommon.lean` — the shared measure-theoretic helper
+  `ae_tendsto_const_of_ae_convergent_of_L1_const` consumed by both endpoint files
+  (identifies a pointwise a.e. limit with the L¹-limit constant).
 
 Downstream consumers (`DirectingMeasureIic`, `DirectingMeasureCore`) can
 import this umbrella module unchanged.

--- a/Exchangeability/DeFinetti/ViaL2/AlphaConvergence/EndpointAtBot.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaConvergence/EndpointAtBot.lean
@@ -5,6 +5,7 @@ Authors: Cameron Freer
 -/
 import Exchangeability.DeFinetti.ViaL2.AlphaIicCE
 import Exchangeability.DeFinetti.ViaL2.CesaroConvergence.L1
+import Exchangeability.DeFinetti.ViaL2.AlphaConvergence.EndpointCommon
 
 /-!
 # Endpoint limit at -∞ for `alphaIicCE`
@@ -147,172 +148,46 @@ lemma alphaIicCE_ae_tendsto_zero_atBot
     ∀ᵐ ω ∂μ, Tendsto (fun n : ℕ =>
       alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ)) ω)
       atTop (𝓝 0) := by
-  -- Strategy:
-  -- 1. alphaIicCE is monotone decreasing in the sequence (-(n:ℝ))
-  --    (since t ↦ alphaIicCE t is monotone increasing)
-  -- 2. alphaIicCE ∈ [0,1] (bounded)
-  -- 3. By monotone convergence, the sequence converges a.e. to some limit L
-  -- 4. By L¹ convergence to 0, we have L = 0 a.e.
-
-  -- Set up the tail σ-algebra (needed for conditional expectation)
+  -- Strategy: the sequence is antitone (since `t ↦ alphaIicCE _ t` is monotone) and
+  -- bounded in [0,1], so it converges pointwise a.e. to its infimum `L ω`. The L¹
+  -- limit (from `alphaIicCE_L1_tendsto_zero_atBot`) is `0`, so the shared helper
+  -- `ae_tendsto_const_of_ae_convergent_of_L1_const` identifies `L ω = 0` a.e.
+  set f : ℕ → Ω → ℝ := fun n ω => alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ)) ω
+    with hf_def
+  set L : Ω → ℝ := fun ω => ⨅ (n : ℕ), f n ω with hL_def
   have hm_le : TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω) :=
     TailSigma.tailSigma_le X hX_meas
-
-  -- Step 1: Monotonicity - for each ω, alphaIicCE (-(m):ℝ) ω ≤ alphaIicCE (-(n):ℝ)) ω when n ≤ m
-  have h_mono : ∀ᵐ ω ∂μ, ∀ n m : ℕ, n ≤ m →
-      alphaIicCE X hX_contract hX_meas hX_L2 (-(m : ℝ)) ω
-      ≤ alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ)) ω := by
-    -- Use alphaIicCE_mono: s ≤ t implies alphaIicCE s ≤ alphaIicCE t a.e.
-    -- When n ≤ m, we have -(m : ℝ) ≤ -(n : ℝ)
-    -- Combine countably many ae statements using ae_all_iff
-    rw [ae_all_iff]
-    intro n
-    rw [ae_all_iff]
-    intro m
-    by_cases hnm : n ≤ m
-    · -- When n ≤ m, use alphaIicCE_mono with -(m:ℝ) ≤ -(n:ℝ)
-      have h_le : -(m : ℝ) ≤ -(n : ℝ) := by
-        simp [neg_le_neg_iff, Nat.cast_le, hnm]
-      filter_upwards [alphaIicCE_mono X hX_contract hX_meas hX_L2 (-(m : ℝ)) (-(n : ℝ)) h_le] with ω hω
-      intro _
-      exact hω
-    · -- When ¬(n ≤ m), the implication is vacuously true
-      exact ae_of_all μ (fun ω h_contra => absurd h_contra hnm)
-
-  -- Step 2: Boundedness - 0 ≤ alphaIicCE ≤ 1
-  have h_bound : ∀ᵐ ω ∂μ, ∀ n : ℕ,
-      0 ≤ alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ)) ω
-      ∧ alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ)) ω ≤ 1 := by
-    -- Use alphaIicCE_nonneg_le_one for each t, combine with ae_all_iff
-    rw [ae_all_iff]
-    intro n
-    exact alphaIicCE_nonneg_le_one X hX_contract hX_meas hX_L2 (-(n : ℝ))
-
-  -- Step 3: Monotone bounded sequences converge a.e.
-  have h_ae_conv : ∀ᵐ ω ∂μ, ∃ L : ℝ, Tendsto (fun n : ℕ =>
-      alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ)) ω) atTop (𝓝 L) := by
-    -- Monotone decreasing bounded sequence converges (monotone convergence theorem)
-    filter_upwards [h_mono, h_bound] with ω h_mono_ω h_bound_ω
-    -- For this ω, the sequence is antitone and bounded, so it converges
-    refine ⟨⨅ (n : ℕ), alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ)) ω, ?_⟩
-    apply tendsto_atTop_ciInf
-    · -- Antitone: n ≤ m implies f m ≤ f n
-      intro n m hnm
-      exact h_mono_ω n m hnm
-    · -- Bounded below by 0
-      refine ⟨0, ?_⟩
-      rintro _ ⟨k, rfl⟩
-      exact (h_bound_ω k).1
-
-  -- Step 4: The limit is 0 by L¹ convergence
-  -- Define the limit function L : Ω → ℝ
-  -- For each ω in the convergence set, L(ω) = lim f_n(ω) = ⨅ n, f_n(ω)
-  let L_fun : Ω → ℝ := fun ω => ⨅ (n : ℕ), alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ)) ω
-
-  -- L_fun ≥ 0 a.e. (since each f_n ≥ 0 a.e.)
-  have hL_nonneg : 0 ≤ᵐ[μ] L_fun := by
-    filter_upwards [h_bound] with ω h_bound_ω
-    apply le_ciInf
-    intro n
-    exact (h_bound_ω n).1
-
-  -- From L¹ convergence ∫|f_n| → 0 and f_n ≥ 0, we get ∫ f_n → 0
-  have h_L1_conv : Tendsto (fun n : ℕ =>
-      ∫ ω, alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ)) ω ∂μ) atTop (𝓝 0) := by
-    have h_abs := alphaIicCE_L1_tendsto_zero_atBot X hX_contract hX_meas hX_L2
-    -- Since alphaIicCE ≥ 0 a.e., we have |alphaIicCE| = alphaIicCE a.e.
-    -- Therefore ∫|f| = ∫ f
-    refine h_abs.congr' ?_
-    rw [EventuallyEq, eventually_atTop]
-    use 0
-    intro n _
-    apply integral_congr_ae
+  -- (1) Each f n is AEStronglyMeasurable (conditional expectation).
+  have hf_meas : ∀ n, AEStronglyMeasurable (f n) μ := fun n => by
+    show AEStronglyMeasurable (alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ))) μ
+    unfold alphaIicCE
+    exact stronglyMeasurable_condExp.aestronglyMeasurable.mono hm_le
+  -- (2) Uniform bound ‖f n ω‖ ≤ 1.
+  have hf_bound : ∀ n, ∀ᵐ ω ∂μ, ‖f n ω‖ ≤ (1 : ℝ) := fun n => by
     filter_upwards [alphaIicCE_nonneg_le_one X hX_contract hX_meas hX_L2 (-(n : ℝ))] with ω hω
-    exact abs_of_nonneg hω.1
-
-  -- By dominated convergence: ∫ L_fun = lim ∫ f_n = 0
-  have hL_integral_zero : ∫ ω, L_fun ω ∂μ = 0 := by
-    -- Use dominated convergence theorem with bound = 1 (constant function)
-    have h_conv_ae : ∀ᵐ ω ∂μ, Tendsto (fun (n : ℕ) => alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ)) ω)
-        atTop (𝓝 (L_fun ω)) := by
-      filter_upwards [h_ae_conv, h_bound, h_mono] with ω ⟨L, hL⟩ h_bound_ω h_mono_ω
-      have hL_is_inf : L = L_fun ω := by
-        apply tendsto_nhds_unique hL
-        apply tendsto_atTop_ciInf h_mono_ω
-        exact ⟨0, fun y hy => by obtain ⟨k, hk⟩ := hy; rw [← hk]; exact (h_bound_ω k).1⟩
-      rw [← hL_is_inf]
-      exact hL
-    have h_meas : ∀ (n : ℕ), AEStronglyMeasurable (fun ω => alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ)) ω) μ := by
-      intro n
-      -- alphaIicCE is conditional expectation μ[·|m], which is:
-      -- 1. StronglyMeasurable[m] by stronglyMeasurable_condExp
-      -- 2. AEStronglyMeasurable[m] by .aestronglyMeasurable
-      -- 3. AEStronglyMeasurable[m₀] by .mono hm_le (where m ≤ m₀)
-      unfold alphaIicCE
-      exact stronglyMeasurable_condExp.aestronglyMeasurable.mono hm_le
-    have h_bound_ae : ∀ (n : ℕ), ∀ᵐ ω ∂μ, ‖alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ)) ω‖ ≤ (1 : ℝ) := by
-      intro n
-      filter_upwards [alphaIicCE_nonneg_le_one X hX_contract hX_meas hX_L2 (-(n : ℝ))] with ω hω
-      rw [Real.norm_eq_abs, abs_of_nonneg hω.1]
-      exact hω.2
-    have h_int : Integrable (fun _ : Ω => (1 : ℝ)) μ := integrable_const 1
-    have h_lim := tendsto_integral_of_dominated_convergence (fun _ => (1 : ℝ))
-      h_meas h_int h_bound_ae h_conv_ae
-    rw [← tendsto_nhds_unique h_lim h_L1_conv]
-
-  -- Since L_fun ≥ 0 a.e. and ∫ L_fun = 0, we have L_fun = 0 a.e.
-  have hL_ae_zero : L_fun =ᵐ[μ] 0 := by
-    -- Need to show L_fun is integrable first
-    have hL_int : Integrable L_fun μ := by
-      -- L_fun is bounded by 1 a.e., so it's integrable on a probability space
-      have hL_bound : ∀ᵐ ω ∂μ, ‖L_fun ω‖ ≤ 1 := by
-        filter_upwards [hL_nonneg, h_bound] with ω hω_nn h_bound_ω
-        rw [Real.norm_eq_abs, abs_of_nonneg hω_nn]
-        -- L_fun ω = ⨅ n, f(n) where each f(n) ≤ 1, so L_fun ω ≤ 1
-        -- Use that infimum is ≤ any particular value
-        calc L_fun ω
-            = ⨅ (n : ℕ), alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ)) ω := rfl
-          _ ≤ alphaIicCE X hX_contract hX_meas hX_L2 (-((0 : ℕ) : ℝ)) ω := by
-              apply ciInf_le
-              -- Bounded below by 0 (from alphaIicCE_nonneg_le_one)
-              refine ⟨0, fun y hy => ?_⟩
-              obtain ⟨k, hk⟩ := hy
-              rw [← hk]
-              exact (h_bound_ω k).1
-          _ ≤ 1 := (h_bound_ω 0).2
-      -- L_fun is AEStronglyMeasurable as the a.e. limit of measurable functions
-      have hL_meas : AEStronglyMeasurable L_fun μ := by
-        -- Each alphaIicCE (-(n:ℝ)) is AEStronglyMeasurable (conditional expectation)
-        have h_meas_n : ∀ (n : ℕ), AEStronglyMeasurable (fun ω => alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ)) ω) μ := by
-          intro n
-          unfold alphaIicCE
-          exact stronglyMeasurable_condExp.aestronglyMeasurable.mono hm_le
-        -- They converge a.e. to L_fun (by monotone convergence)
-        have h_conv_ae_n : ∀ᵐ ω ∂μ, Tendsto (fun (n : ℕ) => alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ)) ω)
-            atTop (𝓝 (L_fun ω)) := by
-          filter_upwards [h_ae_conv, h_bound, h_mono] with ω ⟨L, hL⟩ h_bound_ω h_mono_ω
-          have hL_is_inf : L = L_fun ω := by
-            apply tendsto_nhds_unique hL
-            apply tendsto_atTop_ciInf h_mono_ω
-            exact ⟨0, fun y hy => by obtain ⟨k, hk⟩ := hy; rw [← hk]; exact (h_bound_ω k).1⟩
-          rw [← hL_is_inf]
-          exact hL
-        -- Apply aestronglyMeasurable_of_tendsto_ae
-        exact aestronglyMeasurable_of_tendsto_ae atTop h_meas_n h_conv_ae_n
-      exact Integrable.of_bound hL_meas 1 hL_bound
-    -- Now apply integral_eq_zero_iff_of_nonneg_ae
-    rw [← integral_eq_zero_iff_of_nonneg_ae hL_nonneg hL_int]
-    exact hL_integral_zero
-
-  -- Now show Tendsto f_n (𝓝 0) at a.e. ω
-  filter_upwards [h_ae_conv, hL_ae_zero, h_bound, h_mono] with ω ⟨L, hL⟩ hL_zero h_bound_ω h_mono_ω
-  -- At this ω, we have f_n → L and L_fun(ω) = 0
-  have hL_eq : L = L_fun ω := by
-    apply tendsto_nhds_unique hL
-    apply tendsto_atTop_ciInf h_mono_ω
-    exact ⟨0, fun y hy => by obtain ⟨k, hk⟩ := hy; rw [← hk]; exact (h_bound_ω k).1⟩
-  rw [hL_eq, hL_zero] at hL
-  exact hL
+    rw [Real.norm_eq_abs, abs_of_nonneg hω.1]; exact hω.2
+  -- (3) Pointwise a.e. convergence to L = ⨅ n, f n ·.
+  have hf_ae : ∀ᵐ ω ∂μ, Tendsto (fun n => f n ω) atTop (𝓝 (L ω)) := by
+    have h_antitone : ∀ᵐ ω ∂μ, ∀ n m : ℕ, n ≤ m → f m ω ≤ f n ω := by
+      rw [ae_all_iff]; intro n; rw [ae_all_iff]; intro m
+      by_cases hnm : n ≤ m
+      · have h_le : -(m : ℝ) ≤ -(n : ℝ) := by simp [neg_le_neg_iff, Nat.cast_le, hnm]
+        filter_upwards [alphaIicCE_mono X hX_contract hX_meas hX_L2
+          (-(m : ℝ)) (-(n : ℝ)) h_le] with ω hω
+        intro _; exact hω
+      · exact ae_of_all μ (fun _ h_contra => absurd h_contra hnm)
+    have h_bound_pt : ∀ᵐ ω ∂μ, ∀ n : ℕ, 0 ≤ f n ω ∧ f n ω ≤ 1 := by
+      rw [ae_all_iff]; intro n
+      exact alphaIicCE_nonneg_le_one X hX_contract hX_meas hX_L2 (-(n : ℝ))
+    filter_upwards [h_antitone, h_bound_pt] with ω h_anti h_bd
+    refine tendsto_atTop_ciInf h_anti ⟨0, ?_⟩
+    rintro _ ⟨k, rfl⟩; exact (h_bd k).1
+  -- (4) L¹ convergence to 0 (the indicator absolute value matches |f - 0|).
+  have hf_L1 : Tendsto (fun n => ∫ ω, |f n ω - 0| ∂μ) atTop (𝓝 0) := by
+    simpa [sub_zero] using
+      alphaIicCE_L1_tendsto_zero_atBot X hX_contract hX_meas hX_L2
+  -- Apply the shared helper.
+  exact ae_tendsto_const_of_ae_convergent_of_L1_const hf_meas hf_bound hf_ae hf_L1
 
 
 end Exchangeability.DeFinetti.ViaL2

--- a/Exchangeability/DeFinetti/ViaL2/AlphaConvergence/EndpointAtTop.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaConvergence/EndpointAtTop.lean
@@ -5,6 +5,7 @@ Authors: Cameron Freer
 -/
 import Exchangeability.DeFinetti.ViaL2.AlphaIicCE
 import Exchangeability.DeFinetti.ViaL2.CesaroConvergence.L1
+import Exchangeability.DeFinetti.ViaL2.AlphaConvergence.EndpointCommon
 
 /-!
 # Endpoint limit at +∞ for `alphaIicCE`
@@ -154,202 +155,45 @@ lemma alphaIicCE_ae_tendsto_one_atTop
     ∀ᵐ ω ∂μ, Tendsto (fun n : ℕ =>
       alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω)
       atTop (𝓝 1) := by
-  -- Strategy: Similar to atBot case
-  -- 1. alphaIicCE is monotone increasing in n
-  -- 2. alphaIicCE ∈ [0,1] (bounded)
-  -- 3. By monotone convergence, the sequence converges a.e. to some limit L
-  -- 4. By L¹ convergence to 1, we have L = 1 a.e.
-
-  -- Step 1: Monotonicity - for each ω, alphaIicCE (n:ℝ) ω ≤ alphaIicCE (m:ℝ) ω when n ≤ m
-  have h_mono : ∀ᵐ ω ∂μ, ∀ n m : ℕ, n ≤ m →
-      alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω
-      ≤ alphaIicCE X hX_contract hX_meas hX_L2 (m : ℝ) ω := by
-    -- Use alphaIicCE_mono with countable ae union
-    rw [ae_all_iff]
-    intro n
-    rw [ae_all_iff]
-    intro m
-    by_cases hnm : n ≤ m
-    · -- When n ≤ m, use alphaIicCE_mono with (n:ℝ) ≤ (m:ℝ)
-      have h_le : (n : ℝ) ≤ (m : ℝ) := Nat.cast_le.mpr hnm
-      filter_upwards [alphaIicCE_mono X hX_contract hX_meas hX_L2 (n : ℝ) (m : ℝ) h_le] with ω hω
-      intro _
-      exact hω
-    · -- When ¬(n ≤ m), the implication is vacuously true
-      exact ae_of_all μ (fun ω h_contra => absurd h_contra hnm)
-
-  -- Step 2: Boundedness - 0 ≤ alphaIicCE ≤ 1
-  have h_bound : ∀ᵐ ω ∂μ, ∀ n : ℕ,
-      0 ≤ alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω
-      ∧ alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω ≤ 1 := by
-    -- Use alphaIicCE_nonneg_le_one with countable ae union
-    rw [ae_all_iff]
-    intro n
-    exact alphaIicCE_nonneg_le_one X hX_contract hX_meas hX_L2 (n : ℝ)
-
-  -- Step 3: Monotone bounded sequences converge a.e.
-  have h_ae_conv : ∀ᵐ ω ∂μ, ∃ L : ℝ, Tendsto (fun n : ℕ =>
-      alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω) atTop (𝓝 L) := by
-    -- Monotone increasing bounded sequence converges (monotone convergence theorem)
-    filter_upwards [h_mono, h_bound] with ω h_mono_ω h_bound_ω
-    -- For this ω, the sequence is monotone and bounded, so it converges
-    refine ⟨⨆ (n : ℕ), alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω, ?_⟩
-    apply tendsto_atTop_ciSup
-    · -- Monotone: n ≤ m implies f n ≤ f m
-      intro n m hnm
-      exact h_mono_ω n m hnm
-    · -- Bounded above by 1
-      refine ⟨1, ?_⟩
-      intro y hy
-      obtain ⟨k, hk⟩ := hy
-      rw [← hk]
-      exact (h_bound_ω k).2
-
-  -- Step 4: The limit is 1 by L¹ convergence
-  -- If f_n → L a.e. and f_n → 1 in L¹, then L = 1 a.e.
-
-  -- Set up the tail σ-algebra (needed for conditional expectation)
+  -- Strategy: the sequence is monotone increasing and bounded in [0,1], so it
+  -- converges pointwise a.e. to its supremum `U ω`. The L¹ limit (from
+  -- `alphaIicCE_L1_tendsto_one_atTop`) is `1`, so the shared helper
+  -- `ae_tendsto_const_of_ae_convergent_of_L1_const` identifies `U ω = 1` a.e.
+  set f : ℕ → Ω → ℝ := fun n ω => alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω
+    with hf_def
+  set U : Ω → ℝ := fun ω => ⨆ (n : ℕ), f n ω with hU_def
   have hm_le : TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω) :=
     TailSigma.tailSigma_le X hX_meas
-
-  -- Define the limit function U : Ω → ℝ (supremum instead of infimum)
-  let U_fun : Ω → ℝ := fun ω => ⨆ (n : ℕ), alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω
-
-  -- U_fun ≤ 1 a.e.
-  have hU_le_one : U_fun ≤ᵐ[μ] 1 := by
-    filter_upwards [h_bound] with ω h_bound_ω
-    apply ciSup_le
-    intro n
-    exact (h_bound_ω n).2
-
-  -- Convert ∫|f_n - 1| → 0 to ∫ (1 - f_n) → 0
-  have h_L1_conv : Tendsto (fun n : ℕ =>
-      ∫ ω, (1 - alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω) ∂μ) atTop (𝓝 0) := by
-    have h_abs := alphaIicCE_L1_tendsto_one_atTop X hX_contract hX_meas hX_L2
-    refine h_abs.congr' ?_
-    rw [EventuallyEq, eventually_atTop]
-    use 0
-    intro n _
-    apply integral_congr_ae
+  -- (1) Each f n is AEStronglyMeasurable (conditional expectation).
+  have hf_meas : ∀ n, AEStronglyMeasurable (f n) μ := fun n => by
+    show AEStronglyMeasurable (alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ)) μ
+    unfold alphaIicCE
+    exact stronglyMeasurable_condExp.aestronglyMeasurable.mono hm_le
+  -- (2) Uniform bound ‖f n ω‖ ≤ 1.
+  have hf_bound : ∀ n, ∀ᵐ ω ∂μ, ‖f n ω‖ ≤ (1 : ℝ) := fun n => by
     filter_upwards [alphaIicCE_nonneg_le_one X hX_contract hX_meas hX_L2 (n : ℝ)] with ω hω
-    rw [abs_sub_comm, abs_of_nonneg (sub_nonneg.mpr hω.2)]
-
-  -- Apply dominated convergence theorem
-  have hU_integral_one : ∫ ω, U_fun ω ∂μ = 1 := by
-    have h_conv_ae : ∀ᵐ ω ∂μ, Tendsto (fun (n : ℕ) => alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω)
-        atTop (𝓝 (U_fun ω)) := by
-      filter_upwards [h_ae_conv, h_bound, h_mono] with ω ⟨L, hL⟩ h_bound_ω h_mono_ω
-      have hU_is_sup : L = U_fun ω := by
-        apply tendsto_nhds_unique hL
-        apply tendsto_atTop_ciSup h_mono_ω
-        exact ⟨1, fun y hy => by obtain ⟨k, hk⟩ := hy; rw [← hk]; exact (h_bound_ω k).2⟩
-      rw [← hU_is_sup]
-      exact hL
-    have h_meas : ∀ (n : ℕ), AEStronglyMeasurable (fun ω => alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω) μ := by
-      intro n
-      unfold alphaIicCE
-      exact stronglyMeasurable_condExp.aestronglyMeasurable.mono hm_le
-    have h_bound_ae : ∀ (n : ℕ), ∀ᵐ ω ∂μ, ‖alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω‖ ≤ (1 : ℝ) := by
-      intro n
-      filter_upwards [alphaIicCE_nonneg_le_one X hX_contract hX_meas hX_L2 (n : ℝ)] with ω hω
-      rw [Real.norm_eq_abs, abs_of_nonneg hω.1]
-      exact hω.2
-    have h_int : Integrable (fun _ : Ω => (1 : ℝ)) μ := integrable_const 1
-    have h_lim := tendsto_integral_of_dominated_convergence (fun _ => (1 : ℝ))
-      h_meas h_int h_bound_ae h_conv_ae
-    have h_int_conv : Tendsto (fun n : ℕ => ∫ ω, alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω ∂μ) atTop (𝓝 1) := by
-      have : Tendsto (fun n : ℕ => 1 - ∫ ω, (1 - alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω) ∂μ) atTop (𝓝 (1 - 0)) := by
-        exact Tendsto.sub tendsto_const_nhds h_L1_conv
-      have this' : Tendsto (fun n : ℕ => 1 - ∫ ω, (1 - alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω) ∂μ) atTop (𝓝 1) := by
-        convert this using 2
-        norm_num
-      -- Show integral convergence by algebra
-      refine this'.congr' ?_
-      rw [EventuallyEq, eventually_atTop]
-      use 0
-      intro n _
-      -- Show: 1 - ∫ (1 - f) = ∫ f
-      have h_f_int : Integrable (fun ω => alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω) μ := by
-        refine Integrable.of_bound (stronglyMeasurable_condExp.aestronglyMeasurable.mono hm_le) 1 ?_
-        filter_upwards [alphaIicCE_nonneg_le_one X hX_contract hX_meas hX_L2 (n : ℝ)] with ω hω
-        rw [Real.norm_eq_abs, abs_of_nonneg hω.1]
-        exact hω.2
-      calc 1 - ∫ ω, (1 - alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω) ∂μ
-          = 1 - (∫ ω, 1 ∂μ - ∫ ω, alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω ∂μ) := by
-              rw [integral_sub (integrable_const 1) h_f_int]
-          _ = 1 - (μ.real Set.univ - ∫ ω, alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω ∂μ) := by
-              rw [integral_const, smul_eq_mul, mul_one]
-          _ = 1 - (1 - ∫ ω, alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω ∂μ) := by
-              simp only [Measure.real]
-              rw [measure_univ]
-              simp
-          _ = ∫ ω, alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω ∂μ := by ring
-    rw [← tendsto_nhds_unique h_lim h_int_conv]
-
-  -- Conclude U_fun = 1 a.e.
-  have hU_ae_one : U_fun =ᵐ[μ] 1 := by
-    have hU_int : Integrable U_fun μ := by
-      have hU_nonneg : 0 ≤ᵐ[μ] U_fun := by
-        filter_upwards [h_bound] with ω h_bound_ω
-        -- U_fun ω = sup of values all ≥ 0, so U_fun ω ≥ value at 0 ≥ 0
-        refine le_trans ?_ (le_ciSup ⟨1, fun y hy => by obtain ⟨k, hk⟩ := hy; rw [← hk]; exact (h_bound_ω k).2⟩ (0 : ℕ))
-        exact (h_bound_ω 0).1
-      have hU_bound : ∀ᵐ ω ∂μ, ‖U_fun ω‖ ≤ 1 := by
-        filter_upwards [hU_nonneg, h_bound] with ω hω_nn h_bound_ω
-        rw [Real.norm_eq_abs, abs_of_nonneg hω_nn]
-        -- U_fun ω = ⨆ n, f(n) where each f(n) ≤ 1, so U_fun ω ≤ 1
-        -- Use that 1 is an upper bound for all values
-        calc U_fun ω
-            = ⨆ (n : ℕ), alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω := rfl
-          _ ≤ 1 := by
-              apply ciSup_le
-              intro n
-              exact (h_bound_ω n).2
-      have hU_meas : AEStronglyMeasurable U_fun μ := by
-        -- Each alphaIicCE (n:ℝ) is AEStronglyMeasurable (conditional expectation)
-        have h_meas_n : ∀ (n : ℕ), AEStronglyMeasurable (fun ω => alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω) μ := by
-          intro n
-          unfold alphaIicCE
-          exact stronglyMeasurable_condExp.aestronglyMeasurable.mono hm_le
-        -- They converge a.e. to U_fun (by monotone convergence)
-        have h_conv_ae_n : ∀ᵐ ω ∂μ, Tendsto (fun (n : ℕ) => alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω)
-            atTop (𝓝 (U_fun ω)) := by
-          filter_upwards [h_ae_conv, h_bound, h_mono] with ω ⟨L, hL⟩ h_bound_ω h_mono_ω
-          have hU_is_sup : L = U_fun ω := by
-            apply tendsto_nhds_unique hL
-            apply tendsto_atTop_ciSup h_mono_ω
-            exact ⟨1, fun y hy => by obtain ⟨k, hk⟩ := hy; rw [← hk]; exact (h_bound_ω k).2⟩
-          rw [← hU_is_sup]
-          exact hL
-        -- Apply aestronglyMeasurable_of_tendsto_ae
-        exact aestronglyMeasurable_of_tendsto_ae atTop h_meas_n h_conv_ae_n
-      exact Integrable.of_bound hU_meas 1 hU_bound
-    -- Show U_fun = 1 a.e. by showing 1 - U_fun = 0 a.e.
-    have h_diff_nonneg : 0 ≤ᵐ[μ] fun ω => 1 - U_fun ω := by
-      filter_upwards [hU_le_one] with ω hω
-      exact sub_nonneg.mpr hω
-    have h_diff_int : Integrable (fun ω => 1 - U_fun ω) μ := by
-      exact Integrable.sub (integrable_const 1) hU_int
-    have h_diff_zero : ∫ ω, (1 - U_fun ω) ∂μ = 0 := by
-      rw [integral_sub (integrable_const 1) hU_int, integral_const, smul_eq_mul, mul_one, hU_integral_one]
-      norm_num
-    have : (fun ω => 1 - U_fun ω) =ᵐ[μ] 0 := by
-      rw [← integral_eq_zero_iff_of_nonneg_ae h_diff_nonneg h_diff_int]
-      exact h_diff_zero
-    filter_upwards [this] with ω hω
-    have h_eq : 1 - U_fun ω = 0 := by simpa using hω
-    have : 1 = U_fun ω := sub_eq_zero.mp h_eq
-    exact this.symm
-
-  -- Now show Tendsto f_n (𝓝 1) at a.e. ω
-  filter_upwards [h_ae_conv, hU_ae_one, h_bound, h_mono] with ω ⟨L, hL⟩ hU_one h_bound_ω h_mono_ω
-  -- At this ω, we have f_n → L and U_fun(ω) = 1
-  have hL_eq : L = U_fun ω := by
-    apply tendsto_nhds_unique hL
-    apply tendsto_atTop_ciSup h_mono_ω
-    exact ⟨1, fun y hy => by obtain ⟨k, hk⟩ := hy; rw [← hk]; exact (h_bound_ω k).2⟩
-  rw [hL_eq, hU_one] at hL
-  exact hL
+    rw [Real.norm_eq_abs, abs_of_nonneg hω.1]; exact hω.2
+  -- (3) Pointwise a.e. convergence to U = ⨆ n, f n ·.
+  have hf_ae : ∀ᵐ ω ∂μ, Tendsto (fun n => f n ω) atTop (𝓝 (U ω)) := by
+    have h_monotone : ∀ᵐ ω ∂μ, ∀ n m : ℕ, n ≤ m → f n ω ≤ f m ω := by
+      rw [ae_all_iff]; intro n; rw [ae_all_iff]; intro m
+      by_cases hnm : n ≤ m
+      · have h_le : (n : ℝ) ≤ (m : ℝ) := Nat.cast_le.mpr hnm
+        filter_upwards [alphaIicCE_mono X hX_contract hX_meas hX_L2
+          (n : ℝ) (m : ℝ) h_le] with ω hω
+        intro _; exact hω
+      · exact ae_of_all μ (fun _ h_contra => absurd h_contra hnm)
+    have h_bound_pt : ∀ᵐ ω ∂μ, ∀ n : ℕ, 0 ≤ f n ω ∧ f n ω ≤ 1 := by
+      rw [ae_all_iff]; intro n
+      exact alphaIicCE_nonneg_le_one X hX_contract hX_meas hX_L2 (n : ℝ)
+    filter_upwards [h_monotone, h_bound_pt] with ω h_mono h_bd
+    refine tendsto_atTop_ciSup h_mono ⟨1, ?_⟩
+    rintro _ ⟨k, rfl⟩; exact (h_bd k).2
+  -- (4) L¹ convergence to 1.
+  have hf_L1 : Tendsto (fun n => ∫ ω, |f n ω - 1| ∂μ) atTop (𝓝 0) :=
+    alphaIicCE_L1_tendsto_one_atTop X hX_contract hX_meas hX_L2
+  -- Apply the shared helper.
+  exact ae_tendsto_const_of_ae_convergent_of_L1_const hf_meas hf_bound hf_ae hf_L1
 
 
 end Exchangeability.DeFinetti.ViaL2

--- a/Exchangeability/DeFinetti/ViaL2/AlphaConvergence/EndpointCommon.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaConvergence/EndpointCommon.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2025 Cameron Freer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Cameron Freer
+-/
+import Exchangeability.DeFinetti.ViaL2.AlphaIicCE
+
+/-!
+# Shared helper for the `alphaIicCE` endpoint limits
+
+Both `alphaIicCE_ae_tendsto_zero_atBot` (`EndpointAtBot`) and
+`alphaIicCE_ae_tendsto_one_atTop` (`EndpointAtTop`) need the same generic
+measure-theoretic fact:
+
+If a uniformly bounded sequence `f : ℕ → Ω → ℝ` converges pointwise a.e. (to
+some `L`) and also converges to a *constant* `c` in L¹, then the pointwise
+limit equals `c` a.e., so `f n ω → c` a.e.
+
+This is the "L¹-limit-of-a-constant-identifies-the-pointwise-limit" lemma,
+extracted into one private helper so the endpoint files can each derive
+pointwise convergence to their target without duplicating the
+dominated-convergence + `integral_eq_zero_iff_of_nonneg_ae` machinery.
+-/
+
+noncomputable section
+
+namespace Exchangeability.DeFinetti.ViaL2
+
+open MeasureTheory Filter Topology
+
+variable {Ω : Type*} [MeasurableSpace Ω]
+
+/-- **A.e. pointwise limit equals the L¹-limit constant.**
+
+If a uniformly bounded sequence `f : ℕ → Ω → ℝ` converges pointwise a.e. to
+`L : Ω → ℝ` and also converges to a constant `c` in L¹ (in the sense that
+`∫ |f n - c| → 0`), then `L = c` a.e., so `f n ω → c` for a.e. `ω`.
+
+The proof routes through dominated convergence: `|f n - c|` is uniformly
+bounded by `C + |c|`, converges pointwise a.e. to `|L - c|`, and has integrals
+tending to `0`, so `∫ |L - c| = 0`. Since `|L - c| ≥ 0`, that forces `L = c`
+a.e. -/
+lemma ae_tendsto_const_of_ae_convergent_of_L1_const
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {f : ℕ → Ω → ℝ} {L : Ω → ℝ} {c C : ℝ}
+    (hf_meas : ∀ n, AEStronglyMeasurable (f n) μ)
+    (hf_bound : ∀ n, ∀ᵐ ω ∂μ, ‖f n ω‖ ≤ C)
+    (hf_ae : ∀ᵐ ω ∂μ, Tendsto (fun n => f n ω) atTop (𝓝 (L ω)))
+    (hf_L1 : Tendsto (fun n => ∫ ω, |f n ω - c| ∂μ) atTop (𝓝 0)) :
+    ∀ᵐ ω ∂μ, Tendsto (fun n => f n ω) atTop (𝓝 c) := by
+  -- |f n - c| is AEStronglyMeasurable, uniformly bounded by C + |c|, and
+  -- pointwise a.e. → |L - c|.  On ℝ, `|·| = ‖·‖`, so we use `.norm` plus a
+  -- `funext` rewrite.
+  have h_const_meas : AEStronglyMeasurable (fun _ : Ω => c) μ := aestronglyMeasurable_const
+  have h_abs_meas : ∀ n, AEStronglyMeasurable (fun ω => |f n ω - c|) μ := by
+    intro n
+    have h_eq : (fun ω => |f n ω - c|) = (fun ω => ‖f n ω - c‖) := by
+      funext ω; exact (Real.norm_eq_abs _).symm
+    rw [h_eq]
+    exact ((hf_meas n).sub h_const_meas).norm
+  have h_pointwise_bound : ∀ (x : ℝ), ‖x‖ ≤ C → |x - c| ≤ C + |c| := fun x hx => by
+    have hx' : |x| ≤ C := by rwa [← Real.norm_eq_abs]
+    linarith [abs_sub x c, abs_nonneg x, abs_nonneg c]
+  have h_abs_bound : ∀ n, ∀ᵐ ω ∂μ, ‖|f n ω - c|‖ ≤ C + |c| := by
+    intro n
+    filter_upwards [hf_bound n] with ω hω
+    rw [Real.norm_eq_abs, abs_abs]
+    exact h_pointwise_bound _ hω
+  have h_abs_conv : ∀ᵐ ω ∂μ,
+      Tendsto (fun n => |f n ω - c|) atTop (𝓝 (|L ω - c|)) := by
+    filter_upwards [hf_ae] with ω hω
+    exact (hω.sub tendsto_const_nhds).abs
+  -- DCT gives ∫ |f n - c| → ∫ |L - c|; combined with hf_L1 this forces
+  -- ∫ |L - c| = 0.
+  have h_DCT :=
+    tendsto_integral_of_dominated_convergence (fun _ : Ω => C + |c|)
+      h_abs_meas (integrable_const (C + |c|)) h_abs_bound h_abs_conv
+  have h_int_zero : ∫ ω, |L ω - c| ∂μ = 0 := tendsto_nhds_unique h_DCT hf_L1
+  -- L is AEStronglyMeasurable (a.e. limit of AEStronglyMeasurable functions);
+  -- |L - c| is integrable (bounded by C + |c|) and nonneg, so the integral
+  -- being zero forces |L - c| = 0 a.e., i.e. L = c a.e.
+  have hL_meas : AEStronglyMeasurable L μ :=
+    aestronglyMeasurable_of_tendsto_ae atTop hf_meas hf_ae
+  have h_abs_diff_meas : AEStronglyMeasurable (fun ω => |L ω - c|) μ := by
+    have h_eq : (fun ω => |L ω - c|) = (fun ω => ‖L ω - c‖) := by
+      funext ω; exact (Real.norm_eq_abs _).symm
+    rw [h_eq]
+    exact (hL_meas.sub h_const_meas).norm
+  have h_L_bound : ∀ᵐ ω ∂μ, ‖L ω‖ ≤ C := by
+    -- L is the a.e. limit of f, and each |f n| ≤ C a.e., so |L| ≤ C a.e.
+    have h_bound_all : ∀ᵐ ω ∂μ, ∀ n, ‖f n ω‖ ≤ C := ae_all_iff.mpr hf_bound
+    filter_upwards [hf_ae, h_bound_all] with ω h_ae_ω h_bound_ω
+    exact le_of_tendsto h_ae_ω.norm (Filter.Eventually.of_forall h_bound_ω)
+  have h_abs_diff_bound : ∀ᵐ ω ∂μ, ‖|L ω - c|‖ ≤ C + |c| := by
+    filter_upwards [h_L_bound] with ω hω
+    rw [Real.norm_eq_abs, abs_abs]
+    exact h_pointwise_bound _ hω
+  have h_abs_diff_int : Integrable (fun ω => |L ω - c|) μ :=
+    Integrable.of_bound h_abs_diff_meas (C + |c|) h_abs_diff_bound
+  have h_abs_nonneg : (0 : Ω → ℝ) ≤ᵐ[μ] (fun ω => |L ω - c|) :=
+    ae_of_all _ (fun _ => abs_nonneg _)
+  have h_abs_zero : (fun ω => |L ω - c|) =ᵐ[μ] 0 := by
+    rw [← integral_eq_zero_iff_of_nonneg_ae h_abs_nonneg h_abs_diff_int]
+    exact h_int_zero
+  -- Combine: hf_ae gives Tendsto _ (𝓝 (L ω)); h_abs_zero gives L ω = c a.e.
+  filter_upwards [hf_ae, h_abs_zero] with ω h_ae h_eq
+  have h_diff_zero : L ω - c = 0 := by simpa using h_eq
+  have : L ω = c := by linarith
+  rwa [this] at h_ae
+
+end Exchangeability.DeFinetti.ViaL2


### PR DESCRIPTION
## Summary

Bucket 3 from the post-split queue. **Net −170 lines** across the `AlphaConvergence/` subdirectory (`+190 / −357` across 4 files, including a new ~111-line helper).

`alphaIicCE_ae_tendsto_zero_atBot` and `alphaIicCE_ae_tendsto_one_atTop` each had ~150-185 lines of duplicated machinery:

> monotone + bounded → pointwise a.e. limit `L`
> L¹-limit of `f n` is constant `c` ⇒ `L = c` a.e.

The second step is generic measure theory. Extracted it into a shared helper; both endpoint files now just supply the four hypotheses (`AEStronglyMeasurable`, uniform bound, pointwise convergence via `tendsto_atTop_ciInf`/`ciSup`, L¹ convergence) and apply the helper.

## New module: `AlphaConvergence/EndpointCommon.lean`

```lean
/-- Uniformly bounded family with pointwise a.e. limit L and L¹-limit
    constant c has L = c a.e., hence f n ω → c a.e. -/
lemma ae_tendsto_const_of_ae_convergent_of_L1_const
    {μ : Measure Ω} [IsProbabilityMeasure μ]
    {f : ℕ → Ω → ℝ} {L : Ω → ℝ} {c C : ℝ}
    (hf_meas : ∀ n, AEStronglyMeasurable (f n) μ)
    (hf_bound : ∀ n, ∀ᵐ ω ∂μ, ‖f n ω‖ ≤ C)
    (hf_ae : ∀ᵐ ω ∂μ, Tendsto (fun n => f n ω) atTop (𝓝 (L ω)))
    (hf_L1 : Tendsto (fun n => ∫ ω, |f n ω - c| ∂μ) atTop (𝓝 0)) :
    ∀ᵐ ω ∂μ, Tendsto (fun n => f n ω) atTop (𝓝 c)
```

Routes through dominated convergence on `|f n - c|`, the `tendsto_nhds_unique` identification of the two L¹ limits, and the `integral_eq_zero_iff_of_nonneg_ae` machinery — all in one shared spot instead of duplicated.

## Caller savings

| File | Lemma | Before | After |
|---|---|---|---|
| `EndpointAtBot.lean` | `alphaIicCE_ae_tendsto_zero_atBot` | ~175 lines | ~45 lines |
| `EndpointAtTop.lean` | `alphaIicCE_ae_tendsto_one_atTop` | ~205 lines | ~45 lines |
| (file totals) | | 318 / 355 | 193 / 199 |

`EndpointAtTop` particularly benefits: it no longer needs the ~60-line "convert `∫ |f-1| → 0` into `∫(1-f) → 0` and `1 - ∫(1-f) = ∫f`" detour, because the helper accepts the L¹ form directly.

## Verification

- `lake build` clean (3528 jobs, was 3527 — 1 new module) with 0 warnings.
- `lake exe checkdecls blueprint/lean_decls` exit 0.
- `python3 blueprint/check_blueprint.py` exit 0.
- `#print axioms` on `deFinetti_viaL2`, `deFinetti`, `deFinetti_viaKoopman`: `[propext, Classical.choice, Quot.sound]` (unchanged).
- No proof body changed in `AlphaIicEq.lean`.

## Test plan
- [x] `lake build` clean
- [x] `checkdecls` + `check_blueprint.py` pass
- [x] `#print axioms` on the three main theorems unchanged
- [x] No public decl signature changed; the new helper is the only new export