### PR TITLE
chore: stale-code cleanup batch — dead decls, line refs, privatize, kill TailSigma compat

### DIFF
--- a/Exchangeability/DeFinetti/L2Helpers.lean
+++ b/Exchangeability/DeFinetti/L2Helpers.lean
@@ -345,8 +345,10 @@ variable {α : Type*} [MeasurableSpace α]
 variable {Ω : Type*} [MeasurableSpace Ω]
 
 /-- **Step 1:** Centering reduction - when coefficients sum to zero, we can replace
-variables with centered variables in weighted sums. -/
-lemma integral_sq_weighted_sum_eq_centered {μ : Measure Ω}
+variables with centered variables in weighted sums.
+File-private — only callers are in `integral_sq_weighted_sum_via_covariance` in the
+same file. -/
+private lemma integral_sq_weighted_sum_eq_centered {μ : Measure Ω}
     {n : ℕ} (ξ : Fin n → Ω → ℝ) (c : Fin n → ℝ) (m : ℝ)
     (hc_sum : ∑ i, c i = 0) :
     ∫ ω, (∑ i, c i * ξ i ω)^2 ∂μ = ∫ ω, (∑ i, c i * (ξ i ω - m))^2 ∂μ := by
@@ -356,8 +358,10 @@ lemma integral_sq_weighted_sum_eq_centered {μ : Measure Ω}
   ring
 
 /-- **Step 2:** Expand L² norm as bilinear form - converts integral of square to
-double sum of covariances. -/
-lemma integral_sq_weighted_sum_eq_double_sum {μ : Measure Ω}
+double sum of covariances.
+File-private — only callers are in `integral_sq_weighted_sum_via_covariance` in the
+same file. -/
+private lemma integral_sq_weighted_sum_eq_double_sum {μ : Measure Ω}
     {n : ℕ} (η : Fin n → Ω → ℝ) (c : Fin n → ℝ)
     (h_integrable : ∀ i j, Integrable (fun ω => η i ω * η j ω) μ) :
     ∫ ω, (∑ i, c i * η i ω)^2 ∂μ =

--- a/Exchangeability/DeFinetti/ViaKoopman/ContractableFactorization.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/ContractableFactorization.lean
@@ -186,8 +186,8 @@ lemma product_blockAvg_L1_convergence
   --   Finite sum of things → 0 is → 0 (by tendsto_finset_sum).
   --
   -- **Key ingredients from MoreL2Helpers.lean**:
-  --   - abs_prod_sub_prod_le (line 4624): |∏ f - ∏ g| ≤ ∑ |f_i - g_i| for |f|, |g| ≤ 1
-  --   - prod_tendsto_L1_of_L1_tendsto (line 4670): Alternative direct approach
+  --   - abs_prod_sub_prod_le: |∏ f - ∏ g| ≤ ∑ |f_i - g_i| for |f|, |g| ≤ 1
+  --   - prod_tendsto_L1_of_L1_tendsto: Alternative direct approach
 
   -- Handle m = 0 case first
   by_cases hm : m = 0

--- a/Exchangeability/DeFinetti/ViaKoopman/InfraCore.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/InfraCore.lean
@@ -139,23 +139,9 @@ omit [MeasurableSpace α] in
 @[simp] lemma extendByZero_apply_nat (ω : Ω[α]) (n : ℕ) :
     extendByZero (α := α) ω ↑n = ω n := by simp [extendByZero]
 
-omit [MeasurableSpace α] in
-lemma restrictNonneg_shiftℤ (ω : Ωℤ[α]) :
-    restrictNonneg (α := α) (shiftℤ (α := α) ω)
-      = shift (restrictNonneg (α := α) ω) := by ext; simp [restrictNonneg, shiftℤ, shift]
-
-omit [MeasurableSpace α] in
-lemma restrictNonneg_shiftℤInv (ω : Ωℤ[α]) :
-    restrictNonneg (α := α) (shiftℤInv (α := α) ω)
-      = fun n => ω (Int.ofNat n - 1) := by ext; simp [restrictNonneg, shiftℤInv]
-
 @[measurability, fun_prop]
 lemma measurable_shiftℤ : Measurable (shiftℤ (α := α)) := by
   unfold shiftℤ; fun_prop
-
-@[measurability, fun_prop]
-lemma measurable_shiftℤInv : Measurable (shiftℤInv (α := α)) := by
-  unfold shiftℤInv; fun_prop
 
 /-- Two-sided shift-invariant sets. A set is shift-invariant if it is measurable and equals its preimage under the shift. -/
 def IsShiftInvariantℤ (S : Set (Ωℤ[α])) : Prop :=

--- a/Exchangeability/DeFinetti/ViaL2/AlphaConvergence/AlphaIicEq.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaConvergence/AlphaIicEq.lean
@@ -211,7 +211,7 @@ lemma alphaIic_ae_eq_alphaIicCE
     have hε_half : ε/2 > 0 := by linarith
     have h_axiom : ∃ (M : ℕ), ∀ (m : ℕ), m ≥ M →
         ∫ ω, |(1 / (m : ℝ)) * ∑ i : Fin m, indIic t (X i ω) -
-              (μ[(indIic t ∘ X 0) | TailSigma.tailSigma X] ω)| ∂μ < ε/2 :=
+              (μ[(indIic t ∘ X 0) | Exchangeability.Tail.tailProcess X] ω)| ∂μ < ε/2 :=
       cesaro_to_condexp_L1 hX_contract hX_meas (indIic t) (indIic_measurable t) (indIic_bdd t) (ε/2) hε_half
     obtain ⟨M₁, hM₁⟩ := h_axiom
 
@@ -365,7 +365,7 @@ lemma alphaIic_ae_eq_alphaIicCE
         _ = ε/2 := by field_simp; ring
 
     -- Apply the axiom
-    have hB_conv : ∫ ω, |B m ω - μ[indIic t ∘ X 0|TailSigma.tailSigma X] ω| ∂μ < ε/2 := by
+    have hB_conv : ∫ ω, |B m ω - μ[indIic t ∘ X 0|Exchangeability.Tail.tailProcess X] ω| ∂μ < ε/2 := by
       convert hM₁ m (Nat.cast_le.mp h1) using 2
 
     -- Apply h_diff_small
@@ -401,9 +401,9 @@ lemma alphaIic_ae_eq_alphaIicCE
 
     -- Triangle inequality for integrals
     calc ∫ ω, |(1/(m:ℝ)) * ∑ k : Fin m, indIic t (X (k.val + 1) ω) -
