### PR TITLE
chore: privatize 4 same-file helpers + drop 7 dead @[simp] lemmas in InfraCore

### DIFF
--- a/Exchangeability/DeFinetti/ViaKoopman/CesaroL2ToL1.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/CesaroL2ToL1.lean
@@ -95,8 +95,9 @@ lemma eventuallyEq_comp_measurePreserving {f g : Ω[α] → ℝ}
   hT.quasiMeasurePreserving.ae_eq_comp hfg
 
 omit [MeasurableSpace α] [StandardBorelSpace α] in
-/-- General evaluation formula for shift iteration. -/
-lemma iterate_shift_eval' (k n : ℕ) (ω : Ω[α]) :
+/-- General evaluation formula for shift iteration. File-private — only caller
+is `iterate_shift_eval0'` directly below. -/
+private lemma iterate_shift_eval' (k n : ℕ) (ω : Ω[α]) :
     (shift^[k] ω) n = ω (k + n) := by
   induction k generalizing n with
   | zero => simp
@@ -107,8 +108,9 @@ lemma iterate_shift_eval' (k n : ℕ) (ω : Ω[α]) :
       ac_rfl
 
 omit [MeasurableSpace α] [StandardBorelSpace α] in
-/-- Evaluate the k-th shift at 0: shift^[k] ω 0 = ω k. -/
-lemma iterate_shift_eval0' (k : ℕ) (ω : Ω[α]) :
+/-- Evaluate the k-th shift at 0: shift^[k] ω 0 = ω k. File-private — only
+in-file caller. -/
+private lemma iterate_shift_eval0' (k : ℕ) (ω : Ω[α]) :
     (shift^[k] ω) 0 = ω k := by
   rw [iterate_shift_eval']
   simp

--- a/Exchangeability/DeFinetti/ViaKoopman/InfraCore.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/InfraCore.lean
@@ -97,31 +97,11 @@ notation "Ωℤ[" α "]" => Ωℤ α
 /-- The two-sided shift on bi-infinite sequences. -/
 def shiftℤ (ω : Ωℤ[α]) : Ωℤ[α] := fun n => ω (n + 1)
 
-omit [MeasurableSpace α] in
-@[simp] lemma shiftℤ_apply (ω : Ωℤ[α]) (n : ℤ) :
-    shiftℤ (α := α) ω n = ω (n + 1) := rfl
-
 /-- The inverse shift on bi-infinite sequences. -/
 def shiftℤInv (ω : Ωℤ[α]) : Ωℤ[α] := fun n => ω (n - 1)
 
-omit [MeasurableSpace α] in
-@[simp] lemma shiftℤInv_apply (ω : Ωℤ[α]) (n : ℤ) :
-    shiftℤInv (α := α) ω n = ω (n - 1) := rfl
-
-omit [MeasurableSpace α] in
-@[simp] lemma shiftℤ_comp_shiftℤInv (ω : Ωℤ[α]) :
-    shiftℤ (α := α) (shiftℤInv (α := α) ω) = ω := by ext; simp [shiftℤ, shiftℤInv]
-
-omit [MeasurableSpace α] in
-@[simp] lemma shiftℤInv_comp_shiftℤ (ω : Ωℤ[α]) :
-    shiftℤInv (α := α) (shiftℤ (α := α) ω) = ω := by ext; simp [shiftℤ, shiftℤInv]
-
 /-- Restrict a bi-infinite path to its nonnegative coordinates. -/
 def restrictNonneg (ω : Ωℤ[α]) : Ω[α] := fun n => ω (Int.ofNat n)
-
-omit [MeasurableSpace α] in
-@[simp] lemma restrictNonneg_apply (ω : Ωℤ[α]) (n : ℕ) :
-    restrictNonneg (α := α) ω n = ω (Int.ofNat n) := rfl
 
 /-- Extend a one-sided path to the bi-infinite path space by duplicating the zeroth
 coordinate on the negative side. This is a convenient placeholder when we only need
@@ -130,14 +110,6 @@ def extendByZero (ω : Ω[α]) : Ωℤ[α] :=
   fun
   | Int.ofNat n => ω n
   | Int.negSucc _ => ω 0
-
-omit [MeasurableSpace α] in
-@[simp] lemma restrictNonneg_extendByZero (ω : Ω[α]) :
-    restrictNonneg (α := α) (extendByZero (α := α) ω) = ω := by ext; simp [extendByZero]
-
-omit [MeasurableSpace α] in
-@[simp] lemma extendByZero_apply_nat (ω : Ω[α]) (n : ℕ) :
-    extendByZero (α := α) ω ↑n = ω n := by simp [extendByZero]
 
 @[measurability, fun_prop]
 lemma measurable_shiftℤ : Measurable (shiftℤ (α := α)) := by

--- a/Exchangeability/Ergodic/ShiftInvariantRepresentatives.lean
+++ b/Exchangeability/Ergodic/ShiftInvariantRepresentatives.lean
@@ -143,7 +143,7 @@ private lemma gRep_ae_eq_of_constant_orbit {g0 : Ω[α] → ℝ}
   exact gRep_eq_of_constant_orbit (g0 := g0) hω
 
 
-lemma ae_shift_invariance_on_rep
+private lemma ae_shift_invariance_on_rep
     {μ : Measure (Ω[α])} [IsProbabilityMeasure μ]
     (hσ : MeasurePreserving shift μ μ)
     {f g : Ω[α] → ℝ}

--- a/Exchangeability/Util/ProductBounds.lean
+++ b/Exchangeability/Util/ProductBounds.lean
@@ -14,14 +14,14 @@ These are used in the contractability-based proof of de Finetti's theorem.
 
 ## Main results
 
-* `abs_prod_le_one`: |∏ f| ≤ 1 when all |f i| ≤ 1
 * `abs_prod_sub_prod_le`: |∏ f - ∏ g| ≤ ∑ |f_j - g_j| when factors bounded by 1
 -/
 
 namespace Exchangeability.Util
 
-/-- Helper: |∏ f| ≤ 1 when all |f i| ≤ 1. -/
-lemma abs_prod_le_one {n : ℕ} (f : Fin n → ℝ) (hf : ∀ i, |f i| ≤ 1) : |∏ i, f i| ≤ 1 := by
+/-- Helper: |∏ f| ≤ 1 when all |f i| ≤ 1. File-private — only caller is
+`abs_prod_sub_prod_le` directly below. -/
+private lemma abs_prod_le_one {n : ℕ} (f : Fin n → ℝ) (hf : ∀ i, |f i| ≤ 1) : |∏ i, f i| ≤ 1 := by
   rw [Finset.abs_prod]
   have h1 : ∏ i, |f i| ≤ ∏ _i : Fin n, (1 : ℝ) := by
     apply Finset.prod_le_prod


### PR DESCRIPTION
## Summary

Two-commit batch addressing the two leftover items from the reviewer thread:

**Commit 1 — privatization audit (4 lemmas, +10/−8):**

Wrote a small audit script that enumerates non-private `lemma`/`theorem` decls under `Exchangeability/`, excludes anything with a tactic-database attribute (`@[simp]`, `@[measurability]`, `@[fun_prop]`, `@[ext]`, `@[norm_cast]`, `@[push_cast]`, `@[mono]`, `@[aesop ...]`, `@[simps]`, `@[gcongr]`, `@[positivity]`, etc. — where grep can't see implicit use), and reports those with zero `git grep -lw` hits outside their owner file (including blueprint `.tex` and lean_decls).

The audit hit 25 candidates. I left 21 of them public — they're namespace methods on public types (`Contractable.*`, `Exchangeable.*`, `Integrable.of_abs_bounded`, `fixedSubspace_closed`, `iidProduct_isProjectiveLimit`, `preimage_injective_of_surjective`, etc.) that read like API even though nothing internal happens to call them today. The four genuine proof-step helpers were privatized:

| File | Lemma | Only caller |
|---|---|---|
| `ViaKoopman/CesaroL2ToL1.lean:99` | `iterate_shift_eval'` | `iterate_shift_eval0'` (next decl) |
| `ViaKoopman/CesaroL2ToL1.lean:111` | `iterate_shift_eval0'` | same-file L681 |
| `Ergodic/ShiftInvariantRepresentatives.lean:146` | `ae_shift_invariance_on_rep` | same-file L338 |
| `Util/ProductBounds.lean:24` | `abs_prod_le_one` | sibling `abs_prod_sub_prod_le` directly below |

The `Util/ProductBounds.lean` docstring "Main results" list was updated to drop the newly-private name.

**Commit 2 — InfraCore `@[simp]` probe (−28 lines):**

Following the "delete + build" probe pattern that PR #103 calibrated (since `@[simp]` lemmas can be implicitly load-bearing and grep won't see those uses), I bulk-removed seven `@[simp]` lemmas in `ViaKoopman/InfraCore.lean` that had zero named external references, then verified `lake build` still completes 3527/3527:

* `shiftℤ_apply`, `shiftℤInv_apply`, `restrictNonneg_apply` (the three `rfl` unfolding lemmas)
* `shiftℤ_comp_shiftℤInv`, `shiftℤInv_comp_shiftℤ` (round-trip)
* `restrictNonneg_extendByZero`, `extendByZero_apply_nat` (extend/restrict interaction)

The probe confirmed none was load-bearing at the simp level either.

**Combined diff:** 4 files, +10/−36 (net −26 lines).

## Test plan

- [x] `lake build` clean (3527/3527 jobs)
- [x] `#print axioms` on `deFinetti`, `deFinetti_viaL2`, `deFinetti_viaKoopman` — all `[propext, Classical.choice, Quot.sound]`
- [x] `lake exe checkdecls blueprint/lean_decls` passes
- [x] `python3 blueprint/check_blueprint.py` — 52 cites, 52 labels, 50 refs/uses, 52 lean_decls, all consistent
- [x] 0 sorries