### PR TITLE
chore: privatize 6 Koopman proof-step helpers (all 0 external refs)

### DIFF
--- a/Exchangeability/DeFinetti/ViaKoopman/CesaroL2ToL1.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/CesaroL2ToL1.lean
@@ -123,7 +123,7 @@ omit [StandardBorelSpace α] in
     implies L¹ convergence of chosen representatives.  This version is robust to
     older mathlib snapshots (no `Subtype.aestronglyMeasurable`, no `tendsto_iff_*`,
     and `snorm` is fully qualified). -/
-lemma optionB_Step3b_L2_to_L1
+private lemma optionB_Step3b_L2_to_L1
     {μ : Measure (Ω[α])} [IsProbabilityMeasure μ]
     (hσ : MeasurePreserving shift μ μ)
     (fL2 : Lp ℝ 2 μ)
@@ -266,7 +266,7 @@ omit [StandardBorelSpace α] in
 /-- **Step 4b helper**: A_n and B_n differ negligibly.
 
 For bounded g, shows |A_n ω - B_n ω| ≤ 2·Cg/(n+1) → 0 via dominated convergence. -/
-lemma optionB_Step4b_AB_close
+private lemma optionB_Step4b_AB_close
     {μ : Measure (Ω[α])} [IsProbabilityMeasure μ]
     (g : α → ℝ) (hg_meas : Measurable g) (Cg : ℝ) (hCg_bd : ∀ x, |g x| ≤ Cg)
     (A B : ℕ → Ω[α] → ℝ)
@@ -428,7 +428,7 @@ omit [StandardBorelSpace α] in
 /-- **Step 4c helper**: Triangle inequality to combine convergences.
 
 Given ∫|B_n - Y| → 0 and ∫|A_n - B_n| → 0, proves ∫|A_n - Y| → 0 via squeeze theorem. -/
-lemma optionB_Step4c_triangle
+private lemma optionB_Step4c_triangle
     {μ : Measure (Ω[α])} [IsProbabilityMeasure μ]
     (g : α → ℝ) (hg_meas : Measurable g) (hg_bd : ∃ Cg, ∀ x, |g x| ≤ Cg)
     (A B : ℕ → Ω[α] → ℝ) (Y : Ω[α] → ℝ) (G : Ω[α] → ℝ)

--- a/Exchangeability/DeFinetti/ViaKoopman/ContractableFactorization.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/ContractableFactorization.lean
@@ -92,7 +92,7 @@ For functions bounded by C > 0:
   |∏ A - ∏ B| ≤ C^{m-1} * ∑ |A_i - B_i|
 
 This is derived from abs_prod_sub_prod_le by dividing by C. -/
-lemma abs_prod_sub_prod_le_general {m : ℕ} (A B : Fin m → ℝ) {C : ℝ} (hC : 0 < C)
+private lemma abs_prod_sub_prod_le_general {m : ℕ} (A B : Fin m → ℝ) {C : ℝ} (hC : 0 < C)
     (hA : ∀ i, |A i| ≤ C) (hB : ∀ i, |B i| ≤ C) :
     |∏ i, A i - ∏ i, B i| ≤ C^(m - 1) * ∑ i, |A i - B i| := by
   by_cases hm : m = 0
@@ -346,7 +346,7 @@ variable {μ : Measure (Ω[α])} [IsProbabilityMeasure μ]
 Given contractability (finite marginals on `{k(0), ..., k(m-1)}` equal marginals on `{0, ..., m-1}`),
 we show that the pushforward under reindexing by any strictly monotone ρ equals the original
 measure. This is the π-λ argument: finite marginal equality → full measure equality. -/
-lemma measure_map_reindexBlock_eq_of_contractable
+private lemma measure_map_reindexBlock_eq_of_contractable
     (hContract : ∀ (m : ℕ) (k : Fin m → ℕ), StrictMono k →
         Measure.map (fun ω i => ω (k i)) μ = Measure.map (fun ω (i : Fin m) => ω i.val) μ)
     {m n : ℕ} (hn : 0 < n) (j : Fin m → Fin n) :
@@ -396,7 +396,7 @@ If the measure is invariant under reindexing (μ = μ ∘ reindexBlock⁻¹) and
 under reindexing (s = reindexBlock⁻¹(s)), then ∫_s f ∘ reindexBlock = ∫_s f.
 
 This is the key lemma that replaces "conditional contractability". -/
-lemma setIntegral_comp_reindexBlock_eq
+private lemma setIntegral_comp_reindexBlock_eq
     (hμ : Measure.map (reindexBlock (α := α) m n j) μ = μ)
     {s : Set (Ω[α])} (hs_meas : MeasurableSet s)
     (hs_inv : reindexBlock m n j ⁻¹' s = s)


### PR DESCRIPTION
## Summary

Reviewer's item 1 — shrink the visible API surface in two Koopman files. **6 lemmas privatized, no behaviour change**.

Each verified:
- 0 external references (grep across `Exchangeability/`).
- No tactic-database attributes (no `@[simp]`, `@[measurability]`, `@[fun_prop]`).
- Each used only by the final theorem in its own file.

## Privatized — `CesaroL2ToL1.lean` (3 decls)

The three `optionB_StepN_*` helpers that compose into the file's final L²-to-L¹ convergence theorem:

- `optionB_Step3b_L2_to_L1`
- `optionB_Step4b_AB_close`
- `optionB_Step4c_triangle`

## Privatized — `ContractableFactorization.lean` (3 decls)

Three reindex/contractability infrastructure lemmas, each used only by the file's main factorization theorem:

- `abs_prod_sub_prod_le_general` — telescoping `|∏ A - ∏ B|` bound
- `measure_map_reindexBlock_eq_of_contractable` — π-λ argument
- `setIntegral_comp_reindexBlock_eq` — set-integral invariance under reindex

## Verification

- `lake build` clean (3527 jobs, 0 warnings).
- `#lint+ only unusedArguments in Exchangeability` exit 0 (no findings).
- `lake exe checkdecls blueprint/lean_decls` exit 0.
- `python3 blueprint/check_blueprint.py` exit 0.
- `#print axioms` on `deFinetti_viaL2`, `deFinetti`, `deFinetti_viaKoopman`: `[propext, Classical.choice, Quot.sound]` (unchanged).

## Test plan
- [x] `lake build` clean
- [x] `#lint+`, `checkdecls`, blueprint check all pass
- [x] `#print axioms` unchanged
- [x] No proof bodies changed; only access-modifier change

## Next up (per reviewer's prioritized list)

- Item 2: linter suppression audit — 13 suppressions, probe `pathify`, `iidProjectiveFamily`, `iidProduct`, `directingMeasure`, `alphaIicCE`
- Item 3: AlphaIicCE comment/proof cleanup
- Items 4-5: stale docs and small CylinderHelpers cleanup