### PR TITLE
feat(Contractable): generic map_single, replaces 2 Tail blocks + ℝ-specific wrapper (−50)

### DIFF
--- a/Exchangeability/Contractability.lean
+++ b/Exchangeability/Contractability.lean
@@ -314,6 +314,23 @@ lemma Contractable.shift_and_select {μ : Measure Ω} {X : ℕ → Ω → α}
       Measure.map (fun ω i => X i.val ω) μ :=
   hX m (fun i => offset + k i) (fun _ _ hij => Nat.add_lt_add_left (hk hij) offset)
 
+/-- **Marginal law equality.** For a contractable sequence, the law of any
+coordinate `X i` equals the law of `X 0`.
+
+Proof: instantiate the contractability axiom at the length-1 singleton
+subsequence `{i}`, then push forward by the evaluation map `g ↦ g 0`. -/
+lemma Contractable.map_single
+    {μ : Measure Ω} {X : ℕ → Ω → α}
+    (hX : Contractable μ X) (hX_meas : ∀ i, Measurable (X i)) (i : ℕ) :
+    Measure.map (X i) μ = Measure.map (X 0) μ := by
+  have hk : StrictMono (fun _ : Fin 1 => i) := fun a b hab => by
+    simp_all [Fin.eq_zero a, Fin.eq_zero b]
+  have h_map := hX 1 (fun _ => i) hk
+  have e := congrArg (Measure.map (fun g : Fin 1 → α => g 0)) h_map
+  rwa [Measure.map_map (measurable_pi_apply 0) (by fun_prop : Measurable fun ω _ => X i ω),
+       Measure.map_map (measurable_pi_apply 0)
+         (by fun_prop : Measurable fun ω (j : Fin 1) => X j.val ω)] at e
+
 /--
 Helper lemma: All values of a strictly monotone function are bounded by its last value plus one.
 

--- a/Exchangeability/DeFinetti/L2Helpers.lean
+++ b/Exchangeability/DeFinetti/L2Helpers.lean
@@ -73,34 +73,8 @@ This follows from contractability by taking the singleton subsequence `{i}`.
 
 This is used to establish uniform covariance structure across all pairs of coordinates. -/
 lemma contractable_map_single (hX_contract : Contractable μ X) (hX_meas : ∀ i, Measurable (X i)) {i : ℕ} :
