### PR TITLE
chore: 32 `by exact` wrapper collapses (find_golfable.py scripted pass)

### DIFF
--- a/Exchangeability/Core.lean
+++ b/Exchangeability/Core.lean
@@ -390,8 +390,7 @@ private lemma pathLaw_map_prefix_perm (μ : Measure Ω) (X : ℕ → Ω → α)
         rw [Measure.map_map (measurable_prefixProj (α:=α) (n:=n)) hreindex]
     _ = Measure.map (prefixProj (α:=α) n ∘ reindex (α:=α) π)
         (Measure.map (fun ω => fun i : ℕ => X i ω) μ) := by rw [pathLaw]
-    _ = Measure.map ((prefixProj (α:=α) n ∘ reindex (α:=α) π) ∘ fun ω => fun i : ℕ => X i ω) μ := by
-        exact Measure.map_map ((measurable_prefixProj (α:=α) (n:=n)).comp hreindex) (by fun_prop)
+    _ = Measure.map ((prefixProj (α:=α) n ∘ reindex (α:=α) π) ∘ fun ω => fun i : ℕ => X i ω) μ := Measure.map_map ((measurable_prefixProj (α:=α) (n:=n)).comp hreindex) (by fun_prop)
     _ = Measure.map (fun ω => fun i : Fin n => X (π i) ω) μ := rfl
 
 /--

--- a/Exchangeability/DeFinetti/TheoremViaL2.lean
+++ b/Exchangeability/DeFinetti/TheoremViaL2.lean
@@ -138,7 +138,6 @@ theorem conditionallyIID_of_contractable_viaL2
     (X : ℕ → Ω → ℝ) (hX_meas : ∀ i, Measurable (X i))
     (hContract : Contractable μ X)
     (hX_L2 : ∀ i, MemLp (X i) 2 μ) :
-    ConditionallyIID μ X := by
-  exact (deFinetti_RyllNardzewski_equivalence_viaL2 μ X hX_meas hX_L2).mp hContract |>.2
+    ConditionallyIID μ X := (deFinetti_RyllNardzewski_equivalence_viaL2 μ X hX_meas hX_L2).mp hContract |>.2
 
 end Exchangeability.DeFinetti

--- a/Exchangeability/DeFinetti/ViaKoopman/CesaroL2ToL1.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/CesaroL2ToL1.lean
@@ -312,8 +312,7 @@ private lemma optionB_Step4b_AB_close
           gcongr
           -- |S| ≤ n * Cg since |g(ω k)| ≤ Cg for all k
           calc |S|
-              ≤ (Finset.range n).sum (fun j => |g (ω j)|) := by
-                exact Finset.abs_sum_le_sum_abs _ _
+              ≤ (Finset.range n).sum (fun j => |g (ω j)|) := Finset.abs_sum_le_sum_abs _ _
             _ ≤ (Finset.range n).sum (fun j => Cg) :=
                 Finset.sum_le_sum fun j _ => hCg_bd (ω j)
             _ = n * Cg := by rw [Finset.sum_const, Finset.card_range]; ring
@@ -676,8 +675,7 @@ theorem optionB_L1_convergence_bounded
       have hk_pres := hσ.iterate k
       -- Pull hfL2_eq back along shift^[k] using measure-preserving property
       have hpull : (fun ω => (fL2 : Ω[α] → ℝ) (shift^[k] ω)) =ᵐ[μ]
