### PR TITLE
chore: manual golf — 6 remaining `by exact` + 2 intro_exact term-mode (−3)

### DIFF
--- a/Exchangeability/DeFinetti/L2Helpers.lean
+++ b/Exchangeability/DeFinetti/L2Helpers.lean
@@ -283,9 +283,8 @@ lemma covariance_formula_zero_sum {n : ℕ} {c : Fin n → ℝ} (σSq ρ : ℝ)
 /-- **Step 5:** Sum of squares bounded by L¹ norm times supremum. -/
 lemma sum_sq_le_sum_abs_mul_sup {n : ℕ} {c : Fin n → ℝ} :
     ∑ i, (c i)^2 ≤ ∑ i, |c i| * (⨆ j, |c j|) := by
-  have hbdd : BddAbove (Set.range fun j : Fin n => |c j|) := ⟨∑ k, |c k|, by
-    intro y ⟨k, hk⟩; rw [← hk]
-    exact Finset.single_le_sum (fun i _ => abs_nonneg (c i)) (Finset.mem_univ k)⟩
+  have hbdd : BddAbove (Set.range fun j : Fin n => |c j|) := ⟨∑ k, |c k|, fun _ ⟨k, hk⟩ =>
+    hk ▸ Finset.single_le_sum (fun i _ => abs_nonneg (c i)) (Finset.mem_univ k)⟩
   apply Finset.sum_le_sum; intro i _
   calc (c i)^2 = |c i|^2 := (sq_abs _).symm
      _ = |c i| * |c i| := sq _
@@ -299,9 +298,8 @@ lemma l2_bound_from_steps {n : ℕ} {c p q : Fin n → ℝ} (σSq ρ : ℝ)
     (hc_abs_sum : ∑ i, |c i| ≤ 2)
     (step5 : ∑ i, (c i)^2 ≤ ∑ i, |c i| * (⨆ j, |c j|)) :
     σSq * (1 - ρ) * ∑ i, (c i)^2 ≤ 2 * σSq * (1 - ρ) * (⨆ i, |p i - q i|) := by
-  have hbdd : BddAbove (Set.range fun j : Fin n => |c j|) := ⟨∑ k, |c k|, by
-    intro y ⟨k, hk⟩; rw [← hk]
-    exact Finset.single_le_sum (fun i _ => abs_nonneg (c i)) (Finset.mem_univ k)⟩
+  have hbdd : BddAbove (Set.range fun j : Fin n => |c j|) := ⟨∑ k, |c k|, fun _ ⟨k, hk⟩ =>
+    hk ▸ Finset.single_le_sum (fun i _ => abs_nonneg (c i)) (Finset.mem_univ k)⟩
   have hσ_1ρ_nonneg : 0 ≤ σSq * (1 - ρ) := mul_nonneg hσSq_nonneg (by linarith)
   have hsup_nonneg : 0 ≤ ⨆ j, |c j| := by
     by_cases h : Nonempty (Fin n)

--- a/Exchangeability/DeFinetti/ViaKoopman.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman.lean
@@ -140,9 +140,8 @@ lemma measure_map_shift_eq_of_contractable
   -- LHS marginal: μ.map(i < n ↦ X(i+1))
   -- RHS marginal: μ.map(i < n ↦ X i)
   -- By contractability with k(i) = i+1 (strictly monotone): these are equal
-  have hk : StrictMono (fun i : Fin n => (i.val + 1 : ℕ)) := by
-    intro i j hij
-    exact Nat.add_lt_add_right hij 1
+  have hk : StrictMono (fun i : Fin n => (i.val + 1 : ℕ)) :=
+    fun _ _ hij => Nat.add_lt_add_right hij 1
   -- The marginal projection
   have h_proj_L : Measure.map (Exchangeability.prefixProj α n) (Measure.map (fun ω' i => X (i + 1) ω') μ)
       = Measure.map (fun ω' (i : Fin n) => X (i.val + 1) ω') μ := by