-    Measure.map (fun ω => X i ω) μ = Measure.map (fun ω => X 0 ω) μ := by
-  classical
-  -- `k` selects the singleton subsequence `{i}`.
-  let k : Fin 1 → ℕ := fun _ => i
-  have hk : StrictMono k := by
-    intro a b hab
-    simp_all [Fin.eq_zero a, Fin.eq_zero b]
-  have h_map := hX_contract 1 k hk
-  let eval : (Fin 1 → ℝ) → ℝ := fun g => g fin1Zero
-  have h_eval_meas : Measurable eval := measurable_eval_fin1
-  have h_meas_k : Measurable fun ω => fun j : Fin 1 => X (k j) ω := by
-    fun_prop
-  have h_meas_std : Measurable fun ω => fun j : Fin 1 => X j.val ω := by
-    fun_prop
-  have h_left := (Measure.map_map h_eval_meas h_meas_k (μ := μ)).symm
-  have h_right := Measure.map_map h_eval_meas h_meas_std (μ := μ)
-  have h_eval := congrArg (Measure.map eval) h_map
-  have h_comp := h_left.trans (h_eval.trans h_right)
-  -- Evaluate the compositions explicitly.
-  have h_comp_simp :
-      (fun ω => eval (fun j : Fin 1 => X (k j) ω)) = fun ω => X i ω := by
-    funext ω
-    simp [eval, k, fin1Zero]
-  have h_comp_simp' :
-      (fun ω => eval (fun j : Fin 1 => X j.val ω)) = fun ω => X 0 ω := by
-    funext ω
-    simp [eval, fin1Zero]
-  simpa [Function.comp, h_comp_simp, h_comp_simp'] using h_comp
+    Measure.map (fun ω => X i ω) μ = Measure.map (fun ω => X 0 ω) μ :=
+  Exchangeability.Contractable.map_single hX_contract hX_meas i
 
 /-- **Strict monotonicity for two-point subsequence selection.**
 

--- a/Exchangeability/Tail/CondExpShiftInvariance.lean
+++ b/Exchangeability/Tail/CondExpShiftInvariance.lean
@@ -77,30 +77,8 @@ lemma condExp_shift_eq_condExp
     -- Integrability of f ∘ X (n+1)
     have hf_int_n : Integrable (f ∘ X (n + 1)) μ := by
       -- By contractability, X (n+1) has the same distribution as X 0
-      have h_shift := Exchangeability.Contractable.shift_segment_eq hX_contract 1 (n + 1)
-      have h_meas_comp : Measurable (f ∘ X (n + 1)) := hf_meas.comp (hX_meas (n + 1))
-      -- The distributions are equal
-      have h_map_eq : Measure.map (X (n + 1)) μ = Measure.map (X 0) μ := by
-        have h1 := Exchangeability.Contractable.shift_segment_eq hX_contract 1 (n + 1)
-        ext s hs
-        let S : Set (Fin 1 → α) := {f | f 0 ∈ s}
-        have hS : MeasurableSet S := measurable_pi_apply 0 hs
-        have h_preimage_n1 : X (n + 1) ⁻¹' s = (fun ω (i : Fin 1) => X ((n + 1) + i.val) ω) ⁻¹' S := by
-          ext ω
-          simp only [Set.mem_preimage, Set.mem_setOf_eq, S, Fin.val_zero, add_zero]
-        have h_preimage_0 : X 0 ⁻¹' s = (fun ω (i : Fin 1) => X i.val ω) ⁻¹' S := by
-          ext ω
-          simp only [Set.mem_preimage, Set.mem_setOf_eq, S, Fin.val_zero]
-        have h_meas_n1 : Measurable (fun ω (i : Fin 1) => X ((n + 1) + i.val) ω) := by
-          fun_prop
-        have h_meas_0 : Measurable (fun ω (i : Fin 1) => X i.val ω) := by
-          fun_prop
-        rw [Measure.map_apply (hX_meas (n + 1)) hs, Measure.map_apply (hX_meas 0) hs]
-        rw [h_preimage_n1, h_preimage_0]
-        have h_eq := congrFun (congrArg (·.toOuterMeasure) h1) S
-        simp only [Measure.coe_toOuterMeasure] at h_eq
-        rw [Measure.map_apply h_meas_n1 hS, Measure.map_apply h_meas_0 hS] at h_eq
-        exact h_eq
+      have h_map_eq : Measure.map (X (n + 1)) μ = Measure.map (X 0) μ :=
+        Exchangeability.Contractable.map_single hX_contract hX_meas (n + 1)
       have hf_aesm_0 : AEStronglyMeasurable f (Measure.map (X 0) μ) :=
         hf_meas.aestronglyMeasurable
       have h_int_map : Integrable f (Measure.map (X 0) μ) :=

--- a/Exchangeability/Tail/ShiftInvariantMeasure.lean
+++ b/Exchangeability/Tail/ShiftInvariantMeasure.lean
@@ -154,27 +154,8 @@ lemma setIntegral_comp_shift_eq
     have h_shift := tailSigma_shift_invariant_for_contractable X hX_contract hX_meas
 
     -- X_{k+1} and X_0 have the same distribution (from contractability)
-    have hX_k1_eq_X0 : Measure.map (X (k + 1)) μ = Measure.map (X 0) μ := by
-      have h1 := Exchangeability.Contractable.shift_segment_eq hX_contract 1 (k + 1)
-      ext s hs
-      let S : Set (Fin 1 → α) := {g | g 0 ∈ s}
-      have hS : MeasurableSet S := measurable_pi_apply 0 hs
-      have h_meas_k1 : Measurable (fun ω (i : Fin 1) => X ((k + 1) + i.val) ω) := by
-        fun_prop
-      have h_meas_0 : Measurable (fun ω (i : Fin 1) => X i.val ω) := by
-        fun_prop
-      rw [Measure.map_apply (hX_meas (k + 1)) hs, Measure.map_apply (hX_meas 0) hs]
-      have h_pre_k1 : X (k + 1) ⁻¹' s = (fun ω (i : Fin 1) => X ((k + 1) + i.val) ω) ⁻¹' S := by
-        ext ω
-        simp only [Set.mem_preimage, Set.mem_setOf_eq, S, Fin.val_zero, add_zero]
-      have h_pre_0 : X 0 ⁻¹' s = (fun ω (i : Fin 1) => X i.val ω) ⁻¹' S := by
-        ext ω
-        simp only [Set.mem_preimage, Set.mem_setOf_eq, S, Fin.val_zero]
-      rw [h_pre_k1, h_pre_0]
-      have h_eq := congrFun (congrArg (·.toOuterMeasure) h1) S
-      simp only [Measure.coe_toOuterMeasure] at h_eq
-      rw [Measure.map_apply h_meas_k1 hS, Measure.map_apply h_meas_0 hS] at h_eq
-      exact h_eq
+    have hX_k1_eq_X0 : Measure.map (X (k + 1)) μ = Measure.map (X 0) μ :=
+      Exchangeability.Contractable.map_single hX_contract hX_meas (k + 1)
 
     -- Integrability transfer
     have hf_int_k1 : Integrable (f ∘ X (k + 1)) μ := by


### PR DESCRIPTION
## Summary

Add a generic `Contractable.map_single` lemma in `Contractability.lean` and use it to remove duplicated singleton-map proof structure in the Tail/ files and shrink the ℝ-specific wrapper in `DeFinetti.L2Helpers`.

**The duplication being removed:** the Tail/ files manually rebuilt the same ~20-line argument in two places (deriving `Measure.map (X i) μ = Measure.map (X 0) μ` from contractability via the `Fin 1` trick), while `DeFinetti.L2Helpers` carried an ℝ-typed version of essentially the same fact.

**Changes:**

1. **`Contractability.lean`**: new lemma `Contractable.map_single` next to the existing `shift_segment_eq` / `shift_and_select`. Generic over `α : Type*` with `[MeasurableSpace α]`:
   ```lean
   lemma Contractable.map_single
       {μ : Measure Ω} {X : ℕ → Ω → α}
       (hX : Contractable μ X) (hX_meas : ∀ i, Measurable (X i)) (i : ℕ) :
       Measure.map (X i) μ = Measure.map (X 0) μ
   ```
   Proof: feed the singleton subsequence `fun _ : Fin 1 => i` into the contractability axiom and push forward by `g ↦ g 0`.

2. **`Tail/CondExpShiftInvariance.lean`**: the 20-line `h_map_eq` `ext`/`Measure.map_apply`/`congrFun (congrArg ...)` block collapses to one line:
   ```lean
   have h_map_eq : Measure.map (X (n + 1)) μ = Measure.map (X 0) μ :=
     Exchangeability.Contractable.map_single hX_contract hX_meas (n + 1)
   ```

3. **`Tail/ShiftInvariantMeasure.lean`**: the parallel `hX_k1_eq_X0` block collapses identically.

4. **`DeFinetti/L2Helpers.lean`**: `contractable_map_single` becomes a one-line wrapper around the new generic version. Kept (rather than deleted) so existing ℝ-specific callsites that use the `fun ω => X i ω` signature continue to work without churn.

**Net:** 4 files, +23 / −73 (−50 lines).

## Test plan

- [x] `lake build` clean (3527/3527 jobs)
- [x] `#print axioms` on `deFinetti`, `deFinetti_viaL2`, `deFinetti_viaKoopman` — all `[propext, Classical.choice, Quot.sound]`
- [x] `lake exe checkdecls blueprint/lean_decls` passes
- [x] `python3 blueprint/check_blueprint.py` — 52 cites, 52 labels, 50 refs/uses, 52 lean_decls, all consistent
- [x] 0 sorries