### PR TITLE
chore: mechanical golf batch — term-mode collapses + linter-suppression removal (−8)

### DIFF
--- a/Exchangeability/DeFinetti/L2Helpers.lean
+++ b/Exchangeability/DeFinetti/L2Helpers.lean
@@ -157,8 +157,8 @@ lemma eLpNorm_two_from_integral_sq_le
   (h : ∫ ω, (g ω)^2 ∂μ ≤ C) :
   eLpNorm g 2 μ ≤ ENNReal.ofReal (Real.sqrt C) := by
   -- For real-valued g, use ‖g‖ = |g| and sq_abs
-  have h_sq_eq : ∀ ω, ‖g ω‖^2 = (g ω)^2 := by
-    intro ω; rw [Real.norm_eq_abs, sq_abs]
+  have h_sq_eq : ∀ ω, ‖g ω‖^2 = (g ω)^2 :=
+    fun _ => by rw [Real.norm_eq_abs, sq_abs]
   -- Get integral bound in terms of ‖g‖^2
   have h_int_le : ∫ ω, ‖g ω‖^2 ∂μ ≤ C := by
     have : (fun ω => ‖g ω‖^2) = fun ω => (g ω)^2 := funext h_sq_eq

--- a/Exchangeability/DeFinetti/MartingaleHelpers.lean
+++ b/Exchangeability/DeFinetti/MartingaleHelpers.lean
@@ -74,9 +74,7 @@ lemma strictMono_fin_cases
   | succ i =>
     cases j using Fin.cases with
     | zero =>
-      have : (Fin.succ i : Fin (n + 1)).1 < 0 := by
-        set_option linter.unnecessarySimpa false in
-        simpa [Fin.lt_def] using hij
+      have : (Fin.succ i : Fin (n + 1)).1 < 0 := Fin.lt_def.mp hij
       exact absurd this (Nat.not_lt.mpr (Nat.zero_le _))
     | succ j =>
       have hij' : i < j := (Fin.succ_lt_succ_iff).1 hij

--- a/Exchangeability/DeFinetti/ViaKoopman/CesaroL1Bounded.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/CesaroL1Bounded.lean
@@ -262,9 +262,7 @@ lemma L1_cesaro_convergence
       have h_each_int : ∀ j ∈ Finset.range (n + 1), Integrable (fun ω => g (ω j)) μ := by
         intro j _
         have h_eq : (fun ω => g (ω j)) = (fun ω => g ((shift^[j] ω) 0)) := by
-          funext ω
-          congr 1
-          exact (shift_iterate_apply_zero j ω).symm
+          simp [shift_iterate_apply_zero]
         rw [h_eq]
         have h_shiftj_pres : MeasurePreserving (shift^[j]) μ μ := hσ.iterate j
         exact h_shiftj_pres.integrable_comp_of_integrable hg_int
@@ -319,7 +317,7 @@ lemma L1_cesaro_convergence
                     refine integrable_finset_sum _ (fun j _ => ?_)
                     have h_int_gj : Integrable (fun ω => g (ω j)) μ := by
                       have h_eq : (fun ω => g (ω j)) = (fun ω => g ((shift^[j] ω) 0)) := by
-                        funext ω; congr 1; exact (shift_iterate_apply_zero j ω).symm
+                        simp [shift_iterate_apply_zero]
                       rw [h_eq]
                       exact (hσ.iterate j).integrable_comp_of_integrable hg_int
                     have h_int_gMj : Integrable (fun ω => g_M M₀ (ω j)) μ := by
@@ -337,7 +335,7 @@ lemma L1_cesaro_convergence
                 intro j _
                 have h_int_gj : Integrable (fun ω => g (ω j)) μ := by
                   have h_eq : (fun ω => g (ω j)) = (fun ω => g ((shift^[j] ω) 0)) := by
-                    funext ω; congr 1; exact (shift_iterate_apply_zero j ω).symm
+                    simp [shift_iterate_apply_zero]
                   rw [h_eq]
                   exact (hσ.iterate j).integrable_comp_of_integrable hg_int
                 have h_int_gMj : Integrable (fun ω => g_M M₀ (ω j)) μ := by

--- a/Exchangeability/DeFinetti/ViaL2/MoreL2Helpers.lean
+++ b/Exchangeability/DeFinetti/ViaL2/MoreL2Helpers.lean
@@ -259,9 +259,8 @@ lemma directing_measure_bridge
       have h_eq := directing_measure_integral_eq_condExp X hX_contract hX_meas hX_L2
         (Set.indicator B (fun _ => (1 : ℝ))) hf_meas
         ⟨1, fun x => by simp only [Set.indicator]; split_ifs <;> norm_num⟩