-          (fun ω => G (shift^[k] ω)) := by
-        exact hk_pres.quasiMeasurePreserving.ae_eq_comp hfL2_eq
+          (fun ω => G (shift^[k] ω)) := hk_pres.quasiMeasurePreserving.ae_eq_comp hfL2_eq
       -- Now use iterate_shift_eval0': shift^[k] ω 0 = ω k
       have heval : (fun ω => G (shift^[k] ω)) =ᵐ[μ] (fun ω => g (ω k)) :=
         ae_of_all _ fun ω => congr_arg g (iterate_shift_eval0' k ω)
@@ -736,8 +734,7 @@ theorem optionB_L1_convergence_bounded
     -- Use helper lemma: condexpL2 = condExp a.e.
     have h1 := condexpL2_ae_eq_condExp fL2
     -- condExp preserves a.e. equality
-    have h2 : μ[fL2 | mSI] =ᵐ[μ] μ[G | mSI] := by
-      exact MeasureTheory.condExp_congr_ae hfL2_eq
+    have h2 : μ[fL2 | mSI] =ᵐ[μ] μ[G | mSI] := MeasureTheory.condExp_congr_ae hfL2_eq
     simp only [Y]
     exact h1.trans h2
 

--- a/Exchangeability/DeFinetti/ViaL2/BlockAverages/Covariance.lean
+++ b/Exchangeability/DeFinetti/ViaL2/BlockAverages/Covariance.lean
@@ -96,12 +96,10 @@ lemma contractable_covariance_structure
     show ∫ ω, (X k ω - m)^2 ∂μ = σSq
     -- Transform X_k integral to X_0 integral via measure map
     have h_int_k : ∫ ω, (X k ω - m)^2 ∂μ = ∫ x, (x - m)^2 ∂(Measure.map (X k) μ) := by
-      have h_ae : AEStronglyMeasurable (fun x : ℝ => (x - m)^2) (Measure.map (X k) μ) := by
-        exact (continuous_id.sub continuous_const).pow 2 |>.aestronglyMeasurable
+      have h_ae : AEStronglyMeasurable (fun x : ℝ => (x - m)^2) (Measure.map (X k) μ) := (continuous_id.sub continuous_const).pow 2 |>.aestronglyMeasurable
       exact (integral_map (hX_meas k).aemeasurable h_ae).symm
     have h_int_0 : ∫ ω, (X 0 ω - m)^2 ∂μ = ∫ x, (x - m)^2 ∂(Measure.map (X 0) μ) := by
-      have h_ae : AEStronglyMeasurable (fun x : ℝ => (x - m)^2) (Measure.map (X 0) μ) := by
-        exact (continuous_id.sub continuous_const).pow 2 |>.aestronglyMeasurable
+      have h_ae : AEStronglyMeasurable (fun x : ℝ => (x - m)^2) (Measure.map (X 0) μ) := (continuous_id.sub continuous_const).pow 2 |>.aestronglyMeasurable
       exact (integral_map (hX_meas 0).aemeasurable h_ae).symm
     rw [h_int_k, h_eq_dist, ← h_int_0]
 

--- a/Exchangeability/DeFinetti/ViaL2/BlockAverages/TwoWindows.lean
+++ b/Exchangeability/DeFinetti/ViaL2/BlockAverages/TwoWindows.lean
@@ -49,8 +49,7 @@ private lemma reindexed_weights_prob
           (fun i : Fin nS => wS ((eβ i).1))
           (fun b => wS b.1) (by intro i; rfl)
       have h_sum_attach :
-          ∑ b : {t // t ∈ S}, wS b.1 = ∑ t ∈ S, wS t := by
-        exact Finset.sum_attach (s := S) (f := fun t => wS t)
+          ∑ b : {t // t ∈ S}, wS b.1 = ∑ t ∈ S, wS t := Finset.sum_attach (s := S) (f := fun t => wS t)
       have h_sum_w :
           ∑ i : Fin nS, w i = ∑ i : Fin nS, wS ((eβ i).1) := by
         refine Finset.sum_congr rfl fun i _ => ?_

--- a/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/KallenbergBound.lean
+++ b/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/KallenbergBound.lean
@@ -237,8 +237,7 @@ lemma kallenberg_L2_bound
                       symm
                       exact eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas k).aemeasurable
                 _ = eLpNorm id 2 (Measure.map (Z 0) μ) := by rw [h_dist]
-                _ = eLpNorm (Z 0) 2 μ := by
-                      exact eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas 0).aemeasurable
+                _ = eLpNorm (Z 0) 2 μ := eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas 0).aemeasurable
             -- Now transfer MemLp using equal eLpNorm
             have : eLpNorm (Z 0) 2 μ < ⊤ := by
               rw [h_Lpnorm_eq]