-               μ[indIic t ∘ X 0|TailSigma.tailSigma X] ω| ∂μ
+               μ[indIic t ∘ X 0|Exchangeability.Tail.tailProcess X] ω| ∂μ
         ≤ ∫ ω, |(1/(m:ℝ)) * ∑ k : Fin m, indIic t (X (k.val + 1) ω) - B m ω| ∂μ +
-          ∫ ω, |B m ω - μ[indIic t ∘ X 0|TailSigma.tailSigma X] ω| ∂μ := by
+          ∫ ω, |B m ω - μ[indIic t ∘ X 0|Exchangeability.Tail.tailProcess X] ω| ∂μ := by
             -- Use pointwise triangle inequality: |a - c| ≤ |a - b| + |b - c|
             rw [← integral_add]
             · apply integral_mono

--- a/Exchangeability/DeFinetti/ViaL2/AlphaConvergence/EndpointAtBot.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaConvergence/EndpointAtBot.lean
@@ -57,9 +57,9 @@ private lemma alphaIicCE_L1_tendsto_zero_atBot
   -- First show ‖(indIic (-(n:ℝ))) ∘ X 0‖₁ → 0 by dominated convergence
 
   -- Set up the tail σ-algebra Fact instance (needed for condExp)
-  have hm_le : TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω) :=
-    TailSigma.tailSigma_le X hX_meas
-  haveI : Fact (TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω)) := ⟨hm_le⟩
+  have hm_le : Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω) :=
+    Exchangeability.Tail.tailProcess_le_ambient X hX_meas
+  haveI : Fact (Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω)) := ⟨hm_le⟩
 
   -- Step 1: Show ∫ |(indIic (-(n:ℝ))) ∘ X 0| → 0
   -- Indicator integral = measure of set {X 0 ≤ -n} → 0 by continuity
@@ -128,7 +128,7 @@ private lemma alphaIicCE_L1_tendsto_zero_atBot
     intro n
     -- alphaIicCE is conditional expectation, so use integral_abs_condExp_le
     unfold alphaIicCE
-    exact integral_abs_condExp_le (μ := μ) (m := TailSigma.tailSigma X) _
+    exact integral_abs_condExp_le (μ := μ) (m := Exchangeability.Tail.tailProcess X) _
 
   -- Apply squeeze theorem: 0 ≤ ‖alphaIicCE‖₁ ≤ ‖indicator‖₁ → 0
   refine tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds h_indicator_tendsto ?_ h_contraction
@@ -155,8 +155,8 @@ lemma alphaIicCE_ae_tendsto_zero_atBot
   set f : ℕ → Ω → ℝ := fun n ω => alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ)) ω
     with hf_def
   set L : Ω → ℝ := fun ω => ⨅ (n : ℕ), f n ω with hL_def
-  have hm_le : TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω) :=
-    TailSigma.tailSigma_le X hX_meas
+  have hm_le : Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω) :=
+    Exchangeability.Tail.tailProcess_le_ambient X hX_meas
   -- (1) Each f n is AEStronglyMeasurable (conditional expectation).
   have hf_meas : ∀ n, AEStronglyMeasurable (f n) μ := fun n => by
     show AEStronglyMeasurable (alphaIicCE X hX_contract hX_meas hX_L2 (-(n : ℝ))) μ

--- a/Exchangeability/DeFinetti/ViaL2/AlphaConvergence/EndpointAtTop.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaConvergence/EndpointAtTop.lean
@@ -49,9 +49,9 @@ private lemma alphaIicCE_L1_tendsto_one_atTop
   -- So ∫ |(indIic (n:ℝ)) ∘ X 0 - 1| → 0
 
   -- Set up the tail σ-algebra Fact instance (needed for condExp)
-  have hm_le : TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω) :=
-    TailSigma.tailSigma_le X hX_meas
-  haveI : Fact (TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω)) := ⟨hm_le⟩
+  have hm_le : Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω) :=
+    Exchangeability.Tail.tailProcess_le_ambient X hX_meas
+  haveI : Fact (Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω)) := ⟨hm_le⟩
 
   -- Step 1: Show ∫ |(indIic (n:ℝ)) ∘ X 0 - 1| → 0
   -- Integral of |indicator - 1| = μ(X 0 > n) → 0 by continuity
@@ -124,19 +124,19 @@ private lemma alphaIicCE_L1_tendsto_one_atTop
     intro n
     have h_int : Integrable ((indIic (n : ℝ)) ∘ (X 0)) μ :=
       Exchangeability.Probability.integrable_indicator_comp (hX_meas 0) measurableSet_Iic
-    have h_const : μ[(fun _ : Ω => (1 : ℝ)) | TailSigma.tailSigma X] =ᵐ[μ] (fun _ : Ω => (1 : ℝ)) :=
-      (condExp_const (μ := μ) (m := TailSigma.tailSigma X) hm_le (1 : ℝ)).eventuallyEq
+    have h_const : μ[(fun _ : Ω => (1 : ℝ)) | Exchangeability.Tail.tailProcess X] =ᵐ[μ] (fun _ : Ω => (1 : ℝ)) :=
+      (condExp_const (μ := μ) (m := Exchangeability.Tail.tailProcess X) hm_le (1 : ℝ)).eventuallyEq
     have h_ae_abs : (fun ω => |alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω - 1|)
-        =ᵐ[μ] (fun ω => |μ[((indIic (n : ℝ)) ∘ (X 0)) | TailSigma.tailSigma X] ω
-                         - μ[(fun _ : Ω => (1 : ℝ)) | TailSigma.tailSigma X] ω|) := by
+        =ᵐ[μ] (fun ω => |μ[((indIic (n : ℝ)) ∘ (X 0)) | Exchangeability.Tail.tailProcess X] ω
+                         - μ[(fun _ : Ω => (1 : ℝ)) | Exchangeability.Tail.tailProcess X] ω|) := by
       filter_upwards [h_const] with ω hω
       show |alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω - 1| =
-        |μ[((indIic (n : ℝ)) ∘ (X 0)) | TailSigma.tailSigma X] ω
-         - μ[(fun _ : Ω => (1 : ℝ)) | TailSigma.tailSigma X] ω|
+        |μ[((indIic (n : ℝ)) ∘ (X 0)) | Exchangeability.Tail.tailProcess X] ω
+         - μ[(fun _ : Ω => (1 : ℝ)) | Exchangeability.Tail.tailProcess X] ω|
       rw [hω]; rfl
     rw [integral_congr_ae h_ae_abs]
     exact Exchangeability.Probability.condExp_L1_lipschitz
