### PR TITLE
chore: mechanical golf batch — rfl/simpa one-liners across 7 files (−28)

### DIFF
--- a/Exchangeability/Bridge/CesaroToCondExp.lean
+++ b/Exchangeability/Bridge/CesaroToCondExp.lean
@@ -116,23 +116,15 @@ lemma contractable_shift_invariant_law {Ω : Type*} [MeasurableSpace Ω]
   let k : Fin n → ℕ := fun i => i.val + 1
   have hk_strictMono : StrictMono k := fun i j hij => Nat.add_lt_add_right hij 1
 
-  -- Show both maps equal the standard forms
-  -- Note: goal has (prefixProj ∘ shift) ∘ pathify X, so match that form
+  -- Show both maps equal the standard forms; both equalities hold definitionally.
   have h_lhs : ((Exchangeability.prefixProj ℝ n ∘ shift) ∘ pathify X)
-      = (fun ω i => X (k i) ω) := by
-    funext ω i
-    simp only [Function.comp_apply, Exchangeability.prefixProj, shift_apply, pathify, k]
-
+      = (fun ω i => X (k i) ω) := rfl
   have h_rhs : (Exchangeability.prefixProj ℝ n ∘ pathify X)
-      = (fun ω i => X i.val ω) := by
-    funext ω i
-    simp only [Function.comp_apply, Exchangeability.prefixProj, pathify]
+      = (fun ω i => X i.val ω) := rfl
 
-  rw [h_lhs, h_rhs]
-
-  -- Apply contractability: k is strictly monotone, so distributions match
-  -- hX n k hk_strictMono : Measure.map (fun ω i => X (k i) ω) μ = Measure.map (fun ω i => X i.val ω) μ
-  rw [hX n k hk_strictMono]
+  -- Apply contractability: hX n k hk_strictMono equates the two pushforward measures,
+  -- so applying both sides at S gives the desired equality of measures on S.
+  simpa [h_lhs, h_rhs] using congrArg (fun ν => ν S) (hX n k hk_strictMono)
 
 /-- **Bridge 1'.** Package the previous lemma as `MeasurePreserving` for MET. -/
 lemma measurePreserving_shift_path {Ω : Type*} [MeasurableSpace Ω]

--- a/Exchangeability/Contractability.lean
+++ b/Exchangeability/Contractability.lean
@@ -426,9 +426,7 @@ theorem contractable_of_exchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
         simpa [ι] using hσ i
       simp [proj, Function.comp_apply, hσi]
 
-    have hrhs_eq : (proj ∘ fun ω j => X j.val ω) = (fun ω i => X i.val ω) := by
-      ext ω i
-      simp [proj, Function.comp_apply, ι]
+    have hrhs_eq : (proj ∘ fun ω j => X j.val ω) = (fun ω i => X i.val ω) := rfl
 
     rwa [hlhs_eq, hrhs_eq] at hproj_eq
 

--- a/Exchangeability/DeFinetti/BridgeProperty.lean
+++ b/Exchangeability/DeFinetti/BridgeProperty.lean
@@ -78,7 +78,7 @@ lemma measure_eq_implies_lintegral_prod_eq
 
   -- Preimage characterization
   have hpre : (fun ω => fun i : Fin m => X (k i) ω) ⁻¹' S = ⋂ i : Fin m, (X (k i)) ⁻¹' (B i) := by