@@ -263,8 +262,7 @@ lemma kallenberg_L2_bound
                       exact eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas 1).aemeasurable
                 _ = eLpNorm id 2 (Measure.map (Z 0) μ) := by rw [h_dist1]
                 _ = eLpNorm id 2 (Measure.map (Z k) μ) := by rw [← h_dist]
-                _ = eLpNorm (Z k) 2 μ := by
-                      exact eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas k).aemeasurable
+                _ = eLpNorm (Z k) 2 μ := eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas k).aemeasurable
             -- Now transfer MemLp using equal eLpNorm
             have : eLpNorm (Z 1) 2 μ < ⊤ := by
               rw [h_Lpnorm_eq]
@@ -278,8 +276,7 @@ lemma kallenberg_L2_bound
 
         -- Apply Cauchy-Schwarz
         calc |∫ ω, (Z 0 ω - m) * (Z 1 ω - m) ∂μ|
-            ≤ (∫ ω, (Z 0 ω - m) ^ 2 ∂μ) ^ (1/2 : ℝ) * (∫ ω, (Z 1 ω - m) ^ 2 ∂μ) ^ (1/2 : ℝ) := by
-                exact Exchangeability.Probability.IntegrationHelpers.abs_integral_mul_le_L2 hf hg
+            ≤ (∫ ω, (Z 0 ω - m) ^ 2 ∂μ) ^ (1/2 : ℝ) * (∫ ω, (Z 1 ω - m) ^ 2 ∂μ) ^ (1/2 : ℝ) := Exchangeability.Probability.IntegrationHelpers.abs_integral_mul_le_L2 hf hg
           _ = (∫ ω, (Z 0 ω - m) ^ 2 ∂μ) ^ (1/2 : ℝ) * (∫ ω, (Z 0 ω - m) ^ 2 ∂μ) ^ (1/2 : ℝ) := by
                 -- Use equal distributions: Z 1 has same variance as Z 0
                 congr 1
@@ -402,8 +399,7 @@ lemma kallenberg_L2_bound
                           = eLpNorm id 2 (Measure.map (Z k) μ) := by
                               symm; exact eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas k).aemeasurable
                         _ = eLpNorm id 2 (Measure.map (Z 0) μ) := by rw [h_dist]
-                        _ = eLpNorm (Z 0) 2 μ := by
-                              exact eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas 0).aemeasurable
+                        _ = eLpNorm (Z 0) 2 μ := eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas 0).aemeasurable
                     have : eLpNorm (Z 0) 2 μ < ⊤ := by
                       rw [h_Lpnorm_eq]
                       exact hZk_L2.eLpNorm_lt_top
@@ -421,8 +417,7 @@ lemma kallenberg_L2_bound
                               symm; exact eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas 1).aemeasurable
                         _ = eLpNorm id 2 (Measure.map (Z 0) μ) := by rw [h_dist1]
                         _ = eLpNorm id 2 (Measure.map (Z k) μ) := by rw [← h_dist]
-                        _ = eLpNorm (Z k) 2 μ := by
-                              exact eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas k).aemeasurable
+                        _ = eLpNorm (Z k) 2 μ := eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas k).aemeasurable
                     have : eLpNorm (Z 1) 2 μ < ⊤ := by
                       rw [h_Lpnorm_eq]
                       exact hZk_L2.eLpNorm_lt_top
@@ -481,8 +476,7 @@ lemma kallenberg_L2_bound
                           = eLpNorm id 2 (Measure.map (Z k) μ) := by
                               symm; exact eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas k).aemeasurable
                         _ = eLpNorm id 2 (Measure.map (Z 0) μ) := by rw [h_dist]