-      (μ := μ) (m := TailSigma.tailSigma X) h_int (integrable_const 1)
+      (μ := μ) (m := Exchangeability.Tail.tailProcess X) h_int (integrable_const 1)
 
   -- Apply squeeze theorem: 0 ≤ ‖alphaIicCE - 1‖₁ ≤ ‖indicator - 1‖₁ → 0
   refine tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds h_indicator_tendsto ?_ h_contraction
@@ -162,8 +162,8 @@ lemma alphaIicCE_ae_tendsto_one_atTop
   set f : ℕ → Ω → ℝ := fun n ω => alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ) ω
     with hf_def
   set U : Ω → ℝ := fun ω => ⨆ (n : ℕ), f n ω with hU_def
-  have hm_le : TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω) :=
-    TailSigma.tailSigma_le X hX_meas
+  have hm_le : Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω) :=
+    Exchangeability.Tail.tailProcess_le_ambient X hX_meas
   -- (1) Each f n is AEStronglyMeasurable (conditional expectation).
   have hf_meas : ∀ n, AEStronglyMeasurable (f n) μ := fun n => by
     show AEStronglyMeasurable (alphaIicCE X hX_contract hX_meas hX_L2 (n : ℝ)) μ

--- a/Exchangeability/DeFinetti/ViaL2/AlphaIicCE.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaIicCE.lean
@@ -69,12 +69,12 @@ noncomputable def alphaIicCE
     (t : ℝ) : Ω → ℝ := by
   classical
   -- Set up the tail σ-algebra and its sub-σ-algebra relation
-  have hm_le : TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω) :=
-    TailSigma.tailSigma_le X hX_meas
+  have hm_le : Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω) :=
+    Exchangeability.Tail.tailProcess_le_ambient X hX_meas
   -- Create the Fact instance for the sub-σ-algebra relation
-  haveI : Fact (TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω)) := ⟨hm_le⟩
+  haveI : Fact (Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω)) := ⟨hm_le⟩
   -- Now we can call condExp with the tail σ-algebra
-  exact μ[(indIic t) ∘ (X 0) | TailSigma.tailSigma X]
+  exact μ[(indIic t) ∘ (X 0) | Exchangeability.Tail.tailProcess X]
 
 /-- Measurability of alphaIicCE.
 
@@ -93,7 +93,7 @@ lemma alphaIicCE_measurable
   unfold alphaIicCE
   -- The conditional expectation μ[f|m] is strongly measurable w.r.t. m
   -- Since m ≤ ambient, measurability w.r.t. m implies measurability w.r.t. ambient
-  have hm_le := TailSigma.tailSigma_le X hX_meas
+  have hm_le := Exchangeability.Tail.tailProcess_le_ambient X hX_meas
   refine Measurable.mono stronglyMeasurable_condExp.measurable hm_le le_rfl
 
 /-- alphaIicCE is monotone nondecreasing in t (for each fixed ω). -/
@@ -111,9 +111,9 @@ lemma alphaIicCE_mono
   intro s t hst
 
   -- Set up tail σ-algebra infrastructure
-  have hm_le : TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω) :=
-    TailSigma.tailSigma_le X hX_meas
-  haveI : Fact (TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω)) := ⟨hm_le⟩
+  have hm_le : Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω) :=
+    Exchangeability.Tail.tailProcess_le_ambient X hX_meas
+  haveI : Fact (Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω)) := ⟨hm_le⟩
 
   -- Show indIic s ≤ indIic t pointwise
   have h_ind_mono : (indIic s) ∘ (X 0) ≤ᵐ[μ] (indIic t) ∘ (X 0) := by
@@ -141,7 +141,7 @@ lemma alphaIicCE_mono
 
   -- Apply condExp_mono
   unfold alphaIicCE
-  exact condExp_mono (μ := μ) (m := TailSigma.tailSigma X) h_int_s h_int_t h_ind_mono
+  exact condExp_mono (μ := μ) (m := Exchangeability.Tail.tailProcess X) h_int_s h_int_t h_ind_mono
 
 /-- alphaIicCE is bounded in [0,1] almost everywhere. -/
 lemma alphaIicCE_nonneg_le_one
@@ -156,9 +156,9 @@ lemma alphaIicCE_nonneg_le_one
   -- Since 0 ≤ indIic t ≤ 1, we have 0 ≤ condExp(...) ≤ 1 a.e.
 
   -- Set up tail σ-algebra infrastructure
-  have hm_le : TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω) :=
-    TailSigma.tailSigma_le X hX_meas
-  haveI : Fact (TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω)) := ⟨hm_le⟩
+  have hm_le : Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω) :=
+    Exchangeability.Tail.tailProcess_le_ambient X hX_meas
+  haveI : Fact (Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω)) := ⟨hm_le⟩
 
   -- Nonnegativity: 0 ≤ indIic t ∘ X 0 implies 0 ≤ condExp
   have h₀ : 0 ≤ᵐ[μ] alphaIicCE X hX_contract hX_meas hX_L2 t := by
@@ -169,7 +169,7 @@ lemma alphaIicCE_nonneg_le_one
       simp [indIic, Set.indicator]
       split_ifs <;> norm_num
     unfold alphaIicCE
-    convert condExp_nonneg (μ := μ) (m := TailSigma.tailSigma X) this using 2
+    convert condExp_nonneg (μ := μ) (m := Exchangeability.Tail.tailProcess X) this using 2
 
   -- Upper bound: indIic t ∘ X 0 ≤ 1 implies condExp ≤ 1
   have h₁ : alphaIicCE X hX_contract hX_meas hX_L2 t ≤ᵐ[μ] fun _ => (1 : ℝ) := by
@@ -186,9 +186,9 @@ lemma alphaIicCE_nonneg_le_one
       rw [this]
       exact Exchangeability.Probability.integrable_indicator_comp (hX_meas 0) measurableSet_Iic
     unfold alphaIicCE
-    have h_mono := condExp_mono (μ := μ) (m := TailSigma.tailSigma X)
+    have h_mono := condExp_mono (μ := μ) (m := Exchangeability.Tail.tailProcess X)
       h_int (integrable_const (1 : ℝ)) h_le
