### PR TITLE
refactor: migrate all call sites + drop the three L2Helpers Contractable wrappers (−38)

### DIFF
--- a/Exchangeability/DeFinetti/L2Helpers.lean
+++ b/Exchangeability/DeFinetti/L2Helpers.lean
@@ -41,44 +41,6 @@ variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
 open scoped BigOperators
 
-section CovarianceHelpers
-
-variable {μ : Measure Ω} [IsProbabilityMeasure μ]
-variable (X : ℕ → Ω → ℝ)
-variable (hX_contract : Contractable μ X)
-variable (hX_meas : ∀ i, Measurable (X i))
-
-omit [IsProbabilityMeasure μ] in
-/-- **All marginals have the same distribution in a contractable sequence.**
-
-For a contractable sequence, the law of each coordinate agrees with the law of `X 0`.
-Thin wrapper around `Exchangeability.Contractable.map_single`. -/
-lemma contractable_map_single (hX_contract : Contractable μ X) (hX_meas : ∀ i, Measurable (X i)) {i : ℕ} :
-    Measure.map (fun ω => X i ω) μ = Measure.map (fun ω => X 0 ω) μ :=
-  Exchangeability.Contractable.map_single hX_contract hX_meas i
-
-omit [IsProbabilityMeasure μ] in
-/-- **All bivariate marginals have the same distribution in a contractable sequence.**
-
-For a contractable sequence, every increasing pair `(i,j)` with `i < j` has the same
-joint law as `(X 0, X 1)`. Thin wrapper around `Exchangeability.Contractable.map_pair`. -/
-lemma contractable_map_pair (hX_contract : Contractable μ X) (hX_meas : ∀ i, Measurable (X i))
-    {i j : ℕ} (hij : i < j) :
-    Measure.map (fun ω => (X i ω, X j ω)) μ =
-      Measure.map (fun ω => (X 0 ω, X 1 ω)) μ :=
-  Exchangeability.Contractable.map_pair hX_contract hX_meas hij
-
-omit [IsProbabilityMeasure μ] in
-/-- **Contractability is preserved under measurable postcomposition.**
-
-If X is a contractable sequence and f is measurable, then `f ∘ X` is also contractable.
-Thin wrapper around `Exchangeability.Contractable.comp`. -/
-lemma contractable_comp (hX_contract : Contractable μ X) (hX_meas : ∀ i, Measurable (X i))
-    (f : ℝ → ℝ) (hf_meas : Measurable f) :
-    Contractable μ (fun n ω => f (X n ω)) :=
-  Exchangeability.Contractable.comp hX_contract hX_meas f hf_meas
-
-end CovarianceHelpers
 /-!
 ## Lp utility lemmas
 

--- a/Exchangeability/DeFinetti/ViaL2/BlockAverages/Covariance.lean
+++ b/Exchangeability/DeFinetti/ViaL2/BlockAverages/Covariance.lean
@@ -71,7 +71,7 @@ lemma contractable_covariance_structure
   have hmean : ∀ k, ∫ ω, X k ω ∂μ = m := by
     intro k
     -- X_k has the same distribution as X_0 by contractability (singleton subsequence)
-    have h_eq_dist := contractable_map_single (X := X) hX_contract hX_meas (i := k)
+    have h_eq_dist := Contractable.map_single hX_contract hX_meas k
     -- Transfer integral via equal distributions
     have h_int_k : ∫ ω, X k ω ∂μ = ∫ x, x ∂(Measure.map (X k) μ) := by
       have h_ae : AEStronglyMeasurable (id : ℝ → ℝ) (Measure.map (X k) μ) :=
@@ -90,7 +90,7 @@ lemma contractable_covariance_structure
   have hvar : ∀ k, ∫ ω, (X k ω - m)^2 ∂μ = σSq := by
     intro k
     -- Use equal distribution to transfer the variance integral
-    have h_eq_dist := contractable_map_single (X := X) hX_contract hX_meas (i := k)
+    have h_eq_dist := Contractable.map_single hX_contract hX_meas k
     have hmean_k := hmean k
     -- The variance with k's mean equals variance with m (since they're equal)
     show ∫ ω, (X k ω - m)^2 ∂μ = σSq
