### PR TITLE
chore: inline map_coords_apply + drop 8 stale linter suppressions (11→3)

### DIFF
--- a/Exchangeability/DeFinetti/CommonEnding.lean
+++ b/Exchangeability/DeFinetti/CommonEnding.lean
@@ -219,21 +219,6 @@ lemma fidi_eq_avg_product {μ : Measure Ω} [IsProbabilityMeasure μ]
     _ = ∫⁻ ω, ∏ i : Fin m, ν ω (B i) ∂μ := h_bridge
     _ = ∫⁻ ω, (Measure.pi fun i : Fin m => ν ω) {x | ∀ i, x i ∈ B i} ∂μ := rhs_eq
 
-/-- Pushforward of a measure through coordinate selection equals the marginal distribution.
-This connects the map in the ConditionallyIID definition to the probability of events.
-
-This is a direct application of `Measure.map_apply` from mathlib. -/
-lemma map_coords_apply {μ : Measure Ω} (X : ℕ → Ω → α) (hX_meas : ∀ i, Measurable (X i))
-  (m : ℕ) (k : Fin m → ℕ) (B : Set (Fin m → α)) (hB : MeasurableSet B) :
-    (Measure.map (fun ω i => X (k i) ω) μ) B = μ {ω | (fun i => X (k i) ω) ∈ B} := by
-  -- The function (fun ω i => X (k i) ω) is measurable as a composition of measurable functions
-  have h_meas : Measurable (fun ω i => X (k i) ω) := by
-    fun_prop
-  -- Apply Measure.map_apply
-  rw [Measure.map_apply h_meas hB]
-  -- The preimage is definitionally equal to the set we want
-  rfl
-
 /-- The bind of a probability measure with the product measure kernel equals the integral
 of the product measure. This is the other side of the ConditionallyIID equation.
 
@@ -422,10 +407,10 @@ theorem conditional_iid_from_directing_measure
       -- S is a rectangle, so S = {x | ∀ i, x i ∈ B i} for some B
       obtain ⟨B, hB_meas, rfl⟩ := hS
 