-    rw [condExp_const (μ := μ) (m := TailSigma.tailSigma X) hm_le (1 : ℝ)] at h_mono
+    rw [condExp_const (μ := μ) (m := Exchangeability.Tail.tailProcess X) hm_le (1 : ℝ)] at h_mono
     exact h_mono
 
   filter_upwards [h₀, h₁] with ω h0 h1
@@ -281,9 +281,9 @@ lemma alphaIicCE_right_continuous_at
   -- - alphaIicCE_mono
 
   -- Set up tail σ-algebra infrastructure
-  have hm_le : TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω) :=
-    TailSigma.tailSigma_le X hX_meas
-  haveI h_fact : Fact (TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω)) := ⟨hm_le⟩
+  have hm_le : Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω) :=
+    Exchangeability.Tail.tailProcess_le_ambient X hX_meas
+  haveI h_fact : Fact (Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω)) := ⟨hm_le⟩
   haveI h_sf : SigmaFinite (μ.trim hm_le) := inferInstance
 
   -- Step 1: Get decreasing rational sequence u_n → t with u_n > t
@@ -512,9 +512,9 @@ lemma alphaIicCE_iInf_rat_gt_eq
         alphaIicCE X hX_contract hX_meas hX_L2 (r : ℝ) ω =
         alphaIicCE X hX_contract hX_meas hX_L2 (q : ℝ) ω := by
   -- Set up tail σ-algebra infrastructure
-  have hm_le : TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω) :=
-    TailSigma.tailSigma_le X hX_meas
-  haveI : Fact (TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω)) := ⟨hm_le⟩
+  have hm_le : Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω) :=
+    Exchangeability.Tail.tailProcess_le_ambient X hX_meas
+  haveI : Fact (Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω)) := ⟨hm_le⟩
 
   -- Use ae_all_iff to reduce to proving for each rational q
   rw [ae_all_iff]

--- a/Exchangeability/DeFinetti/ViaL2/BlockAverages.lean
+++ b/Exchangeability/DeFinetti/ViaL2/BlockAverages.lean
@@ -6,10 +6,9 @@ Authors: Cameron Freer
 import Exchangeability.DeFinetti.ViaL2.BlockAverages.Covariance
 import Exchangeability.DeFinetti.ViaL2.BlockAverages.TwoWindows
 import Exchangeability.DeFinetti.ViaL2.BlockAverages.LongVsTail
-import Exchangeability.Tail.TailSigma
 
 /-!
-# BlockAverages — re-export shim + TailSigma compatibility aliases
+# BlockAverages — re-export shim
 
 Following the split for maintainability, the contents now live in three
 sub-files:
@@ -22,42 +21,8 @@ sub-files:
   `l2_bound_long_vs_tail`, the second L² Cauchy bound (long average vs.
   tail-shifted average).
 
-This umbrella file additionally exposes a small `TailSigma` namespace with
-`@[reducible]` aliases for the canonical `Exchangeability.Tail` declarations,
-kept for backward compatibility with downstream code in the ViaL2 family.
+Callers should refer to the canonical tail σ-algebra declarations directly:
+`Exchangeability.Tail.tailFamily`, `Exchangeability.Tail.tailProcess`,
+`Exchangeability.Tail.tailFamily_antitone`, and
+`Exchangeability.Tail.tailProcess_le_ambient`.
 -/
-
-namespace Exchangeability.DeFinetti.ViaL2
-
-/-!
-## Tail σ-algebra for sequences
-
-Now using the canonical definitions from `Exchangeability.Tail.TailSigma`.
-
-For backward compatibility in this file, we create a namespace with re-exports:
-- `TailSigma.tailFamily X n` := `Tail.tailFamily X n` (future σ-algebra from index n onward)
-- `TailSigma.tailSigma X` := `Tail.tailProcess X` (tail σ-algebra)
--/
-
-namespace TailSigma
-
--- Re-export the definitions for backward compatibility
-/-- Re-export of `Tail.tailFamily` for backward compatibility. -/
-@[reducible] def tailFamily := @Exchangeability.Tail.tailFamily
-/-- Re-export of `Tail.tailProcess` for backward compatibility. -/
-@[reducible] def tailSigma := @Exchangeability.Tail.tailProcess
-
--- Re-export the lemmas for backward compatibility
-lemma antitone_tailFamily {Ω β : Type*} [MeasurableSpace Ω] [MeasurableSpace β]
-    (X : ℕ → Ω → β) : Antitone (tailFamily X) :=
-  Exchangeability.Tail.tailFamily_antitone X
-
-
-lemma tailSigma_le {Ω β : Type*} [MeasurableSpace Ω] [MeasurableSpace β]
-    (X : ℕ → Ω → β) (hX_meas : ∀ i, Measurable (X i)) :
-    tailSigma X ≤ (inferInstance : MeasurableSpace Ω) :=
-  Exchangeability.Tail.tailProcess_le_ambient X hX_meas
-
-end TailSigma
-
-end Exchangeability.DeFinetti.ViaL2

--- a/Exchangeability/DeFinetti/ViaL2/BlockAverages/LongVsTail.lean
+++ b/Exchangeability/DeFinetti/ViaL2/BlockAverages/LongVsTail.lean
@@ -179,7 +179,7 @@ lemma l2_bound_long_vs_tail
 
   have hξ_L2 : ∀ i, MemLp (fun ω => ξ i ω - mf) 2 μ := by
     intro i
-    -- Reconstruct MemLp from boundedness (M, hM already available from line 1690)
+    -- Reconstruct MemLp from boundedness (M, hM already available above)
     have : MemLp (fun ω => f (X (n + i.val + 1) ω)) 2 μ := by
       apply MemLp.of_bound (hf_meas.comp (hX_meas (n + i.val + 1))).aestronglyMeasurable M
       filter_upwards with ω

--- a/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/L1.lean
+++ b/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/L1.lean
@@ -44,7 +44,7 @@ lemma cesaro_to_condexp_L1
     (f : ℝ → ℝ) (hf_meas : Measurable f) (hf_bdd : ∀ x, |f x| ≤ 1) :
     ∀ ε > 0, ∃ (M : ℕ), ∀ (m : ℕ), m ≥ M →
       ∫ ω, |(1 / (m : ℝ)) * ∑ i : Fin m, f (X i ω) -