-                        _ = eLpNorm (Z 0) 2 μ := by
-                              exact eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas 0).aemeasurable
+                        _ = eLpNorm (Z 0) 2 μ := eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas 0).aemeasurable
                     have : eLpNorm (Z 0) 2 μ < ⊤ := by
                       rw [h_Lpnorm_eq]
                       exact hZk_L2.eLpNorm_lt_top
@@ -500,8 +494,7 @@ lemma kallenberg_L2_bound
                               symm; exact eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas 1).aemeasurable
                         _ = eLpNorm id 2 (Measure.map (Z 0) μ) := by rw [h_dist1]
                         _ = eLpNorm id 2 (Measure.map (Z k) μ) := by rw [← h_dist]
-                        _ = eLpNorm (Z k) 2 μ := by
-                              exact eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas k).aemeasurable
+                        _ = eLpNorm (Z k) 2 μ := eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas k).aemeasurable
                     have : eLpNorm (Z 1) 2 μ < ⊤ := by
                       rw [h_Lpnorm_eq]
                       exact hZk_L2.eLpNorm_lt_top
@@ -606,8 +599,7 @@ lemma kallenberg_L2_bound
                   symm
                   exact eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas k).aemeasurable
             _ = eLpNorm id 2 (Measure.map (Z 0) μ) := by rw [h_dist]
-            _ = eLpNorm (Z 0) 2 μ := by
-                  exact eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas 0).aemeasurable
+            _ = eLpNorm (Z 0) 2 μ := eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas 0).aemeasurable
         have : eLpNorm (Z 0) 2 μ < ⊤ := by
           rw [h_Lpnorm_eq]
           exact hZk_L2.eLpNorm_lt_top
@@ -629,8 +621,7 @@ lemma kallenberg_L2_bound
                   exact eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas 1).aemeasurable
             _ = eLpNorm id 2 (Measure.map (Z 0) μ) := by rw [h_dist1]
             _ = eLpNorm id 2 (Measure.map (Z k) μ) := by rw [← h_dist]
-            _ = eLpNorm (Z k) 2 μ := by
-                  exact eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas k).aemeasurable
+            _ = eLpNorm (Z k) 2 μ := eLpNorm_map_measure aestronglyMeasurable_id (hZ_meas k).aemeasurable
         have : eLpNorm (Z 1) 2 μ < ⊤ := by
           rw [h_Lpnorm_eq]
           exact hZk_L2.eLpNorm_lt_top