-      -- LHS: μ_map {x | ∀ i, x i ∈ B i}
+      -- LHS: μ_map {x | ∀ i, x i ∈ B i} = μ ((fun ω i => X (k i) ω) ⁻¹' …)
       have lhs_eq : μ_map {x | ∀ i, x i ∈ B i} = μ {ω | ∀ i, X (k i) ω ∈ B i} := by
         have hB := rectangle_as_pi_measurable m B hB_meas
-        exact map_coords_apply X hX_meas m k _ hB
+        exact Measure.map_apply (by fun_prop) hB
 
       -- RHS: μ_bind {x | ∀ i, x i ∈ B i}
       have rhs_eq : μ_bind {x | ∀ i, x i ∈ B i} =

--- a/Exchangeability/DeFinetti/ViaL2/AlphaIicCE.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaIicCE.lean
@@ -60,7 +60,6 @@ existential `alphaIic` almost everywhere.
 - Monotone in `t` almost everywhere (from positivity of conditional expectation)
 - Endpoint limits follow from L¹ contraction and dominated convergence
 -/
-@[nolint unusedArguments]
 noncomputable def alphaIicCE
     {μ : Measure Ω} [IsProbabilityMeasure μ]
     (X : ℕ → Ω → ℝ) (hX_contract : Contractable μ X)

--- a/Exchangeability/DeFinetti/ViaMartingale/CondExpConvergence.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/CondExpConvergence.lean
@@ -168,7 +168,6 @@ abbrev 𝔽 (m : ℕ) : MeasurableSpace Ω := futureFiltration X m
 The reverse martingale sequence for the indicator of X_k in B.
 
 Uses `condExpWith` from CondExp.lean to manage typeclass instances properly. -/
-@[nolint unusedArguments]
 noncomputable
 def M (hX_meas : ∀ n, Measurable (X n)) (k : ℕ) (B : Set α) (_hB : MeasurableSet B) :
     ℕ → Ω → ℝ :=

--- a/Exchangeability/DeFinetti/ViaMartingale/DirectingMeasure.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/DirectingMeasure.lean
@@ -49,7 +49,6 @@ at ω to get a measure on Ω, then push forward along X₀.
 
 Concretely: `directingMeasure ω = (condExpKernel μ (tailSigma X) ω).map (X 0)`
 -/
-@[nolint unusedArguments]
 noncomputable def directingMeasure
     {Ω : Type*} [MeasurableSpace Ω] [StandardBorelSpace Ω]
     {μ : Measure Ω} [IsProbabilityMeasure μ]

--- a/Exchangeability/Ergodic/InvariantSigma.lean
+++ b/Exchangeability/Ergodic/InvariantSigma.lean
@@ -361,7 +361,6 @@ lemma metProjectionShift_tendsto
 
 This is the orthogonal projection onto the subspace of shift-invariant L² functions,
 implemented using mathlib's `condExpL2`. -/
-@[nolint unusedArguments]
 noncomputable def condexpL2 {μ : Measure (Ω[α])} [IsProbabilityMeasure μ] :
     Lp ℝ 2 μ →L[ℝ] Lp ℝ 2 μ :=
   -- Apply mathlib's conditional expectation to get projection onto lpMeas

--- a/Exchangeability/Ergodic/KoopmanMeanErgodic.lean
+++ b/Exchangeability/Ergodic/KoopmanMeanErgodic.lean
@@ -107,7 +107,6 @@ consists of functions constant along orbits (the invariant σ-algebra).
 is the tail σ-algebra, and the Mean Ergodic Theorem shows convergence to conditional
 expectation onto this σ-algebra.
 -/
-@[nolint unusedArguments]
 def koopman {μ : Measure Ω} [IsProbabilityMeasure μ] (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
     Lp ℝ 2 μ →L[ℝ] Lp ℝ 2 μ :=
   (MeasureTheory.Lp.compMeasurePreservingₗᵢ ℝ T hT).toContinuousLinearMap

--- a/Exchangeability/Probability/CondExp.lean
+++ b/Exchangeability/Probability/CondExp.lean
@@ -227,7 +227,6 @@ when calling `condexp` with sub-σ-algebras. -/
 
 This wrapper "freezes" the conditioning σ-algebra and installs the necessary
 sigma-finite instances before calling `μ[f | m]`, avoiding typeclass metavariable issues. -/
-@[nolint unusedArguments]
 noncomputable
 def condExpWith {Ω : Type*} {m₀ : MeasurableSpace Ω}
     (μ : Measure Ω) [IsFiniteMeasure μ]

--- a/Exchangeability/Probability/InfiniteProduct.lean
+++ b/Exchangeability/Probability/InfiniteProduct.lean
@@ -90,7 +90,6 @@ according to `ν`.
 Kolmogorov's extension theorem. We will show that this family is projective
 (consistent under marginalization) and then extend it to an infinite product.
 -/
-@[nolint unusedArguments]
 def iidProjectiveFamily {ν : Measure α} [IsProbabilityMeasure ν] :
     ∀ I : Finset ℕ, Measure (∀ _ : I, α) :=
   fun I => Measure.pi (fun (_ : I) => ν)
@@ -117,7 +116,6 @@ theorem (used in `Exchangeability.lean`).
 theory of i.i.d. sequences, forming the basis for the law of large numbers, central
 limit theorem, and de Finetti's theorem.
 -/
-@[nolint unusedArguments]
 def iidProduct (ν : Measure α) [IsProbabilityMeasure ν] : Measure (ℕ → α) :=
   Measure.infinitePi (fun _ : ℕ => ν)
 


### PR DESCRIPTION
## Summary

Two unrelated hygiene cleanups bundled. Build remains clean (3527/3527 jobs, **0 warnings**, axioms standard, blueprint OK, 0 sorries).

### 1. Inline `map_coords_apply` in `DeFinetti/CommonEnding.lean`

Per the user's `bind_pi_apply`-leave-alone note. `map_coords_apply` was a single-use direct-application helper around `Measure.map_apply`. Its only caller (same-file at L428) inlines to `exact Measure.map_apply (by fun_prop) hB` once. The lemma + its `have h_meas` / `rw` / `rfl` scaffolding deletes cleanly.

### 2. Linter-suppression audit (11 → 3)

Probed each of the 11 `@[nolint unusedArguments]` / `set_option linter.unusedVariables false in` sites by removing the suppression and rebuilding. **8 were stale** (no warning fired) and were deleted; **3 were load-bearing** (warnings fired, restored).

**Stale (removed):**
| File | Decl | Why stale |
|---|---|---|
| `Probability/InfiniteProduct.lean` | `iidProjectiveFamily`, `iidProduct` | all args actually used |
| `Probability/CondExp.lean` | `condExpWith` | `_hm` already underscore-prefixed |
| `Ergodic/KoopmanMeanErgodic.lean` | `koopman` | both `T` and `hT` used in body |
| `Ergodic/InvariantSigma.lean` | `condexpL2` | all args used |
| `DeFinetti/ViaL2/AlphaIicCE.lean:63` | `@[nolint unusedArguments]` on `alphaIicCE` | the parallel L51 `set_option linter.unusedVariables false in` catches everything |
| `DeFinetti/ViaMartingale/CondExpConvergence.lean` | `M` | all args used (`_hB` already underscore) |
| `DeFinetti/ViaMartingale/DirectingMeasure.lean` | `directingMeasure` | `_hX` already underscore-prefixed |

**Load-bearing (kept):**
| File | Decl | Variable that triggers the warning |
|---|---|---|
| `DeFinetti/ViaL2/AlphaIicCE.lean:51` | `alphaIicCE` | `hX_contract`, `hX_L2` |
| `DeFinetti/ViaKoopman/BlockInjection.lean:175` | `reindex_blockInjection_preimage_shiftInvariant` | `hn : 0 < n` |
| `DeFinetti/ViaKoopman/InfraGeneralized.lean:98` | `Integrable.of_abs_bounded` | `hC : 0 ≤ C` |

All three load-bearing sites are public API where the standing project policy is to keep binder names rather than rename to `_`-prefixed.

**Net:** 8 files, +2 / −25 (−23 lines).

## Test plan

- [x] `lake build` clean (3527/3527 jobs, 0 warnings)
- [x] `#print axioms` on `deFinetti`, `deFinetti_viaL2`, `deFinetti_viaKoopman` — all `[propext, Classical.choice, Quot.sound]`
- [x] `lake exe checkdecls blueprint/lean_decls` passes
- [x] `python3 blueprint/check_blueprint.py` — 52 cites, 52 labels, 50 refs/uses, 52 lean_decls, all consistent
- [x] 0 sorries