-             (μ[(f ∘ X 0) | TailSigma.tailSigma X] ω)| ∂μ < ε := by
+             (μ[(f ∘ X 0) | Exchangeability.Tail.tailProcess X] ω)| ∂μ < ε := by
   -- Get L² convergence from cesaro_to_condexp_L2
   obtain ⟨α_f, hα_L2, hα_tail, hα_conv, hα_eq⟩ := cesaro_to_condexp_L2 hX_contract hX_meas f hf_meas hf_bdd
 
@@ -57,9 +57,9 @@ lemma cesaro_to_condexp_L1
   -- Available from cesaro_to_condexp_L2:
   -- • α_f : Ω → ℝ - the L² limit
   -- • hα_L2 : MemLp α_f 2 μ - α_f is in L²
-  -- • hα_tail : Measurable[TailSigma.tailSigma X] α_f - α_f is tail-measurable
+  -- • hα_tail : Measurable[Exchangeability.Tail.tailProcess X] α_f - α_f is tail-measurable
   -- • hα_conv : Tendsto (fun n => eLpNorm (blockAvg f X 0 n - α_f) 2 μ) atTop (𝓝 0)
-  -- • hα_eq : α_f =ᵐ[μ] μ[f ∘ X 0 | TailSigma.tailSigma X]
+  -- • hα_eq : α_f =ᵐ[μ] μ[f ∘ X 0 | Exchangeability.Tail.tailProcess X]
 
   -- STEP 1: Convert eLpNorm convergence to plain integral form
   -- eLpNorm g 2 μ = (∫ |g|² ∂μ)^(1/2), so squaring both sides and using continuity

--- a/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/L2.lean
+++ b/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/L2.lean
@@ -46,7 +46,7 @@ lemma blockAvg_measurable_tailFamily
     {f : ℝ → ℝ} (hf : Measurable f)
     {X : ℕ → Ω → ℝ}
     (m n : ℕ) :
-    Measurable[TailSigma.tailFamily X m] (blockAvg f X m n) := by
+    Measurable[Exchangeability.Tail.tailFamily X m] (blockAvg f X m n) := by
   -- blockAvg f X m n = (n⁻¹) * ∑_{k<n} f(X_{m+k})
   unfold blockAvg
   -- Each X (m + k) is measurable w.r.t. tailFamily X m by definition
@@ -242,7 +242,7 @@ private lemma tail_measurability_of_blockAvg
     (hX_meas : ∀ i, Measurable (X i))
     (α_f : Ω → ℝ) (hα_memLp : MemLp α_f 2 μ)
     (hα_limit : Tendsto (fun n => eLpNorm (blockAvg f X 0 n - α_f) 2 μ) atTop (𝓝 0)) :
-    AEStronglyMeasurable[TailSigma.tailSigma X] α_f μ := by
+    AEStronglyMeasurable[Exchangeability.Tail.tailProcess X] α_f μ := by
   -- PROOF STRATEGY:
   -- 1. For each N, show α_f is AEStronglyMeasurable[tailFamily X N]
   --    (using closedness of L² measurable functions and blockAvg_shift_tendsto)
@@ -252,21 +252,21 @@ private lemma tail_measurability_of_blockAvg
   -- and tailSigma X = ⨅ N, tailFamily X N by definition.
 
   -- Step 1: Show α_f is AEStronglyMeasurable[tailFamily X N] for each N
-  have h_aesm_each : ∀ N, AEStronglyMeasurable[TailSigma.tailFamily X N] α_f μ := by
+  have h_aesm_each : ∀ N, AEStronglyMeasurable[Exchangeability.Tail.tailFamily X N] α_f μ := by
     intro N
     -- The block averages starting at N converge to α_f in L²
     -- Each blockAvg f X N m is Measurable[tailFamily X N]
     -- By closedness of L²(tailFamily X N), the limit α_f is also in it
 
     -- Step 1a: blockAvg f X N m is Measurable[tailFamily X N] for all m
-    have h_block_meas : ∀ m, @Measurable Ω ℝ (TailSigma.tailFamily X N) _ (blockAvg f X N m) :=
+    have h_block_meas : ∀ m, @Measurable Ω ℝ (Exchangeability.Tail.tailFamily X N) _ (blockAvg f X N m) :=
       fun m => blockAvg_measurable_tailFamily hf_meas N m
 
     -- Step 1b: blockAvg f X N m → α_f in L² (by blockAvg_shift_tendsto)
     have h_L2_conv := blockAvg_shift_tendsto f hf_meas hf_bdd hX_meas α_f hα_memLp hα_limit N
 
     -- Step 1c: tailFamily X N ≤ ambient σ-algebra (for measure compatibility)
-    have h_tf_le : TailSigma.tailFamily X N ≤ (inferInstance : MeasurableSpace Ω) := by
+    have h_tf_le : Exchangeability.Tail.tailFamily X N ≤ (inferInstance : MeasurableSpace Ω) := by
       refine iSup_le (fun k => ?_)
       exact MeasurableSpace.comap_le_iff_le_map.mpr (hX_meas (N + k))
 
@@ -287,12 +287,12 @@ private lemma tail_measurability_of_blockAvg
     exact aestronglyMeasurable_sub_of_tendsto_ae h_tf_le (fun k => h_block_meas (ns k)) h_ae_conv
 
   -- Step 2: Apply the axiom to descend to the infimum
-  have h_anti : Antitone (TailSigma.tailFamily X) := TailSigma.antitone_tailFamily X
+  have h_anti : Antitone (Exchangeability.Tail.tailFamily X) := Exchangeability.Tail.tailFamily_antitone X
 
   -- Each tailFamily X N ≤ ambient measurable space
   -- This follows from: tailFamily X N = ⨆ k, comap (X (N+k)) _
   -- and comap f ≤ ambient when f is measurable
-  have h_le : ∀ N, TailSigma.tailFamily X N ≤ (inferInstance : MeasurableSpace Ω) := by
+  have h_le : ∀ N, Exchangeability.Tail.tailFamily X N ≤ (inferInstance : MeasurableSpace Ω) := by
     intro N
     -- tailFamily X N consists of sets measurable wrt X_{N+k} for k ∈ ℕ
     -- Each such set is in the ambient σ-algebra when X_k are measurable
@@ -300,7 +300,7 @@ private lemma tail_measurability_of_blockAvg
     exact MeasurableSpace.comap_le_iff_le_map.mpr (hX_meas (N + k))
 
   -- tailSigma X = ⨅ N, tailFamily X N (by definition in TailSigma module)
