### PR TITLE
chore(CylinderHelpers): privatize measurable_firstRMap (only in-file caller)

### DIFF
--- a/Exchangeability/PathSpace/CylinderHelpers.lean
+++ b/Exchangeability/PathSpace/CylinderHelpers.lean
@@ -94,9 +94,12 @@ lemma firstRCylinder_measurable_ambient
   simp only [firstRCylinder, Set.setOf_forall]
   exact MeasurableSet.iInter fun i => (hX i) (hC i)
 
-/-- The firstRMap is measurable when all coordinates are measurable. -/
+/-- The firstRMap is measurable when all coordinates are measurable.
+File-private — the only caller is `firstRSigma_le_ambient` directly below;
+if a future external file needs this, lift the privacy and re-register the
+`@[measurability, fun_prop]` attributes. -/
 @[measurability, fun_prop]
-lemma measurable_firstRMap
+private lemma measurable_firstRMap
     (X : ℕ → Ω → α) (r : ℕ) (hX : ∀ i, Measurable (X i)) :
     Measurable (firstRMap X r) := by
   unfold firstRMap; fun_prop


### PR DESCRIPTION
## Summary

Reviewer's item 5 — last in the prioritized list. `measurable_firstRMap` in `Exchangeability/PathSpace/CylinderHelpers.lean` has zero external references; its only caller is `firstRSigma_le_ambient` directly below it in the same file.

Privatized rather than inlined: the body is just `by unfold firstRMap; fun_prop`, but the name documents what the step proves and the call site uses it by name (no `by measurability` invocation that would lose tactic-database resolution). Added a docstring note explaining the file-private status and how to reverse it.

## Context

In PR #103 I had skipped this candidate because the lemma carries `@[measurability, fun_prop]` attributes, and privatizing would drop it from those global tactic databases for any future external file. The reviewer pushed back: speculative-future-use isn't a compelling reason to keep an otherwise-internal lemma exported. Action this time: privatize.

## Diff

```diff
-/-- The firstRMap is measurable when all coordinates are measurable. -/
+/-- The firstRMap is measurable when all coordinates are measurable.
+File-private — the only caller is `firstRSigma_le_ambient` directly below;
+if a future external file needs this, lift the privacy and re-register the
+`@[measurability, fun_prop]` attributes. -/
 @[measurability, fun_prop]
-lemma measurable_firstRMap
+private lemma measurable_firstRMap
```

Net: 1 file, +5 / −2 lines.

## Verification

- `lake build` clean (3527 jobs, 0 warnings).
- `#lint+ only unusedArguments in Exchangeability` exit 0 (no findings).
- `lake exe checkdecls blueprint/lean_decls` exit 0.
- `python3 blueprint/check_blueprint.py` exit 0.
- `#print axioms` on `deFinetti_viaL2`, `deFinetti`, `deFinetti_viaKoopman`: `[propext, Classical.choice, Quot.sound]` (unchanged).

## Test plan
- [x] `lake build` clean
- [x] `#lint+`, `checkdecls`, blueprint check all pass
- [x] `#print axioms` unchanged

## Backlog logged from your FYI

Mid-PR you mentioned `WorkPlans/Deprecated/DeFinetti/PROOF_SNIPPETS.md` (214 lines, references "remaining sorries" + an `hR` admit) and noted "maybe for a later pass." Confirmed the file exists; also ~10 sibling files under `WorkPlans/Deprecated/` that could be candidates for a similar stale-sorry-docs sweep. Holding off until you give the go.