--- a/Exchangeability/DeFinetti/ViaL2/AlphaIic.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaIic.lean
@@ -92,8 +92,8 @@ lemma alphaIic_measurable
   -- alphaIic is max 0 (min 1 limit) where limit is measurable
   unfold alphaIic
   have h_limit_meas : Measurable (weighted_sums_converge_L1 X hX_contract hX_meas hX_L2
-            (indIic t) (indIic_measurable t) ⟨1, indIic_bdd t⟩).choose := by
-    exact (weighted_sums_converge_L1 X hX_contract hX_meas hX_L2
+            (indIic t) (indIic_measurable t) ⟨1, indIic_bdd t⟩).choose :=
+    (weighted_sums_converge_L1 X hX_contract hX_meas hX_L2
             (indIic t) (indIic_measurable t) ⟨1, indIic_bdd t⟩).choose_spec.1
   -- max and min preserve measurability: max 0 (min 1 limit)
   -- Build: min limit 1, then max 0 result

--- a/Exchangeability/DeFinetti/ViaL2/BlockAverages/Covariance.lean
+++ b/Exchangeability/DeFinetti/ViaL2/BlockAverages/Covariance.lean
@@ -124,8 +124,8 @@ lemma contractable_covariance_structure
         have h_int_ij : ∫ ω, (X i ω - m) * (X j ω - m) ∂μ
             = ∫ p : ℝ × ℝ, (p.1 - m) * (p.2 - m) ∂(Measure.map (fun ω => (X i ω, X j ω)) μ) := by
           have h_ae : AEStronglyMeasurable (fun p : ℝ × ℝ => (p.1 - m) * (p.2 - m))