-      have h_integral : ∀ ω, ∫ x, Set.indicator B (fun _ => (1 : ℝ)) x ∂(ν ω) = (ν ω B).toReal := by
-        intro ω
-        simpa using integral_indicator_one hB
+      have h_integral : ∀ ω, ∫ x, Set.indicator B (fun _ => (1 : ℝ)) x ∂(ν ω) = (ν ω B).toReal :=
+        fun _ => by simpa using integral_indicator_one hB
       filter_upwards [h_eq] with ω hω; rw [← h_integral ω, hω]; rfl
     -- Shift invariance: E[1_B ∘ X n | tail] =ᵐ E[1_B ∘ X 0 | tail]
     have h_shift : μ[Set.indicator B (fun _ => (1 : ℝ)) ∘ (X n) | Exchangeability.Tail.tailProcess X] =ᵐ[μ]

--- a/Exchangeability/Probability/LpNormHelpers.lean
+++ b/Exchangeability/Probability/LpNormHelpers.lean
@@ -60,9 +60,8 @@ lemma eLpNorm_two_sq_eq_integral_sq
   -- 3. Convert lintegral to integral: ∫⁻ ‖f‖² = ↑(∫ |f|²) = ↑(∫ f²)
 
   -- For real functions, ‖f‖² = |f|² = f²
-  have h_norm_eq : ∀ ω, ‖f ω‖ ^ 2 = (f ω) ^ 2 := by
-    intro ω
-    rw [Real.norm_eq_abs, sq_abs]
+  have h_norm_eq : ∀ ω, ‖f ω‖ ^ 2 = (f ω) ^ 2 :=
+    fun _ => by rw [Real.norm_eq_abs, sq_abs]
 
   -- Use the fundamental relationship for p = 2
   -- eLpNorm f p μ ^ p = ∫⁻ ‖f‖^p when p ≠ 0, ∞

--- a/Exchangeability/Probability/SigmaAlgebraHelpers.lean
+++ b/Exchangeability/Probability/SigmaAlgebraHelpers.lean
@@ -133,9 +133,7 @@ lemma aestronglyMeasurable_sub_of_tendsto_ae
     haveI : MeasurableSpace α := m
     exact Measurable.limsup hf_meas
   -- h = g a.e. because on the convergence set, limsup = lim = g
-  have h_ae_eq : h =ᵐ[μ] g := by
-    filter_upwards [hlim] with x hx
-    exact Filter.Tendsto.limsup_eq hx
+  have h_ae_eq : h =ᵐ[μ] g := hlim.mono fun _ hx => Filter.Tendsto.limsup_eq hx
   -- Convert Measurable[m] h to StronglyMeasurable[m] h (for ℝ)
   have h_sm : @MeasureTheory.StronglyMeasurable α ℝ _ m h := by
     haveI : MeasurableSpace α := m


### PR DESCRIPTION
## Summary

Five LSP-pre-verified mechanical reductions, follow-up to the generic-`Contractable` PR #118.

| File | Site | Change |
|---|---|---|
| `MoreL2Helpers.lean` | `h_integral` | `by intro ω; simpa using …` → term-mode `fun _ => by simpa using integral_indicator_one hB` |
| `MartingaleHelpers.lean` | inner `Fin.succ … < 0` | drop the `set_option linter.unnecessarySimpa false` workaround; close with the direct `Fin.lt_def.mp hij` (no `simpa` needed) |
| `ViaKoopman/CesaroL1Bounded.lean` | 3 sites | each `funext ω; congr 1; exact (shift_iterate_apply_zero j ω).symm` block collapses to one-line `simp [shift_iterate_apply_zero]` |
| `SigmaAlgebraHelpers.lean` | `h_ae_eq` | `filter_upwards [hlim] with x hx; exact Filter.Tendsto.limsup_eq hx` → term-mode `hlim.mono fun _ hx => Filter.Tendsto.limsup_eq hx` |
| `L2Helpers.lean` + `LpNormHelpers.lean` | `∀ ω, ‖f ω‖^2 = …` (parallel sites) | `by intro ω; rw [Real.norm_eq_abs, sq_abs]` → term-mode `fun _ => by rw [Real.norm_eq_abs, sq_abs]` |

**Net:** 6 files, +11 / −19 (−8 lines).

## Test plan

- [x] `lake build` clean (3527/3527 jobs)
- [x] `#print axioms` on `deFinetti`, `deFinetti_viaL2`, `deFinetti_viaKoopman` — all `[propext, Classical.choice, Quot.sound]`
- [x] `lake exe checkdecls blueprint/lean_decls` passes
- [x] `python3 blueprint/check_blueprint.py` — 52 cites, 52 labels, 50 refs/uses, 52 lean_decls, all consistent
- [x] 0 sorries