@@ -120,8 +120,8 @@ lemma contractable_covariance_structure
       intro i j hij
       -- Apply contractability to get equal distributions for pairs
       by_cases h_ord : i < j
-      · -- Case i < j: use contractable_map_pair directly
-        have h_eq_dist := contractable_map_pair (X := X) hX_contract hX_meas h_ord
+      · -- Case i < j: use Contractable.map_pair directly
+        have h_eq_dist := Contractable.map_pair hX_contract hX_meas h_ord
         -- Transfer the covariance integral via measure map
         have h_int_ij : ∫ ω, (X i ω - m) * (X j ω - m) ∂μ
             = ∫ p : ℝ × ℝ, (p.1 - m) * (p.2 - m) ∂(Measure.map (fun ω => (X i ω, X j ω)) μ) := by
@@ -152,7 +152,7 @@ lemma contractable_covariance_structure
       · -- Case j < i: use symmetry
         push Not at h_ord
         have h_ji : j < i := Nat.lt_of_le_of_ne h_ord (Ne.symm hij)
-        have h_eq_dist := contractable_map_pair (X := X) hX_contract hX_meas h_ji
+        have h_eq_dist := Contractable.map_pair hX_contract hX_meas h_ji
         have h_int_ji : ∫ ω, (X j ω - m) * (X i ω - m) ∂μ
             = ∫ p : ℝ × ℝ, (p.1 - m) * (p.2 - m) ∂(Measure.map (fun ω => (X j ω, X i ω)) μ) := by
           have h_ae : AEStronglyMeasurable (fun p : ℝ × ℝ => (p.1 - m) * (p.2 - m))

--- a/Exchangeability/DeFinetti/ViaL2/BlockAverages/LongVsTail.lean
+++ b/Exchangeability/DeFinetti/ViaL2/BlockAverages/LongVsTail.lean
@@ -58,7 +58,7 @@ lemma get_covariance_constant
       -1 ≤ ρf ∧ ρf ≤ 1 := by
   -- Step 1: Show f∘X is contractable
   have hfX_contract : Contractable μ (fun n ω => f (X n ω)) :=
-    @contractable_comp Ω _ μ X hX_contract hX_meas f hf_meas
+    Contractable.comp hX_contract hX_meas f hf_meas
 
   -- Step 2: Get covariance structure (m, σ², ρ) of f∘X
   obtain ⟨M, hM⟩ := hf_bdd

--- a/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/KallenbergBound.lean
+++ b/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/KallenbergBound.lean
@@ -224,9 +224,9 @@ lemma kallenberg_L2_bound
         have hZ0_L2 : MemLp (Z 0) 2 μ := by
           by_cases h : k = 0
           · subst h; exact hZk_L2
-          · -- Use contractable_map_single to show Z k and Z 0 have same distribution
+          · -- Use Contractable.map_single to show Z k and Z 0 have same distribution
             -- Then transfer MemLp via equal eLpNorm
-            have h_dist := Exchangeability.DeFinetti.L2Helpers.contractable_map_single
+            have h_dist := Contractable.map_single
               (X := Z) hZ_contract hZ_meas (i := k)
             -- h_dist : Measure.map (Z k) μ = Measure.map (Z 0) μ
             -- Transfer eLpNorm: show eLpNorm (Z 0) 2 μ = eLpNorm (Z k) 2 μ
@@ -247,12 +247,12 @@ lemma kallenberg_L2_bound
         have hZ1_L2 : MemLp (Z 1) 2 μ := by
           by_cases h : k = 1
           · subst h; exact hZk_L2
-          · -- Use contractable_map_single to show Z k and Z 1 have same distribution
+          · -- Use Contractable.map_single to show Z k and Z 1 have same distribution
             -- Then transfer MemLp via equal eLpNorm
-            have h_dist := Exchangeability.DeFinetti.L2Helpers.contractable_map_single
+            have h_dist := Contractable.map_single
               (X := Z) hZ_contract hZ_meas (i := k)
             -- h_dist : Measure.map (Z k) μ = Measure.map (Z 0) μ