-              (Measure.map (fun ω => (X i ω, X j ω)) μ) := by
-            exact ((continuous_fst.sub continuous_const).mul
+              (Measure.map (fun ω => (X i ω, X j ω)) μ) :=
+            ((continuous_fst.sub continuous_const).mul
               (continuous_snd.sub continuous_const)).aestronglyMeasurable
           have h_comp : (fun ω => (X i ω - m) * (X j ω - m))
               = (fun p : ℝ × ℝ => (p.1 - m) * (p.2 - m)) ∘ (fun ω => (X i ω, X j ω)) := rfl
@@ -134,8 +134,8 @@ lemma contractable_covariance_structure
         have h_int_01 : ∫ ω, (X 0 ω - m) * (X 1 ω - m) ∂μ
             = ∫ p : ℝ × ℝ, (p.1 - m) * (p.2 - m) ∂(Measure.map (fun ω => (X 0 ω, X 1 ω)) μ) := by
           have h_ae : AEStronglyMeasurable (fun p : ℝ × ℝ => (p.1 - m) * (p.2 - m))
-              (Measure.map (fun ω => (X 0 ω, X 1 ω)) μ) := by
-            exact ((continuous_fst.sub continuous_const).mul
+              (Measure.map (fun ω => (X 0 ω, X 1 ω)) μ) :=
+            ((continuous_fst.sub continuous_const).mul
               (continuous_snd.sub continuous_const)).aestronglyMeasurable
           have h_comp : (fun ω => (X 0 ω - m) * (X 1 ω - m))
               = (fun p : ℝ × ℝ => (p.1 - m) * (p.2 - m)) ∘ (fun ω => (X 0 ω, X 1 ω)) := rfl
@@ -154,8 +154,8 @@ lemma contractable_covariance_structure
         have h_int_ji : ∫ ω, (X j ω - m) * (X i ω - m) ∂μ
             = ∫ p : ℝ × ℝ, (p.1 - m) * (p.2 - m) ∂(Measure.map (fun ω => (X j ω, X i ω)) μ) := by
           have h_ae : AEStronglyMeasurable (fun p : ℝ × ℝ => (p.1 - m) * (p.2 - m))
-              (Measure.map (fun ω => (X j ω, X i ω)) μ) := by
-            exact ((continuous_fst.sub continuous_const).mul
+              (Measure.map (fun ω => (X j ω, X i ω)) μ) :=
+            ((continuous_fst.sub continuous_const).mul
               (continuous_snd.sub continuous_const)).aestronglyMeasurable
           have h_comp : (fun ω => (X j ω - m) * (X i ω - m))
               = (fun p : ℝ × ℝ => (p.1 - m) * (p.2 - m)) ∘ (fun ω => (X j ω, X i ω)) := rfl
@@ -164,8 +164,8 @@ lemma contractable_covariance_structure
         have h_int_01 : ∫ ω, (X 0 ω - m) * (X 1 ω - m) ∂μ
             = ∫ p : ℝ × ℝ, (p.1 - m) * (p.2 - m) ∂(Measure.map (fun ω => (X 0 ω, X 1 ω)) μ) := by
           have h_ae : AEStronglyMeasurable (fun p : ℝ × ℝ => (p.1 - m) * (p.2 - m))
-              (Measure.map (fun ω => (X 0 ω, X 1 ω)) μ) := by
-            exact ((continuous_fst.sub continuous_const).mul
+              (Measure.map (fun ω => (X 0 ω, X 1 ω)) μ) :=
+            ((continuous_fst.sub continuous_const).mul
               (continuous_snd.sub continuous_const)).aestronglyMeasurable
           have h_comp : (fun ω => (X 0 ω - m) * (X 1 ω - m))
               = (fun p : ℝ × ℝ => (p.1 - m) * (p.2 - m)) ∘ (fun ω => (X 0 ω, X 1 ω)) := rfl

--- a/Exchangeability/Tail/ShiftInvariantMeasure.lean
+++ b/Exchangeability/Tail/ShiftInvariantMeasure.lean
@@ -188,8 +188,8 @@ lemma setIntegral_comp_shift_eq
 
     let π : Set (Set Ω) := piiUnionInter (fun j => {s | MeasurableSet[m j] s}) Set.univ
 
-    have hπ_isPiSystem : IsPiSystem π := by
-      exact isPiSystem_piiUnionInter (fun j => {s | MeasurableSet[m j] s})
+    have hπ_isPiSystem : IsPiSystem π :=
+      isPiSystem_piiUnionInter (fun j => {s | MeasurableSet[m j] s})
         (fun j => @MeasurableSpace.isPiSystem_measurableSet Ω (m j)) Set.univ
 
     have h_gen : tailFamily X N = MeasurableSpace.generateFrom π := by


### PR DESCRIPTION
## Summary

Follow-up to the scripted pass in #122. The 6 `by exact` sites that the script skipped were all multi-line `:= by\n  exact <wrapped expr>` forms — applied manually. Plus 2 HIGH-priority `intro_exact` term-mode collapses from `find_exact_candidates.py`.

**Remaining 6 `by exact` sites:**
| File:line | Wrapper around |
|---|---|
| `DeFinetti/ViaL2/AlphaIic.lean:91` | `h_limit_meas` re-uses `weighted_sums_converge_L1` on both LHS and RHS |
| `DeFinetti/ViaL2/BlockAverages/Covariance.lean:127, 137, 157, 167` | four `h_ae : AEStronglyMeasurable (fun p ...) ...` wrappers around `(continuous_fst.sub ...).mul (continuous_snd.sub ...).aestronglyMeasurable` |
| `Tail/ShiftInvariantMeasure.lean:191` | `hπ_isPiSystem` around `isPiSystem_piiUnionInter ...` |

**2 intro_exact term-mode collapses:**
| File:line | Change |
|---|---|
| `DeFinetti/ViaKoopman.lean:143` | `hk : StrictMono …` `by intro i j hij; exact Nat.add_lt_add_right hij 1` → term-mode `fun _ _ hij => Nat.add_lt_add_right hij 1` |
| `DeFinetti/L2Helpers.lean:286,302` (parallel) | `⟨S, by intro y ⟨k, hk⟩; rw [← hk]; exact …⟩` → `⟨S, fun _ ⟨k, hk⟩ => hk ▸ …⟩` |

**Net:** 5 files, +18 / −21 (−3 lines). Most of the saved bytes come from the multi-line `by exact` collapses (each saves only the `by` line + indent).

## Test plan

- [x] `lake build` clean (3527/3527 jobs, 0 warnings)
- [x] `#print axioms` on `deFinetti`, `deFinetti_viaL2`, `deFinetti_viaKoopman` — all `[propext, Classical.choice, Quot.sound]`
- [x] `lake exe checkdecls blueprint/lean_decls` passes
- [x] `python3 blueprint/check_blueprint.py` — 52 cites, 52 labels, 50 refs/uses, 52 lean_decls, all consistent
- [x] 0 sorries