### PR TITLE
chore(AlphaIicCE): drop stale 'for now'/'proof would' scaffolding around right-continuity (−34 lines)

### DIFF
--- a/Exchangeability/DeFinetti/ViaL2/AlphaIicCE.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaIicCE.lean
@@ -617,45 +617,11 @@ lemma alphaIicCE_iInf_rat_gt_eq
       intro ⟨r, hr⟩
       exact h_mono q r (le_of_lt hr)
 
-    -- For the upper bound, we use that alphaIicCE is right-continuous
-    -- This follows from the fact that it's the conditional CDF, which is right-continuous
-
-    -- Key: alphaIicCE r ≤ 1 for all r, and alphaIicCE r decreases as r → q⁺
-    -- Since the function is bounded and monotone, the infimum is achieved
-
-    -- For a decreasing net bounded below, the infimum is the limit
-    -- lim_{r → q⁺} alphaIicCE r = ⨅ r > q, alphaIicCE r
-
-    -- And for conditional CDFs, lim_{r → q⁺} P(X₀ ≤ r | tail) = P(X₀ ≤ q | tail)
-
-    -- The hard direction: ⨅ r > q, alphaIicCE r ω ≤ alphaIicCE q ω
-    -- This is right-continuity of CDFs.
-    --
-    -- Mathematical proof:
-    -- 1. For sequence rₙ = q + 1/n, we have rₙ ↓ q
-    -- 2. 1_{Iic rₙ}(x) ↓ 1_{Iic q}(x) for all x (decreasing indicators)
-    -- 3. By dominated convergence for conditional expectations:
-    --    E[1_{Iic rₙ}(X₀)|tail] → E[1_{Iic q}(X₀)|tail] in L¹
-    -- 4. For monotone decreasing sequences, L¹ convergence implies a.e. convergence
-    -- 5. Therefore alphaIicCE rₙ ω → alphaIicCE q ω for a.e. ω
-    -- 6. The infimum equals this limit, so ⨅ r > q = alphaIicCE q
-
-    -- Since alphaIicCE is monotone in t and bounded in [0,1]:
-    -- - The infimum from the right exists and equals the limit from the right
-    -- - For CDFs, the limit from the right equals the value (right-continuity)
-
-    -- The key insight is that h_inf_ge shows ⨅ ≥ value (by monotonicity),
-    -- and we need ⨅ ≤ value (by right-continuity of CDF).
-    -- Combined, they give equality.
-
-    -- For now, since the proper dominated convergence proof is complex,
-    -- we use that alphaIicCE is a CDF and CDFs are right-continuous.
-    -- The proof would formally use tendsto_condExpL1_of_dominated_convergence.
-    -- See mathlib's IsRatCondKernelCDFAux.iInf_rat_gt_eq for the pattern.
-
-    -- Use the right-continuity property from h_right_cont
-    -- The infimum over Set.Ioi q is ≤ infimum over {r : ℚ // (q : ℝ) < r}
-    -- because Set.Ioi q ⊆ {r : ℚ // (q : ℝ) < r} (they're actually equal)
+    -- Upper bound: ⨅_{r > q, r ∈ ℝ} alphaIicCE r ω ≤ alphaIicCE q ω, the right-continuity
+    -- direction. We pass through the rational-indexed infimum `h_right_cont` (established
+    -- above via `tendsto_condExpL1_of_dominated_convergence` applied to indicator decrease);
+    -- the real-indexed infimum is ≤ the rational-indexed one since {r : ℚ // q < r}
+    -- realises a cofinal subset of `Set.Ioi q`.
 
     -- Nonempty instances for the infima
     haveI : Nonempty { r : ℚ // (q : ℝ) < r } :=


### PR DESCRIPTION
## Summary

Reviewer's item 3 — the right-continuity step inside `alphaIicCE_right_continuous_at` had ~35 lines of overlapping explanatory commentary preceding 5 lines of actual proof. The actual proof just calls `h_right_cont` (established earlier via `tendsto_condExpL1_of_dominated_convergence`).

**Net −34 lines in one file**, comment-only deletions. No proof body or decl signature touched.

## What was there

The cluster between L620-654 mixed three things:

1. Genuine mathematical-outline commentary (5-step sketch of DCT-based right-continuity) — already duplicated by the lemma's top-of-body PROOF STRUCTURE comment at L256-281.
2. Repetitive prose ("Key: …", "For a decreasing net …", "And for conditional CDFs …", "Since alphaIicCE is monotone in t and bounded in [0,1]: …").
3. A 4-line "For now, since the proper dominated convergence proof is complex, we use that alphaIicCE is a CDF / The proof would formally use `tendsto_condExpL1_of_dominated_convergence`" placeholder — **stale**: the actual proof DOES use that mathlib lemma at L370, and the current `h_right_cont` IS the DCT result.

## What it became

5 lines explaining what the upper-bound step does:

```lean
-- Upper bound: ⨅_{r > q, r ∈ ℝ} alphaIicCE r ω ≤ alphaIicCE q ω, the right-continuity
-- direction. We pass through the rational-indexed infimum `h_right_cont` (established
-- above via `tendsto_condExpL1_of_dominated_convergence` applied to indicator decrease);
-- the real-indexed infimum is ≤ the rational-indexed one since {r : ℚ // q < r}
-- realises a cofinal subset of `Set.Ioi q`.
```

## What was deliberately kept

The structural PROOF STRUCTURE block at the top of the lemma body (L256-281) — that's load-bearing documentation of the overall proof shape and accurately describes what the proof does.

## Verification

- `lake build` clean (3527 jobs, 0 warnings).
- `lake exe checkdecls blueprint/lean_decls` exit 0.
- `python3 blueprint/check_blueprint.py` exit 0.
- `#print axioms` on `deFinetti_viaL2`, `deFinetti`, `deFinetti_viaKoopman`: `[propext, Classical.choice, Quot.sound]` (unchanged).

## Test plan
- [x] `lake build` clean
- [x] `#print axioms` unchanged
- [x] No proof body or decl signature changed

## Next up per reviewer's priority

- Item 4: stale docs in `docs/implementation_guides/sorry3_*` and `docs/guides/PROOF_COMPLETION_GUIDE.md` (release hygiene).
- Item 5: tiny `measurable_firstRMap` private-or-inline in `PathSpace/CylinderHelpers.lean`.