-            have h_dist1 := Exchangeability.DeFinetti.L2Helpers.contractable_map_single
+            have h_dist1 := Contractable.map_single
               (X := Z) hZ_contract hZ_meas (i := 1)
             -- h_dist1 : Measure.map (Z 1) μ = Measure.map (Z 0) μ
             -- Transfer eLpNorm: show eLpNorm (Z 1) 2 μ = eLpNorm (Z k) 2 μ
@@ -284,7 +284,7 @@ lemma kallenberg_L2_bound
                 -- Use equal distributions: Z 1 has same variance as Z 0
                 congr 1
                 -- Use contractability: Z 1 has same distribution as Z 0
-                have h_dist := Exchangeability.DeFinetti.L2Helpers.contractable_map_single
+                have h_dist := Contractable.map_single
                   (X := Z) hZ_contract hZ_meas (i := 1)
                 rw [← Exchangeability.Probability.IntegrationHelpers.integral_pushforward_sq_diff (hZ_meas 1) m,
                     h_dist,
@@ -311,7 +311,7 @@ lemma kallenberg_L2_bound
   have hmean : ∀ k : Fin n, ∫ ω, ξ k ω ∂μ = m := by
     intro k
     -- ξ k = Z (enum k).val, and all Z i have the same distribution by contractability
-    have h_same_dist := Exchangeability.DeFinetti.L2Helpers.contractable_map_single
+    have h_same_dist := Contractable.map_single
       (X := Z) hZ_contract hZ_meas (i := (enum k).val)
     -- Equal distributions → equal integrals
     simp only [ξ, m]
@@ -333,7 +333,7 @@ lemma kallenberg_L2_bound
   have hvar : ∀ k : Fin n, ∫ ω, (ξ k ω - m)^2 ∂μ = σSq := by
     intro k
     -- Same distribution → same variance
-    have h_same_dist := Exchangeability.DeFinetti.L2Helpers.contractable_map_single
+    have h_same_dist := Contractable.map_single
       (X := Z) hZ_contract hZ_meas (i := (enum k).val)
     simp only [ξ, σSq]
     -- Use integral_pushforward_sq_diff
@@ -344,7 +344,7 @@ lemma kallenberg_L2_bound
   -- Prove all covariances equal σ²ρ
   have hcov : ∀ i j : Fin n, i ≠ j → ∫ ω, (ξ i ω - m) * (ξ j ω - m) ∂μ = σSq * ρ := by
     intro i j hij
-    -- Use contractable_map_pair to show all pairs have same distribution as (Z 0, Z 1)
+    -- Use Contractable.map_pair to show all pairs have same distribution as (Z 0, Z 1)
     simp only [ξ, σSq, ρ, covOffDiag]
 
     -- Get the indices from enum
@@ -361,8 +361,8 @@ lemma kallenberg_L2_bound
 
     -- Case split on ordering
     rcases hij'.lt_or_gt with h_lt | h_lt
-    · -- Case i' < j': Use contractable_map_pair directly
-      have h_dist := Exchangeability.DeFinetti.L2Helpers.contractable_map_pair
+    · -- Case i' < j': Use Contractable.map_pair directly
+      have h_dist := Contractable.map_pair
         (X := Z) hZ_contract hZ_meas h_lt
       -- Use integral_map to transfer the integral
       have h_prod_meas : Measurable (fun ω => (Z i' ω, Z j' ω)) :=
@@ -394,7 +394,7 @@ lemma kallenberg_L2_bound
                 have hZ0_L2_local : MemLp (Z 0) 2 μ := by
                   by_cases h' : k = 0
                   · subst h'; exact hZk_L2
-                  · have h_dist := Exchangeability.DeFinetti.L2Helpers.contractable_map_single
+                  · have h_dist := Contractable.map_single
                       (X := Z) hZ_contract hZ_meas (i := k)
                     have h_Lpnorm_eq : eLpNorm (Z 0) 2 μ = eLpNorm (Z k) 2 μ := by
                       symm
@@ -411,9 +411,9 @@ lemma kallenberg_L2_bound
                 have hZ1_L2_local : MemLp (Z 1) 2 μ := by
                   by_cases h' : k = 1
                   · subst h'; exact hZk_L2
-                  · have h_dist := Exchangeability.DeFinetti.L2Helpers.contractable_map_single
+                  · have h_dist := Contractable.map_single
                       (X := Z) hZ_contract hZ_meas (i := k)
-                    have h_dist1 := Exchangeability.DeFinetti.L2Helpers.contractable_map_single
+                    have h_dist1 := Contractable.map_single
                       (X := Z) hZ_contract hZ_meas (i := 1)
                     have h_Lpnorm_eq : eLpNorm (Z 1) 2 μ = eLpNorm (Z k) 2 μ := by
                       calc eLpNorm (Z 1) 2 μ
@@ -439,7 +439,7 @@ lemma kallenberg_L2_bound
                 exact abs_eq_zero.mp (le_antisymm cs (abs_nonneg _))
               · simp [h]; field_simp
     · -- Case j' < i': Use symmetry of multiplication
-      have h_dist := Exchangeability.DeFinetti.L2Helpers.contractable_map_pair
+      have h_dist := Contractable.map_pair
         (X := Z) hZ_contract hZ_meas h_lt
       -- Note: (Z i' - m) * (Z j' - m) = (Z j' - m) * (Z i' - m)
       have h_prod_meas : Measurable (fun ω => (Z j' ω, Z i' ω)) :=
@@ -473,7 +473,7 @@ lemma kallenberg_L2_bound
                 have hZ0_L2_local : MemLp (Z 0) 2 μ := by
                   by_cases h' : k = 0
                   · subst h'; exact hZk_L2
-                  · have h_dist := Exchangeability.DeFinetti.L2Helpers.contractable_map_single
+                  · have h_dist := Contractable.map_single
                       (X := Z) hZ_contract hZ_meas (i := k)
                     have h_Lpnorm_eq : eLpNorm (Z 0) 2 μ = eLpNorm (Z k) 2 μ := by
                       symm
@@ -490,9 +490,9 @@ lemma kallenberg_L2_bound
                 have hZ1_L2_local : MemLp (Z 1) 2 μ := by
                   by_cases h' : k = 1
                   · subst h'; exact hZk_L2
-                  · have h_dist := Exchangeability.DeFinetti.L2Helpers.contractable_map_single
+                  · have h_dist := Contractable.map_single
                       (X := Z) hZ_contract hZ_meas (i := k)
-                    have h_dist1 := Exchangeability.DeFinetti.L2Helpers.contractable_map_single
+                    have h_dist1 := Contractable.map_single
                       (X := Z) hZ_contract hZ_meas (i := 1)
                     have h_Lpnorm_eq : eLpNorm (Z 1) 2 μ = eLpNorm (Z k) 2 μ := by
                       calc eLpNorm (Z 1) 2 μ
@@ -596,7 +596,7 @@ lemma kallenberg_L2_bound
       · subst h; exact hZk_L2
       · -- Use that Z 0 has same distribution as Z k via contractability
         -- Equal distributions imply equal eLpNorm, hence MemLp transfers
-        have h_dist := Exchangeability.DeFinetti.L2Helpers.contractable_map_single
+        have h_dist := Contractable.map_single
           (X := Z) hZ_contract hZ_meas (i := k)
         -- Transfer eLpNorm using equal distributions
         have h_Lpnorm_eq : eLpNorm (Z 0) 2 μ = eLpNorm (Z k) 2 μ := by
@@ -617,9 +617,9 @@ lemma kallenberg_L2_bound
       · subst h; exact hZk_L2
       · -- Use that Z 1 has same distribution as Z k via contractability
         -- Equal distributions imply equal eLpNorm, hence MemLp transfers
-        have h_dist := Exchangeability.DeFinetti.L2Helpers.contractable_map_single
+        have h_dist := Contractable.map_single
           (X := Z) hZ_contract hZ_meas (i := k)
-        have h_dist1 := Exchangeability.DeFinetti.L2Helpers.contractable_map_single
+        have h_dist1 := Contractable.map_single
           (X := Z) hZ_contract hZ_meas (i := 1)
         -- Transfer eLpNorm using equal distributions
         have h_Lpnorm_eq : eLpNorm (Z 1) 2 μ = eLpNorm (Z k) 2 μ := by
@@ -669,7 +669,7 @@ lemma kallenberg_L2_bound
     -- First prove Z 1 has same variance as Z 0
     have hvar1 : ∫ ω, (Z 1 ω - m)^2 ∂μ = σSq := by
       -- Use contractability: Z 1 has same distribution as Z 0
-      have h_dist := Exchangeability.DeFinetti.L2Helpers.contractable_map_single
+      have h_dist := Contractable.map_single
         (X := Z) hZ_contract hZ_meas (i := 1)
       simp only [σSq]
       rw [← Exchangeability.Probability.IntegrationHelpers.integral_pushforward_sq_diff (hZ_meas 1) m,

--- a/Exchangeability/Probability/CenteredVariables.lean
+++ b/Exchangeability/Probability/CenteredVariables.lean
@@ -66,9 +66,9 @@ lemma centered_uniform_covariance
   -- Step 2: Show Z is contractable
   -- Z = f ∘ X - m, and contractability is preserved under composition + constant shift
   have hZ_contract : Contractable μ Z := by
-    -- First show f ∘ X is contractable using contractable_comp
+    -- First show f ∘ X is contractable using Contractable.comp
     have hfX_contract : Contractable μ (fun i ω => f (X i ω)) :=
-      Exchangeability.DeFinetti.L2Helpers.contractable_comp (X := X) hX_contract hX_meas f hf_meas
+      Exchangeability.Contractable.comp hX_contract hX_meas f hf_meas
     -- Subtracting a constant preserves contractability
     intro n k hk
     -- Need: map (fun ω i => Z (k i) ω) μ = map (fun ω i => Z i ω) μ
@@ -112,7 +112,7 @@ lemma centered_uniform_covariance
     intro i
     -- From contractability: map (Z i) μ = map (Z 0) μ
     have h_map_eq : Measure.map (Z i) μ = Measure.map (Z 0) μ :=
-      Exchangeability.DeFinetti.L2Helpers.contractable_map_single (X := Z) hZ_contract hZ_meas (i := i)
+      Exchangeability.Contractable.map_single (X := Z) hZ_contract hZ_meas (i := i)
 
     -- Strategy: Use integral_map to rewrite both sides
     -- ∫ (Z i ω)² dμ = ∫ x² d(map (Z i) μ) [by integral_map]
@@ -146,12 +146,12 @@ lemma centered_uniform_covariance
     rw [integral_sub hfX_int (integrable_const m)]
     -- Now show ∫ f(X i) = m, so that ∫ f(X i) - m = m - m = 0
 
-    -- Strategy: contractable_map_single gives map (X i) μ = map (X 0) μ
+    -- Strategy: Contractable.map_single gives map (X i) μ = map (X 0) μ
     -- Then integral_map gives: ∫ f(X i) dμ = ∫ f d(map (X i) μ) = ∫ f d(map (X 0) μ) = ∫ f(X 0) dμ = m
 
     -- Use contractability to get measure equality
     have h_map_eq : Measure.map (X i) μ = Measure.map (X 0) μ :=
-      Exchangeability.DeFinetti.L2Helpers.contractable_map_single (X := X) hX_contract hX_meas (i := i)
+      Exchangeability.Contractable.map_single (X := X) hX_contract hX_meas (i := i)
 
     -- f is measurable and bounded, so we can apply integral_map
     have hXi_meas : AEMeasurable (X i) μ := (hX_meas i).aemeasurable
@@ -172,13 +172,13 @@ lemma centered_uniform_covariance
   have hZ_cov_uniform : ∀ i j, i ≠ j →
       ∫ ω, Z i ω * Z j ω ∂μ = ∫ ω, Z 0 ω * Z 1 ω ∂μ := by
     intro i j hij
-    -- Strategy: If i < j, use contractable_map_pair directly
-    --           If i > j, use contractable_map_pair on (j,i) + symmetry of multiplication
+    -- Strategy: If i < j, use Contractable.map_pair directly
+    --           If i > j, use Contractable.map_pair on (j,i) + symmetry of multiplication
     by_cases h_lt : i < j
-    · -- Case i < j: use contractable_map_pair directly
+    · -- Case i < j: use Contractable.map_pair directly
       have h_map_eq : Measure.map (fun ω => (Z i ω, Z j ω)) μ =
           Measure.map (fun ω => (Z 0 ω, Z 1 ω)) μ :=
-        Exchangeability.DeFinetti.L2Helpers.contractable_map_pair (X := Z) hZ_contract hZ_meas h_lt
+        Exchangeability.Contractable.map_pair (X := Z) hZ_contract hZ_meas h_lt
 
       -- The function (x, y) ↦ x * y is continuous, hence measurable
       have h_mul_meas : Measurable (fun p : ℝ × ℝ => p.1 * p.2) :=
@@ -200,17 +200,17 @@ lemma centered_uniform_covariance
       rw [← integral_map h_prod_ij h_mul_meas.aestronglyMeasurable,
           ← integral_map h_prod_01 h_mul_meas.aestronglyMeasurable, h_map_eq]
 
-    · -- Case i > j: use contractable_map_pair on (j,i) + symmetry
+    · -- Case i > j: use Contractable.map_pair on (j,i) + symmetry
       have hji : j < i := Nat.lt_of_le_of_ne (Nat.le_of_not_lt h_lt) (hij.symm)
 
       -- Symmetry of multiplication: Z i * Z j = Z j * Z i
       have h_sym_ij : ∫ ω, Z i ω * Z j ω ∂μ = ∫ ω, Z j ω * Z i ω ∂μ := by
         congr 1; ext ω; ring
 
-      -- Now use contractable_map_pair on (j, i)
+      -- Now use Contractable.map_pair on (j, i)
       have h_map_eq : Measure.map (fun ω => (Z j ω, Z i ω)) μ =
           Measure.map (fun ω => (Z 0 ω, Z 1 ω)) μ :=
-        Exchangeability.DeFinetti.L2Helpers.contractable_map_pair (X := Z) hZ_contract hZ_meas hji
+        Exchangeability.Contractable.map_pair (X := Z) hZ_contract hZ_meas hji
 
       -- The function (x, y) ↦ x * y is continuous, hence measurable
       have h_mul_meas : Measurable (fun p : ℝ × ℝ => p.1 * p.2) :=


### PR DESCRIPTION
## Summary

Closes the Contractable.* migration started in #114 (`map_single`) and extended in #118 (`map_pair`, `comp`). After this PR, the L2Helpers namespace no longer carries the three contractability wrappers — all callers invoke the canonical `Exchangeability.Contractable.*` API directly.

**Call-site migrations** (4 files, 24+ sites):

| File | Sites | Replacement |
|---|---|---|
| `Probability/CenteredVariables.lean` | 5 call sites (2× `map_single`, 2× `map_pair`, 1× `comp`) | fully-qualified `Exchangeability.Contractable.*` (file lacks `open Exchangeability`) |
| `BlockAverages/Covariance.lean` | 2× `map_single` + 2× `map_pair`, previously unqualified via `open L2Helpers` | `Contractable.*` (`open Exchangeability` already in scope) |
| `BlockAverages/LongVsTail.lean` | 1× explicit-arg `@contractable_comp Ω _ μ X …` | `Contractable.comp hX_contract hX_meas f hf_meas` |
| `CesaroConvergence/KallenbergBound.lean` | 16× `L2Helpers.contractable_map_single` + 2× `contractable_map_pair` | `Contractable.*` |

All in-code comments mentioning the old names were also updated to the new `Contractable.*` form.

**Wrapper deletion** in `DeFinetti/L2Helpers.lean`:

* Drop `contractable_map_single`, `contractable_map_pair`, and `contractable_comp`. The entire `CovarianceHelpers` section disappears with them since they were its only contents (the local `μ`/`X`/`hX_contract`/`hX_meas` variable declarations went too).

**Net:** 5 files, +40 / −78 (−38 lines).

## Test plan

- [x] `lake build` clean (3527/3527 jobs)
- [x] `#print axioms` on `deFinetti`, `deFinetti_viaL2`, `deFinetti_viaKoopman` — all `[propext, Classical.choice, Quot.sound]`
- [x] `lake exe checkdecls blueprint/lean_decls` passes
- [x] `python3 blueprint/check_blueprint.py` — 52 cites, 52 labels, 50 refs/uses, 52 lean_decls, all consistent
- [x] 0 sorries
- [x] No remaining `contractable_map_single`, `contractable_map_pair`, or `contractable_comp` references anywhere in the tree (verified by `git grep -nw`)