--- a/Exchangeability/DeFinetti/ViaL2/MainConvergence.lean
+++ b/Exchangeability/DeFinetti/ViaL2/MainConvergence.lean
@@ -96,8 +96,7 @@ theorem weighted_sums_converge_L1
             by_cases hm : m = 0
             · simp [hm]
             · have hm_pos : 0 < (m : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero hm
-              have h_inv_pos : 0 < 1 / (m : ℝ) := by
-                exact div_pos (by norm_num) hm_pos
+              have h_inv_pos : 0 < 1 / (m : ℝ) := div_pos (by norm_num) hm_pos
               have h_abs_sum :
                   |∑ k : Fin m, f (X (n + k.val + 1) ω)|
                     ≤ ∑ k : Fin m, |f (X (n + k.val + 1) ω)| :=
@@ -560,8 +559,7 @@ theorem weighted_sums_converge_L1
     calc eLpNorm (fun ω => A n m ω - alpha_0 ω) 1 μ
         ≤ eLpNorm (fun ω => A n m ω - A 0 m ω) 1 μ +
             eLpNorm (fun ω => A 0 m ω - alpha_0 ω) 1 μ := h_triangle
-      _ < ENNReal.ofReal (ε / 2) + ENNReal.ofReal (ε / 2) := by
-            exact ENNReal.add_lt_add h_term1 h_term2
+      _ < ENNReal.ofReal (ε / 2) + ENNReal.ofReal (ε / 2) := ENNReal.add_lt_add h_term1 h_term2
       _ = ENNReal.ofReal ε := by
             rw [← ENNReal.ofReal_add hε2_pos.le hε2_pos.le]; norm_num
 

--- a/Exchangeability/Probability/CenteredVariables.lean
+++ b/Exchangeability/Probability/CenteredVariables.lean
@@ -98,12 +98,10 @@ lemma centered_uniform_covariance
     -- Apply map_map: map (h ∘ g) μ = map h (map g μ)
     calc Measure.map (fun ω i => f (X (k i) ω) - m) μ
         = Measure.map (h ∘ (fun ω i => f (X (k i) ω))) μ := by congr
-      _ = Measure.map h (Measure.map (fun ω i => f (X (k i) ω)) μ) := by
-            exact (Measure.map_map h_meas hL_meas).symm
+      _ = Measure.map h (Measure.map (fun ω i => f (X (k i) ω)) μ) := (Measure.map_map h_meas hL_meas).symm
       _ = Measure.map h (Measure.map (fun ω i => f (X (↑i) ω)) μ) := by
             rw [h_eq]
-      _ = Measure.map (h ∘ (fun ω i => f (X (↑i) ω))) μ := by
-            exact Measure.map_map h_meas hR_meas
+      _ = Measure.map (h ∘ (fun ω i => f (X (↑i) ω))) μ := Measure.map_map h_meas hR_meas
       _ = Measure.map (fun ω (i : Fin n) => f (X (↑i) ω) - m) μ := by congr
 
   -- Step 3: Show uniform variance via contractability

--- a/Exchangeability/Probability/CondIndep/Bounded/Projection.lean
+++ b/Exchangeability/Probability/CondIndep/Bounded/Projection.lean
@@ -214,12 +214,10 @@ lemma condExp_project_of_condIndep (μ : Measure Ω) [IsProbabilityMeasure μ]
         exact measurableSet_preimage (Measurable.of_comap_le le_rfl) (hB.prod hC)
 
       -- By setIntegral_condExp on mZW
-      have h1 : ∫ x in Z ⁻¹' B ∩ W ⁻¹' C, (μ[f | mZW]) x ∂μ = ∫ x in Z ⁻¹' B ∩ W ⁻¹' C, f x ∂μ := by
-        exact setIntegral_condExp hmZW_le hf_int hrect
+      have h1 : ∫ x in Z ⁻¹' B ∩ W ⁻¹' C, (μ[f | mZW]) x ∂μ = ∫ x in Z ⁻¹' B ∩ W ⁻¹' C, f x ∂μ := setIntegral_condExp hmZW_le hf_int hrect
 
       -- By tower property: E[E[f|mZW]|mW] = E[f|mW] (since mW ≤ mZW)
-      have h2 : μ[μ[f | mZW] | mW] =ᵐ[μ] μ[f | mW] := by
-        exact condExp_condExp_of_le hle hmZW_le
+      have h2 : μ[μ[f | mZW] | mW] =ᵐ[μ] μ[f | mW] := condExp_condExp_of_le hle hmZW_le
 
       -- So ∫_{rectangle} E[f|mW] = ∫_{rectangle} E[E[f|mZW]|mW]
       have h3 : ∫ x in Z ⁻¹' B ∩ W ⁻¹' C, (μ[f | mW]) x ∂μ =
@@ -251,8 +249,7 @@ lemma condExp_project_of_condIndep (μ : Measure Ω) [IsProbabilityMeasure μ]
           -- Gives: E[1_A(Y) · 1_B(Z) | σ(W)] =ᵐ E[1_A(Y) | σ(W)] · E[1_B(Z) | σ(W)]
 
           -- W⁻¹C is σ(W)-measurable
-          have hC_meas : MeasurableSet[mW] (W ⁻¹' C) := by
-            exact measurableSet_preimage (Measurable.of_comap_le le_rfl) hC
+          have hC_meas : MeasurableSet[mW] (W ⁻¹' C) := measurableSet_preimage (Measurable.of_comap_le le_rfl) hC
 
           -- Integrability of gB (already defined at top of rectangle case)
           have hint_B : Integrable gB μ := by
@@ -318,8 +315,7 @@ lemma condExp_project_of_condIndep (μ : Measure Ω) [IsProbabilityMeasure μ]
                           (setIntegral_condExp (μ := μ) (m := mW)
                             (hm := hmW_le) (hs := hCpre) (hf := hint_prod))
                       exact h_set_eq.symm
-                  _ = ∫ x in W ⁻¹' C, ((μ[f | mW]) * μ[gB | mW]) x ∂μ := by
-                      exact setIntegral_congr_ae (hmW_le _ hC_meas) (by filter_upwards [h_pull] with x hx _; exact hx)
+                  _ = ∫ x in W ⁻¹' C, ((μ[f | mW]) * μ[gB | mW]) x ∂μ := setIntegral_congr_ae (hmW_le _ hC_meas) (by filter_upwards [h_pull] with x hx _; exact hx)
             _ = ∫ x in W ⁻¹' C, (μ[f * gB | mW]) x ∂μ := by
                 -- Reverse CondIndep factorization: E[f|mW] · E[gB|mW] =ᵐ E[f · gB|mW]
                 -- Use hCI which states: μ[f · gB | mW] =ᵐ μ[f | mW] · μ[gB | mW]
@@ -346,10 +342,8 @@ lemma condExp_project_of_condIndep (μ : Measure Ω) [IsProbabilityMeasure μ]
     · -- Complement
       intro t htm ht_ind
       -- For complement: ∫_{t} g + ∫_{tᶜ} g = ∫_Ω g, so ∫_{tᶜ} g = ∫_Ω g - ∫_t g
-      have h_add : ∫ x in t, (μ[f | mW]) x ∂μ + ∫ x in tᶜ, (μ[f | mW]) x ∂μ = ∫ x, (μ[f | mW]) x ∂μ := by
-        exact integral_add_compl₀ (hmZW_le _ htm).nullMeasurableSet integrable_condExp
-      have h_add' : ∫ x in t, f x ∂μ + ∫ x in tᶜ, f x ∂μ = ∫ x, f x ∂μ := by
-        exact integral_add_compl₀ (hmZW_le _ htm).nullMeasurableSet hf_int
+      have h_add : ∫ x in t, (μ[f | mW]) x ∂μ + ∫ x in tᶜ, (μ[f | mW]) x ∂μ = ∫ x, (μ[f | mW]) x ∂μ := integral_add_compl₀ (hmZW_le _ htm).nullMeasurableSet integrable_condExp
+      have h_add' : ∫ x in t, f x ∂μ + ∫ x in tᶜ, f x ∂μ = ∫ x, f x ∂μ := integral_add_compl₀ (hmZW_le _ htm).nullMeasurableSet hf_int
       -- ht_ind is the equality for t, use it to substitute in h_add
       rw [ht_ind] at h_add
       -- Now we have: ∫_t f + ∫_{tᶜ} E[f|mW] = ∫ E[f|mW]

--- a/Exchangeability/Probability/CondIndep/Indicator.lean
+++ b/Exchangeability/Probability/CondIndep/Indicator.lean
@@ -78,8 +78,7 @@ private lemma condIndep_indicator (μ : Measure Ω) [IsProbabilityMeasure μ]
         ext ω
         simp [Pi.smul_apply, Pi.mul_apply]
         ring
-    _ =ᵐ[μ] μ[ c • (Y ⁻¹' A).indicator (fun _ => 1) | mW ] * μ[ d • (Z ⁻¹' B).indicator (fun _ => 1) | mW ] := by
-        exact Filter.EventuallyEq.mul (condExp_smul c _ mW).symm (condExp_smul d _ mW).symm
+    _ =ᵐ[μ] μ[ c • (Y ⁻¹' A).indicator (fun _ => 1) | mW ] * μ[ d • (Z ⁻¹' B).indicator (fun _ => 1) | mW ] := Filter.EventuallyEq.mul (condExp_smul c _ mW).symm (condExp_smul d _ mW).symm
     _ =ᵐ[μ] μ[ (A.indicator (fun _ => c)) ∘ Y | mW ] * μ[ (B.indicator (fun _ => d)) ∘ Z | mW ] := by
         -- Prove c • (Y ⁻¹' A).indicator (fun _ => 1) = (A.indicator (fun _ => c)) ∘ Y
         have hY_ind : c • (Y ⁻¹' A).indicator (fun _ => 1) = (A.indicator (fun _ => c)) ∘ Y := by

--- a/Exchangeability/Probability/Martingale/Crossings/AntitoneLimit.lean
+++ b/Exchangeability/Probability/Martingale/Crossings/AntitoneLimit.lean
@@ -113,8 +113,7 @@ lemma condExp_exists_ae_limit_antitone
 
       calc ↑(upcrossingsBefore (↑a) (↑b) (fun n => μ[f | 𝔽 n]) N ω)
           ≤ ↑(upcrossingsBefore (- (↑b : ℝ)) (- (↑a : ℝ))
-                (negProcess (revProcess (fun n => μ[f | 𝔽 n]) N)) (N + 1) ω) := by
-              exact Nat.cast_le.mpr h_orig_le
+                (negProcess (revProcess (fun n => μ[f | 𝔽 n]) N)) (N + 1) ω) := Nat.cast_le.mpr h_orig_le
         _ = ↑(upcrossingsBefore (- (↑b : ℝ)) (- (↑a : ℝ))
                 (negProcess (fun n => revCEFinite (μ := μ) f 𝔽 N n)) (N + 1) ω) := by rw [h_rev_eq]
         _ ≤ upcrossings (- (↑b : ℝ)) (- (↑a : ℝ))
@@ -124,8 +123,7 @@ lemma condExp_exists_ae_limit_antitone
     have h_N_bound : ∀ N, ∫⁻ ω, ↑(upcrossingsBefore (↑a) (↑b) (fun n => μ[f | 𝔽 n]) N ω) ∂μ ≤ C := by
       intro N
       calc ∫⁻ ω, ↑(upcrossingsBefore (↑a) (↑b) (fun n => μ[f | 𝔽 n]) N ω) ∂μ
-          ≤ ∫⁻ ω, upcrossings (- (↑b : ℝ)) (- (↑a : ℝ)) (negProcess (fun n => revCEFinite (μ := μ) f 𝔽 N n)) ω ∂μ := by
-            exact lintegral_mono (h_le_key N)
+          ≤ ∫⁻ ω, upcrossings (- (↑b : ℝ)) (- (↑a : ℝ)) (negProcess (fun n => revCEFinite (μ := μ) f 𝔽 N n)) ω ∂μ := lintegral_mono (h_le_key N)
         _ = ∫⁻ ω, downcrossings (↑a) (↑b) (fun n => revCEFinite (μ := μ) f 𝔽 N n) ω ∂μ := by
             -- Use identity: up(-b, -a, -X) = down(a, b, X)
             rw [show (fun ω => upcrossings (- (↑b : ℝ)) (- (↑a : ℝ)) (negProcess (fun n => revCEFinite (μ := μ) f 𝔽 N n)) ω)
@@ -184,8 +182,7 @@ lemma condExp_exists_ae_limit_antitone
         measurable_from_top.comp (h_adapted.measurable_upcrossingsBefore hab')
 
       -- Apply monotone convergence theorem
-      have h_iSup : ∫⁻ ω, (⨆ N, U N ω) ∂μ = ⨆ N, ∫⁻ ω, U N ω ∂μ := by
-        exact lintegral_iSup hU_meas hU_mono
+      have h_iSup : ∫⁻ ω, (⨆ N, U N ω) ∂μ = ⨆ N, ∫⁻ ω, U N ω ∂μ := lintegral_iSup hU_meas hU_mono
 
       -- Bound the supremum of integrals
       have : (⨆ N, ∫⁻ ω, U N ω ∂μ) ≤ C := iSup_le h_N_bound
@@ -373,8 +370,7 @@ lemma ae_limit_is_condexp_iInf
     -- First term ≤ ‖Xlim - Xn‖₁ by L¹-contraction + linearity (condExp_sub)
     have hfirst : eLpNorm (μ[Xlim | F_inf] - μ[Xn n | F_inf]) 1 μ ≤ eLpNorm (Xlim - Xn n) 1 μ := by
       -- linearity a.e.: μ[Xlim|F_inf] - μ[Xn|F_inf] = μ[Xlim - Xn | F_inf]
-      have hsub : μ[Xlim | F_inf] - μ[Xn n | F_inf] =ᵐ[μ] μ[Xlim - Xn n | F_inf] := by
-        exact (condExp_sub hXlimint integrable_condExp F_inf).symm
+      have hsub : μ[Xlim | F_inf] - μ[Xn n | F_inf] =ᵐ[μ] μ[Xlim - Xn n | F_inf] := (condExp_sub hXlimint integrable_condExp F_inf).symm
       -- contraction: ‖μ[g|F]‖₁ ≤ ‖g‖₁
       rw [eLpNorm_congr_ae hsub]
       exact eLpNorm_one_condExp_le_eLpNorm _


### PR DESCRIPTION
## Summary

Ran the lean4-skills `find_golfable.py` script on the full `Exchangeability/` tree. Of the 236 raw candidates it surfaced (after the `--filter-false-positives` heuristic), the cleanest mechanical pattern was the 38 `by exact` wrappers.

A scripted converter applied 32 of the 38 in a single pass — the remaining 6 had non-trivial surrounding context that the converter skipped (e.g., the `exact` line wasn't the last tactic in the `by` block, or the next line was at a still-indented level).

| File | Sites |
|---|---|
| `Core.lean` | 1 |
| `DeFinetti/TheoremViaL2.lean` | 1 |
| `DeFinetti/ViaKoopman/CesaroL2ToL1.lean` | 3 |
| `DeFinetti/ViaL2/BlockAverages/Covariance.lean` | 3 |
| `DeFinetti/ViaL2/BlockAverages/TwoWindows.lean` | 1 |
| `DeFinetti/ViaL2/CesaroConvergence/KallenbergBound.lean` | 9 |
| `DeFinetti/ViaL2/MainConvergence.lean` | 3 |
| `Probability/CenteredVariables.lean` | 3 |
| `Probability/CondIndep/Bounded/Projection.lean` | 6 |
| `Probability/CondIndep/Indicator.lean` | 1 |
| `Probability/Martingale/Crossings/AntitoneLimit.lean` | 1 |

The 6 sites that didn't auto-convert (mostly in `CesaroL2ToL1`, `KallenbergBound`, `AlphaIic`) can be probed manually later if it's worth chasing.

**Net:** 11 files, +32 / −64 (−32 lines).

## Test plan

- [x] `lake build` clean (3527/3527 jobs, **0 warnings**)
- [x] `#print axioms` on `deFinetti`, `deFinetti_viaL2`, `deFinetti_viaKoopman` — all `[propext, Classical.choice, Quot.sound]`
- [x] `lake exe checkdecls blueprint/lean_decls` passes
- [x] `python3 blueprint/check_blueprint.py` — 52 cites, 52 labels, 50 refs/uses, 52 lean_decls, all consistent
- [x] 0 sorries