-  have h_eq : TailSigma.tailSigma X = ⨅ N, TailSigma.tailFamily X N := rfl
+  have h_eq : Exchangeability.Tail.tailProcess X = ⨅ N, Exchangeability.Tail.tailFamily X N := rfl
 
   rw [h_eq]
   exact aestronglyMeasurable_iInf_antitone h_anti h_le α_f h_aesm_each
@@ -343,9 +343,9 @@ lemma cesaro_to_condexp_L2
     (hX_meas : ∀ i, Measurable (X i))
     (f : ℝ → ℝ) (hf_meas : Measurable f) (hf_bdd : ∀ x, |f x| ≤ 1) :
     ∃ (α_f : Ω → ℝ), MemLp α_f 2 μ ∧
-      AEStronglyMeasurable[TailSigma.tailSigma X] α_f μ ∧
+      AEStronglyMeasurable[Exchangeability.Tail.tailProcess X] α_f μ ∧
       Tendsto (fun n => eLpNorm (blockAvg f X 0 n - α_f) 2 μ) atTop (𝓝 0) ∧
-      α_f =ᵐ[μ] μ[(f ∘ X 0) | TailSigma.tailSigma X] := by
+      α_f =ᵐ[μ] μ[(f ∘ X 0) | Exchangeability.Tail.tailProcess X] := by
   -- Step 1: Show block averages form a Cauchy sequence in L² (via `Cauchy.lean`).
   have hCauchy := blockAvg_cauchy_in_L2 hX_contract hX_meas f hf_meas hf_bdd
 
@@ -446,12 +446,12 @@ lemma cesaro_to_condexp_L2
   --                 = E[α_f 1_A] (by L² convergence)
   -- Therefore α_f is the conditional expectation
   · -- Identification as conditional expectation
-    -- The key relationship: TailSigma.tailSigma X = tailProcess X
+    -- The key relationship: Exchangeability.Tail.tailProcess X = tailProcess X
     -- This follows from the re-export in BlockAverages.lean
 
     -- Step 1: Sub-σ-algebra condition
-    have hm : TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω) :=
-      TailSigma.tailSigma_le X hX_meas
+    have hm : Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω) :=
+      Exchangeability.Tail.tailProcess_le_ambient X hX_meas
 
     -- Step 2: SigmaFinite for trimmed measure (automatic for probability measures)
     haveI h_finite : IsFiniteMeasure (μ.trim hm) := by
@@ -482,7 +482,7 @@ lemma cesaro_to_condexp_L2
 
     -- Condition 2: Set integrals are equal
     · intro A hA hμA
-      -- Convert MeasurableSet from TailSigma.tailSigma to tailProcess
+      -- Convert MeasurableSet from Exchangeability.Tail.tailProcess to tailProcess
       -- (They are definitionally equal via the re-export in BlockAverages.lean)
       have hA_tail : MeasurableSet[Exchangeability.Tail.tailProcess X] A := hA
 

--- a/Exchangeability/DeFinetti/ViaL2/DirectingMeasureBridge.lean
+++ b/Exchangeability/DeFinetti/ViaL2/DirectingMeasureBridge.lean
@@ -34,10 +34,10 @@ theorem directing_measure_ae_eq_condExpKernel_map
       =ᵐ[μ]
     (fun ω =>
       Measure.map (X 0)
-        (condExpKernel (μ := μ) (m := TailSigma.tailSigma X) ω)) := by
+        (condExpKernel (μ := μ) (m := Exchangeability.Tail.tailProcess X) ω)) := by
   classical
-  have hm_le : TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω) :=
-    TailSigma.tailSigma_le X hX_meas
+  have hm_le : Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω) :=
+    Exchangeability.Tail.tailProcess_le_ambient X hX_meas
   have hX0 : Measurable (X 0) := hX_meas 0
   -- For each rational q, the Iic-q values agree a.e. via the existing local Iic-integral
   -- identity on the LHS and condExpKernel_ae_eq_condExp on the RHS, both equal to
@@ -45,7 +45,7 @@ theorem directing_measure_ae_eq_condExpKernel_map
   have h_each_q : ∀ q : ℚ, ∀ᵐ ω ∂μ,
       (directing_measure X hX_contract hX_meas hX_L2 ω) (Iic (q : ℝ))
         = (Measure.map (X 0)
-            (condExpKernel (μ := μ) (m := TailSigma.tailSigma X) ω)) (Iic (q : ℝ)) := by
+            (condExpKernel (μ := μ) (m := Exchangeability.Tail.tailProcess X) ω)) (Iic (q : ℝ)) := by
     intro q
     set t : ℝ := (q : ℝ) with ht_def
     have hIic_meas : MeasurableSet (Iic t) := measurableSet_Iic