-    ext ω; simp only [S, mem_preimage, mem_pi, mem_univ, true_implies, mem_iInter]
+    ext ω; simp [S]
 
   -- Measurability of preimage
   have hpre_meas : MeasurableSet (⋂ i : Fin m, (X (k i)) ⁻¹' (B i)) :=
@@ -89,8 +89,8 @@ lemma measure_eq_implies_lintegral_prod_eq
     measurability
 
   -- Characterization: ω in preimage ↔ ∀ i, X (k i) ω ∈ B i
-  have hpre_mem : ∀ ω, ω ∈ ⋂ i : Fin m, (X (k i)) ⁻¹' (B i) ↔ ∀ i, X (k i) ω ∈ B i := by
-    intro ω; simp only [mem_iInter, mem_preimage]
+  have hpre_mem : ∀ ω, ω ∈ ⋂ i : Fin m, (X (k i)) ⁻¹' (B i) ↔ ∀ i, X (k i) ω ∈ B i :=
+    fun ω => by simp [Set.mem_iInter, Set.mem_preimage]
 
   -- LHS: Compute map measure on the rectangle S
   have hL : (Measure.map (fun ω => fun i : Fin m => X (k i) ω) μ) S

--- a/Exchangeability/DeFinetti/ViaKoopman.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman.lean
@@ -176,9 +176,7 @@ lemma pathSpace_shift_preserving_of_contractable
         fun_prop
     rw [Measure.map_map shift_measurable hφ_meas]
     -- shift ∘ φ = (fun ω i => X (i+1) ω)
-    have h_comp : shift ∘ (fun ω' i => X i ω') = fun ω' i => X (i + 1) ω' := by
-      ext ω i
-      simp [shift]
+    have h_comp : shift ∘ (fun ω' i => X i ω') = fun ω' i => X (i + 1) ω' := rfl
     rw [h_comp]
     -- Apply the helper lemma
     exact measure_map_shift_eq_of_contractable X hX_meas hContract

--- a/Exchangeability/DeFinetti/ViaL2/MoreL2Helpers.lean
+++ b/Exchangeability/DeFinetti/ViaL2/MoreL2Helpers.lean
@@ -261,9 +261,7 @@ lemma directing_measure_bridge
         ⟨1, fun x => by simp only [Set.indicator]; split_ifs <;> norm_num⟩
       have h_integral : ∀ ω, ∫ x, Set.indicator B (fun _ => (1 : ℝ)) x ∂(ν ω) = (ν ω B).toReal := by
         intro ω
-        have h1 : Set.indicator B (fun _ => (1 : ℝ)) = B.indicator 1 := by
-          ext x; simp only [Set.indicator, Pi.one_apply]
-        rw [h1, integral_indicator_one hB]; rfl
+        simpa using integral_indicator_one hB
       filter_upwards [h_eq] with ω hω; rw [← h_integral ω, hω]; rfl
     -- Shift invariance: E[1_B ∘ X n | tail] =ᵐ E[1_B ∘ X 0 | tail]
     have h_shift : μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ (X n) | Exchangeability.Tail.tailProcess X] =ᵐ[μ]

--- a/Exchangeability/Probability/SigmaAlgebraHelpers.lean
+++ b/Exchangeability/Probability/SigmaAlgebraHelpers.lean
@@ -84,10 +84,8 @@ lemma aestronglyMeasurable_iInf_antitone
     rw [h_shift]
     -- Now show liminf of g (n + N) is Measurable[m N]
     -- Each g (n + N) is Measurable[m (n + N)], and m (n + N) ≤ m N by antitonicity
-    have hg_meas_shifted : ∀ n, @Measurable α ℝ (m N) _ (g (n + N)) := by
-      intro n
-      have h_le_N : m (n + N) ≤ m N := h_anti (Nat.le_add_left N n)
-      exact Measurable.mono (hg_meas (n + N)) h_le_N le_rfl
+    have hg_meas_shifted : ∀ n, @Measurable α ℝ (m N) _ (g (n + N)) :=
+      fun n => (hg_meas (n + N)).mono (h_anti (Nat.le_add_left N n)) le_rfl
     haveI : MeasurableSpace α := m N
     exact Measurable.liminf hg_meas_shifted
 
@@ -100,17 +98,10 @@ lemma aestronglyMeasurable_iInf_antitone
   -- Step 4: Show f =ᵐ h
   -- On the set where f = g N for all N, we have h = f
   have h_ae_eq : f =ᵐ[μ] h := by
-    -- Countable intersection of full-measure sets is full-measure
-    have h_all_eq : ∀ᵐ x ∂μ, ∀ N, f x = g N x := by
-      rw [MeasureTheory.ae_all_iff]
-      intro N
-      exact hg_ae N
+    have h_all_eq : ∀ᵐ x ∂μ, ∀ N, f x = g N x := MeasureTheory.ae_all_iff.mpr hg_ae
     filter_upwards [h_all_eq] with x hx
     -- At x, f x = g N x for all N, so liminf (g N x) = f x
