### PR TITLE
chore: 5 small golf candidates in Probability/MeasureKernels + TimeReversalCrossing (−7)

### DIFF
--- a/Exchangeability/Probability/MeasureKernels.lean
+++ b/Exchangeability/Probability/MeasureKernels.lean
@@ -208,10 +208,6 @@ lemma aemeasurable_measure_pi {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSp
     {μ : Measure Ω} {m : ℕ}
     (ν : Ω → Measure α) (hν_prob : ∀ ω, IsProbabilityMeasure (ν ω))
     (hν_meas : ∀ s, MeasurableSet s → Measurable (fun ω => ν ω s)) :
-    AEMeasurable (fun ω => Measure.pi fun _ : Fin m => ν ω) μ := by
-  -- The measurable version immediately implies AE-measurability
-  have h_meas : Measurable fun ω => Measure.pi fun _ : Fin m => ν ω := by
-    apply measurable_measure_pi ν hν_prob
-    exact hν_meas
-  exact h_meas.aemeasurable
+    AEMeasurable (fun ω => Measure.pi fun _ : Fin m => ν ω) μ :=
+  (measurable_measure_pi ν hν_prob hν_meas).aemeasurable
 

--- a/Exchangeability/Probability/TimeReversalCrossing.lean
+++ b/Exchangeability/Probability/TimeReversalCrossing.lean
@@ -145,9 +145,8 @@ private lemma timeReversal_crossing_bound_strong
       exact this
 
     have hX_τ_le_a : X τ ω ≤ a := by
-      have := stoppedValue_lowerCrossingTime (f := X) (n := j - 1) h_neq_τ
-      simp only [stoppedValue] at this
-      exact this
+      simpa [stoppedValue] using
+        stoppedValue_lowerCrossingTime (f := X) (n := j - 1) h_neq_τ
 
     -- Y's level conditions at bijected times
     have hY_Nσ_le_negb : Y (N - σ) ω ≤ -b := by
@@ -160,8 +159,7 @@ private lemma timeReversal_crossing_bound_strong
 
     -- lowerCrossingTime X j ≥ σ (hitting starts from σ)
     have h_lct_ge : lowerCrossingTime a b X N j ω ≥ σ := by
-      simp only [lowerCrossingTime, hσ_def]
-      exact le_hittingBtwn (Nat.le_of_lt hσ_lt_N) ω
+      simpa [lowerCrossingTime, hσ_def] using le_hittingBtwn (Nat.le_of_lt hσ_lt_N) ω
 
     -- From IH: upperCrossingTime Y m' ≤ N - lowerCrossingTime X j ≤ N - σ
     have h_uct_le_Nσ : upperCrossingTime (-b) (-a) Y (N+1) m' ω ≤ N - σ := by
@@ -174,8 +172,8 @@ private lemma timeReversal_crossing_bound_strong
     have hY_Nσ_in_Iic : Y (N - σ) ω ∈ Set.Iic (-b) := hY_Nσ_le_negb
 
     have h_lctY_le_Nσ : lowerCrossingTime (-b) (-a) Y (N+1) m' ω ≤ N - σ := by
-      simp only [lowerCrossingTime]
-      exact hittingBtwn_le_of_mem h_uct_le_Nσ h_Nσ_le_N1 hY_Nσ_in_Iic
+      simpa [lowerCrossingTime] using
+        hittingBtwn_le_of_mem h_uct_le_Nσ h_Nσ_le_N1 hY_Nσ_in_Iic
 
     -- N - σ < N - τ and lowerCrossingTime Y m' < N - τ
     have hNσ_lt_Nτ : N - σ < N - τ := Nat.sub_lt_sub_left hτ_lt_N hτ_lt_σ
@@ -204,6 +202,5 @@ lemma timeReversal_crossing_bound
     {Ω : Type*} (X : ℕ → Ω → ℝ) (a b : ℝ) (hab : a < b) (N k : ℕ) (ω : Ω)
     (h_k : upperCrossingTime a b X N k ω < N) :
     upperCrossingTime (-b) (-a) (negProcess (revProcess X N)) (N+1) k ω ≤ N := by
-  have h := timeReversal_crossing_bound_strong X a b hab N k k ω (le_refl k) h_k
-  simp only [Nat.sub_self] at h
-  exact le_trans h (Nat.sub_le N _)
+  have h := timeReversal_crossing_bound_strong X a b hab N k k ω le_rfl h_k
+  exact le_trans (by simpa using h) (Nat.sub_le N _)


### PR DESCRIPTION
## Summary

Manually probed the autoGolf-unreached `Probability/Martingale/*` and `Probability/MeasureKernels.lean` files for residual proof-body golf. Most are too small or too tight to benefit (re-export shims or already terse proofs); two had a handful of clean simpa-or-inline collapses.

**`Probability/MeasureKernels.lean`** (1 site)
- `aemeasurable_measure_pi`: 5-line `have h_meas := by apply ...; exact ...; exact h_meas.aemeasurable` body → term-mode `(measurable_measure_pi ν hν_prob hν_meas).aemeasurable`.

**`Probability/TimeReversalCrossing.lean`** (4 sites)
- `hX_τ_le_a`: `have := …; simp only [stoppedValue] at this; exact this` → `simpa [stoppedValue] using stoppedValue_lowerCrossingTime …`.
- `h_lct_ge`: `simp only [lowerCrossingTime, hσ_def]; exact le_hittingBtwn …` → `simpa [lowerCrossingTime, hσ_def] using le_hittingBtwn …`.
- `h_lctY_le_Nσ`: same shape collapse via `simpa [lowerCrossingTime] using hittingBtwn_le_of_mem …`.
- `timeReversal_crossing_bound` final: `have h := … (le_refl k) …; simp only [Nat.sub_self] at h; exact le_trans h …` → `have h := … le_rfl …; exact le_trans (by simpa using h) …`.

**Net:** 2 files, +9 / −16 (−7 lines).

Small batch — most of the autoGolf-unreached files were already at a state where there's no obvious mechanical golf left to do.

## Test plan

- [x] `lake build` clean (3527/3527 jobs)
- [x] `#print axioms` on `deFinetti`, `deFinetti_viaL2`, `deFinetti_viaKoopman` — all `[propext, Classical.choice, Quot.sound]`
- [x] `lake exe checkdecls blueprint/lean_decls` passes
- [x] `python3 blueprint/check_blueprint.py` — 52 cites, 52 labels, 50 refs/uses, 52 lean_decls, all consistent
- [x] 0 sorries