@@ -59,11 +59,11 @@ theorem directing_measure_ae_eq_condExpKernel_map
     -- RHS in real form: (condExpKernel μ m ω).real (X 0 ⁻¹' Iic t)
     --   =ᵐ μ[(X 0 ⁻¹' Iic t).indicator 1 | tailSigma X] ω
     have h_rhs_real :
-        (fun ω => (condExpKernel (μ := μ) (m := TailSigma.tailSigma X) ω).real
+        (fun ω => (condExpKernel (μ := μ) (m := Exchangeability.Tail.tailProcess X) ω).real
                     (X 0 ⁻¹' Iic t))
           =ᵐ[μ]
         μ[(X 0 ⁻¹' Iic t).indicator (fun _ => (1:ℝ))
-            | TailSigma.tailSigma X] :=
+            | Exchangeability.Tail.tailProcess X] :=
       condExpKernel_ae_eq_condExp hm_le hpreim_meas
     -- The set indicator (X 0 ⁻¹' Iic t).indicator 1 equals indIic t ∘ X 0 as functions.
     have h_fun_eq :
@@ -77,14 +77,14 @@ theorem directing_measure_ae_eq_condExpKernel_map
       directing_measure_isProbabilityMeasure X hX_contract hX_meas hX_L2 ω
     haveI : IsProbabilityMeasure
         (Measure.map (X 0)
-          (condExpKernel (μ := μ) (m := TailSigma.tailSigma X) ω)) :=
+          (condExpKernel (μ := μ) (m := Exchangeability.Tail.tailProcess X) ω)) :=
       Measure.isProbabilityMeasure_map hX0.aemeasurable
     -- alphaIicCE := μ[indIic t ∘ X 0 | tailSigma X]; via h_fun_eq it equals the indicator form.
     have h_alpha_eq_condProb :
         alphaIicCE X hX_contract hX_meas hX_L2 t ω
           = μ[(X 0 ⁻¹' Iic t).indicator (fun _ => (1:ℝ))
-              | TailSigma.tailSigma X] ω := by
-      show μ[(indIic t) ∘ X 0 | TailSigma.tailSigma X] ω = _
+              | Exchangeability.Tail.tailProcess X] ω := by
+      show μ[(indIic t) ∘ X 0 | Exchangeability.Tail.tailProcess X] ω = _
       rw [← h_fun_eq]
     -- Both sides have the same `.toReal`: equal to alphaIicCE t ω.
     have h_lhs_toReal :
@@ -94,12 +94,12 @@ theorem directing_measure_ae_eq_condExpKernel_map
       exact (integral_indicator_one hIic_meas).symm
     have h_rhs_toReal :
         ((Measure.map (X 0)
-            (condExpKernel (μ := μ) (m := TailSigma.tailSigma X) ω)) (Iic t)).toReal
+            (condExpKernel (μ := μ) (m := Exchangeability.Tail.tailProcess X) ω)) (Iic t)).toReal
           = alphaIicCE X hX_contract hX_meas hX_L2 t ω := by
       rw [Measure.map_apply hX0 hIic_meas]
-      have : ((condExpKernel (μ := μ) (m := TailSigma.tailSigma X) ω)
+      have : ((condExpKernel (μ := μ) (m := Exchangeability.Tail.tailProcess X) ω)
                 (X 0 ⁻¹' Iic t)).toReal
-              = (condExpKernel (μ := μ) (m := TailSigma.tailSigma X) ω).real
+              = (condExpKernel (μ := μ) (m := Exchangeability.Tail.tailProcess X) ω).real
                   (X 0 ⁻¹' Iic t) := rfl
       rw [this, hω_rhs, ← h_alpha_eq_condProb]
     -- Lift .toReal equality back to ENNReal values (both measures are finite/probability).
@@ -108,7 +108,7 @@ theorem directing_measure_ae_eq_condExpKernel_map
       measure_ne_top _ _
     have h_rhs_ne_top :
         (Measure.map (X 0)
-          (condExpKernel (μ := μ) (m := TailSigma.tailSigma X) ω)) (Iic t) ≠ ⊤ :=
+          (condExpKernel (μ := μ) (m := Exchangeability.Tail.tailProcess X) ω)) (Iic t) ≠ ⊤ :=
       measure_ne_top _ _
     rw [← ENNReal.ofReal_toReal h_lhs_ne_top, ← ENNReal.ofReal_toReal h_rhs_ne_top,
         h_lhs_toReal, h_rhs_toReal]
@@ -116,7 +116,7 @@ theorem directing_measure_ae_eq_condExpKernel_map
   have h_all_q : ∀ᵐ ω ∂μ, ∀ q : ℚ,
       (directing_measure X hX_contract hX_meas hX_L2 ω) (Iic (q : ℝ))
         = (Measure.map (X 0)
-            (condExpKernel (μ := μ) (m := TailSigma.tailSigma X) ω)) (Iic (q : ℝ)) :=
+            (condExpKernel (μ := μ) (m := Exchangeability.Tail.tailProcess X) ω)) (Iic (q : ℝ)) :=
     ae_all_iff.mpr h_each_q
   -- For each such ω, both measures are probability, agreeing on the rational Iic π-system
   -- that generates the Borel σ-algebra. Hence equal.
@@ -125,7 +125,7 @@ theorem directing_measure_ae_eq_condExpKernel_map
       (directing_measure X hX_contract hX_meas hX_L2 ω) :=
     directing_measure_isProbabilityMeasure X hX_contract hX_meas hX_L2 ω
   haveI : IsProbabilityMeasure
-      (Measure.map (X 0) (condExpKernel (μ := μ) (m := TailSigma.tailSigma X) ω)) :=
+      (Measure.map (X 0) (condExpKernel (μ := μ) (m := Exchangeability.Tail.tailProcess X) ω)) :=
     Measure.isProbabilityMeasure_map hX0.aemeasurable
   refine MeasureTheory.ext_of_generate_finite
       (⋃ a : ℚ, {Iic (a : ℝ)})

--- a/Exchangeability/DeFinetti/ViaL2/DirectingMeasureIntegral.lean
+++ b/Exchangeability/DeFinetti/ViaL2/DirectingMeasureIntegral.lean
@@ -56,9 +56,9 @@ lemma directing_measure_integral_eq_condExp
     (hX_L2 : ∀ i, MemLp (X i) 2 μ)
     (f : ℝ → ℝ) (hf_meas : Measurable f) (hf_bdd : ∃ M, ∀ x, |f x| ≤ M) :
     (fun ω => ∫ x, f x ∂(directing_measure X hX_contract hX_meas hX_L2 ω))
-      =ᵐ[μ] μ[fun ω => f (X 0 ω) | TailSigma.tailSigma X] := by
-  have hm_le : TailSigma.tailSigma X ≤ (inferInstance : MeasurableSpace Ω) :=
-    TailSigma.tailSigma_le X hX_meas
+      =ᵐ[μ] μ[fun ω => f (X 0 ω) | Exchangeability.Tail.tailProcess X] := by
+  have hm_le : Exchangeability.Tail.tailProcess X ≤ (inferInstance : MeasurableSpace Ω) :=
+    Exchangeability.Tail.tailProcess_le_ambient X hX_meas
   obtain ⟨M, hM⟩ := hf_bdd
   -- `f ∘ X 0` is integrable on the probability space (bounded measurable).
   have hfX0_int : Integrable (fun ω => f (X 0 ω)) μ := by
@@ -73,7 +73,7 @@ lemma directing_measure_integral_eq_condExp
   -- against the kernel at `ω`, by `integral_map`.
   have h_push : (fun ω => ∫ x, f x ∂(directing_measure X hX_contract hX_meas hX_L2 ω))
       =ᵐ[μ] fun ω => ∫ y, f (X 0 y)
-          ∂(condExpKernel (μ := μ) (m := TailSigma.tailSigma X) ω) := by
+          ∂(condExpKernel (μ := μ) (m := Exchangeability.Tail.tailProcess X) ω) := by
     filter_upwards [h_bridge] with ω hω
     rw [hω]
     exact integral_map (hX_meas 0).aemeasurable hf_meas.aestronglyMeasurable

--- a/Exchangeability/DeFinetti/ViaL2/MainConvergence.lean
+++ b/Exchangeability/DeFinetti/ViaL2/MainConvergence.lean
@@ -479,7 +479,7 @@ theorem weighted_sums_converge_L1
     rcases halpha_0_conv (ε / 2) hε2_pos with ⟨M₁, hM₁⟩
 
     -- Get uniform bound constant (already computed above, reuse it)
-    -- Note: Cf, mf, σSqf, ρf are already in scope from line 2186
+    -- Note: Cf, mf, σSqf, ρf are already in scope
 
     -- Choose M₂ large enough that √(Cf/M₂) < ε/2
     -- This means Cf/M₂ < ε²/4, so M₂ > 4Cf/ε²

--- a/Exchangeability/DeFinetti/ViaL2/MoreL2Helpers.lean
+++ b/Exchangeability/DeFinetti/ViaL2/MoreL2Helpers.lean
@@ -249,13 +249,13 @@ lemma directing_measure_bridge
       (fun ω => (ν ω B).toReal) =ᵐ[μ]
         μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ (X n) | ViaMartingale.tailSigma X] := by
     intro n B hB
-    have h_tail_eq : ViaMartingale.tailSigma X = TailSigma.tailSigma X :=
+    have h_tail_eq : ViaMartingale.tailSigma X = Exchangeability.Tail.tailProcess X :=
       ViaMartingale.tailSigma_eq_canonical X
     have hf_meas : Measurable (Set.indicator B (fun _ => (1 : ℝ))) :=
       measurable_const.indicator hB
     -- Base case n=0: directing_measure_integral_eq_condExp gives ∫ 1_B dν =ᵐ E[1_B ∘ X 0 | tail]
     have h_n0 : (fun ω => (ν ω B).toReal) =ᵐ[μ]
-        μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ (X 0) | TailSigma.tailSigma X] := by
+        μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ (X 0) | Exchangeability.Tail.tailProcess X] := by
       have h_eq := directing_measure_integral_eq_condExp X hX_contract hX_meas hX_L2
         (Set.indicator B (fun _ => (1 : ℝ))) hf_meas
         ⟨1, fun x => by simp only [Set.indicator]; split_ifs <;> norm_num⟩
@@ -266,14 +266,14 @@ lemma directing_measure_bridge
         rw [h1, integral_indicator_one hB]; rfl
       filter_upwards [h_eq] with ω hω; rw [← h_integral ω, hω]; rfl
     -- Shift invariance: E[1_B ∘ X n | tail] =ᵐ E[1_B ∘ X 0 | tail]
-    have h_shift : μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ (X n) | TailSigma.tailSigma X] =ᵐ[μ]
-        μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ (X 0) | TailSigma.tailSigma X] :=
+    have h_shift : μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ (X n) | Exchangeability.Tail.tailProcess X] =ᵐ[μ]
+        μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ (X 0) | Exchangeability.Tail.tailProcess X] :=
       Exchangeability.Tail.ShiftInvariance.condExp_shift_eq_condExp X hX_contract hX_meas
         (Set.indicator B (fun _ => (1 : ℝ))) hf_meas
         ((integrable_const 1).indicator (hX_meas 0 hB)) n
     calc (fun ω => (ν ω B).toReal) =ᵐ[μ]