-    simp only [h]
-    have h_const : ∀ N, g N x = f x := fun N => (hx N).symm
-    simp_rw [h_const]
-    exact (Filter.liminf_const (f x)).symm
+    simp [h, fun N => (hx N).symm, Filter.liminf_const]
 
   -- Step 5: Convert Measurable to StronglyMeasurable (for ℝ)
   have h_sm : @MeasureTheory.StronglyMeasurable α ℝ _ (⨅ N, m N) h := by

--- a/Exchangeability/Util/ProductBounds.lean
+++ b/Exchangeability/Util/ProductBounds.lean
@@ -22,13 +22,8 @@ namespace Exchangeability.Util
 /-- Helper: |∏ f| ≤ 1 when all |f i| ≤ 1. File-private — only caller is
 `abs_prod_sub_prod_le` directly below. -/
 private lemma abs_prod_le_one {n : ℕ} (f : Fin n → ℝ) (hf : ∀ i, |f i| ≤ 1) : |∏ i, f i| ≤ 1 := by
-  rw [Finset.abs_prod]
-  have h1 : ∏ i, |f i| ≤ ∏ _i : Fin n, (1 : ℝ) := by
-    apply Finset.prod_le_prod
-    · intro i _; exact abs_nonneg _
-    · intro i _; exact hf i
-  simp at h1
-  exact h1
+  simpa [Finset.abs_prod] using
+    Finset.prod_le_prod (fun i _ => abs_nonneg (f i)) (fun i _ => hf i)
 
 /-- Telescoping bound: |∏ f - ∏ g| ≤ ∑ |f_j - g_j| when factors are bounded by 1.
 


### PR DESCRIPTION
## Summary

Seven LSP-pre-verified mechanical reductions, follow-up to the `Contractable.map_single` abstraction in #114. Each site collapses a multi-line `funext`/`simp only`/`have`/`exact` block to a single `rfl`, `simpa using`, or term-mode application.

| File | Site | Reduction |
|---|---|---|
| `Bridge/CesaroToCondExp.lean` | `h_lhs`/`h_rhs` + final two `rw`s | both `have`s → `rfl`; final `rw`/`rw` → single `simpa [h_lhs, h_rhs] using congrArg (fun ν => ν S) (hX n k hk_strictMono)` |
| `Contractability.lean` | `hrhs_eq` in `Contractable.allStrictMono_eq` | `ext ω i; simp [proj, Function.comp_apply, ι]` → `rfl` |
| `DeFinetti/BridgeProperty.lean` | `hpre` + `hpre_mem` | `simp only [...]` trimmed to `simp [S]`; `hpre_mem` becomes term-mode `fun ω => by simp [...]` |
| `DeFinetti/ViaKoopman.lean` | `h_comp : shift ∘ ... = ...` | `ext ω i; simp [shift]` → `rfl` (`shift` is `def`, unfolds definitionally) |
| `DeFinetti/ViaL2/MoreL2Helpers.lean` | `h_integral` | 4-line `Set.indicator`/`Pi.one_apply` rewrite to `B.indicator 1` + `integral_indicator_one hB; rfl` → `intro ω; simpa using integral_indicator_one hB` |
| `Probability/SigmaAlgebraHelpers.lean` | three sites | `hg_meas_shifted` → 1-line term-mode; `h_all_eq` → `MeasureTheory.ae_all_iff.mpr hg_ae`; trailing 4-line filter_upwards block → single `simp [h, fun N => (hx N).symm, Filter.liminf_const]` |
| `Util/ProductBounds.lean` | `abs_prod_le_one` | 7-line `rw`/`Finset.prod_le_prod`/`simp at h1`/`exact h1` → 2-line `simpa [Finset.abs_prod] using Finset.prod_le_prod ...` |

**Net:** 7 files, +18 / −46 (−28 lines).

## Test plan

- [x] `lake build` clean (3527/3527 jobs)
- [x] `#print axioms` on `deFinetti`, `deFinetti_viaL2`, `deFinetti_viaKoopman` — all `[propext, Classical.choice, Quot.sound]`
- [x] `lake exe checkdecls blueprint/lean_decls` passes
- [x] `python3 blueprint/check_blueprint.py` — 52 cites, 52 labels, 50 refs/uses, 52 lean_decls, all consistent
- [x] 0 sorries