-        μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ (X 0) | TailSigma.tailSigma X] := h_n0
-      _ =ᵐ[μ] μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ (X n) | TailSigma.tailSigma X] := h_shift.symm
+        μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ (X 0) | Exchangeability.Tail.tailProcess X] := h_n0
+      _ =ᵐ[μ] μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ (X n) | Exchangeability.Tail.tailProcess X] := h_shift.symm
       _ =ᵐ[μ] μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ (X n) | ViaMartingale.tailSigma X] := by
           rw [h_tail_eq]
   exact indicator_product_bridge X hX_contract hX_meas ν hν_prob hν_meas hν_law k hk B hB


### PR DESCRIPTION
## Summary

Four targeted stale-code cleanups, split across two commits:

**Commit 1 — dead decls + stale comments + privatize (−10 net lines):**
- `InfraCore.lean`: delete `restrictNonneg_shiftℤ`, `restrictNonneg_shiftℤInv`, `measurable_shiftℤInv` — zero in-repo callers. The latter's `@[measurability, fun_prop]` tag turns out not to be used implicitly (build remains green).
- `L2Helpers.lean`: privatize `integral_sq_weighted_sum_eq_centered` and `integral_sq_weighted_sum_eq_double_sum`. Both are only used in `integral_sq_weighted_sum_via_covariance` within the same file.
- Strip stale line-number comments in `ContractableFactorization.lean` (refs to `MoreL2Helpers` line 4624/4670, the file has been split), `LongVsTail.lean` (line 1690), `MainConvergence.lean` (line 2186).

**Commit 2 — drop TailSigma compatibility namespace (−35 net lines):**

`BlockAverages.lean` previously exposed a `TailSigma` namespace with `@[reducible]` aliases of canonical `Exchangeability.Tail` decls, kept for backward compatibility. All ten ViaL2 callers were migrated:

| compat alias | canonical name |
|---|---|
| `TailSigma.tailFamily` | `Exchangeability.Tail.tailFamily` |
| `TailSigma.tailSigma` | `Exchangeability.Tail.tailProcess` |
| `TailSigma.tailSigma_le` | `Exchangeability.Tail.tailProcess_le_ambient` |
| `TailSigma.antitone_tailFamily` | `Exchangeability.Tail.tailFamily_antitone` |

The compat layer is then deleted from `BlockAverages.lean`, which now just re-exports its three sub-files. The transitive `Exchangeability.Tail.TailSigma` import was removed from `BlockAverages.lean` since the aliases were the only reason it lived at that level.

**Combined diff:** 15 files, +102 / −147 (net −45 lines).

## Test plan

- [x] `lake build` clean (3527/3527 jobs)
- [x] `#print axioms` on `deFinetti`, `deFinetti_viaL2`, `deFinetti_viaKoopman` — all `[propext, Classical.choice, Quot.sound]`
- [x] `lake exe checkdecls blueprint/lean_decls` passes
- [x] `python3 blueprint/check_blueprint.py` — 52 cites, 52 labels, 50 refs/uses, 52 lean_decls, all consistent
- [x] 0 sorries