### PR TITLE
chore: 2 let inlines + 3 rw/exact → ▸ collapses (−9)

### DIFF
--- a/Exchangeability/DeFinetti/ViaKoopman/ContractableFactorization.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/ContractableFactorization.lean
@@ -266,9 +266,8 @@ lemma product_blockAvg_L1_convergence
       let R : NNReal := Real.toNNReal C
       have hR_eq : (R : ℝ) = C := Real.coe_toNNReal C (le_of_lt hC_pos)
       -- The function fs i ∘ (· 0) is bounded by C pointwise
-      have h_fs_bdd : ∀ᵐ ω' ∂μ, |fs i (ω' 0)| ≤ (R : ℝ) := by
-        rw [hR_eq]
-        exact Eventually.of_forall (fun ω' => hC_bd i _)
+      have h_fs_bdd : ∀ᵐ ω' ∂μ, |fs i (ω' 0)| ≤ (R : ℝ) :=
+        hR_eq.symm ▸ Eventually.of_forall (fun ω' => hC_bd i _)
       -- Apply ae_bdd_condExp_of_ae_bdd with explicit type annotations
       have h_condexp_bd : ∀ᵐ ω ∂μ, |(μ[(fun ω' => fs i (ω' 0)) | mSI]) ω| ≤ (R : ℝ) :=
         ae_bdd_condExp_of_ae_bdd h_fs_bdd
@@ -518,9 +517,8 @@ theorem condexp_product_factorization_contractable
       intro i
       let R : NNReal := Real.toNNReal C
       have hR_eq : (R : ℝ) = C := Real.coe_toNNReal C (le_of_lt hC_pos)
-      have h_fs_bdd : ∀ᵐ ω' ∂μ, |fs i (ω' 0)| ≤ (R : ℝ) := by
-        rw [hR_eq]
-        exact Eventually.of_forall (fun ω' => hC_bd i _)
+      have h_fs_bdd : ∀ᵐ ω' ∂μ, |fs i (ω' 0)| ≤ (R : ℝ) :=
+        hR_eq.symm ▸ Eventually.of_forall (fun ω' => hC_bd i _)
       have h_condexp_bd : ∀ᵐ ω ∂μ, |(μ[(fun ω' => fs i (ω' 0)) | mSI]) ω| ≤ (R : ℝ) :=
         ae_bdd_condExp_of_ae_bdd h_fs_bdd
       simp only [hR_eq] at h_condexp_bd
@@ -610,12 +608,9 @@ theorem condexp_product_factorization_contractable
         have hμ_inv : Measure.map (reindexBlock m (n + 1) j) μ = μ :=
           measure_map_reindexBlock_eq_of_contractable hContract hn1_pos j
         -- Set invariance for mSI sets
-        -- Note: reindexBlock m n j = fun ω => ω ∘ blockInjection m n j
-        have h_preimage_eq : reindexBlock m (n + 1) j ⁻¹' s =
-            (fun ω => ω ∘ blockInjection m (n + 1) j) ⁻¹' s := rfl
-        have hs_reindex_inv : reindexBlock m (n + 1) j ⁻¹' s = s := by
-          rw [h_preimage_eq]
-          exact reindex_blockInjection_preimage_shiftInvariant hn1_pos j s hs_inv
+        -- Note: reindexBlock m n j = fun ω => ω ∘ blockInjection m n j definitionally
+        have hs_reindex_inv : reindexBlock m (n + 1) j ⁻¹' s = s :=
+          reindex_blockInjection_preimage_shiftInvariant hn1_pos j s hs_inv
         -- f is measurable
         have hf_meas : Measurable f := Finset.measurable_prod _ (fun i _ =>
           (hfs_meas i).comp (measurable_pi_apply _))

--- a/Exchangeability/DeFinetti/ViaKoopman/InfraCore.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/InfraCore.lean
@@ -244,9 +244,8 @@ lemma setIntegral_map_preimage
     ∫ x in g ⁻¹' s, (f ∘ g) x ∂ μ' = ∫ x in s, f x ∂ μ := by
   -- Use setIntegral_map which requires AEStronglyMeasurable
   -- For ℝ, AEMeasurable implies AEStronglyMeasurable (second countable topology)
-  have hf_aesm : AEStronglyMeasurable f (Measure.map g μ') := by
-    rw [← hpush] at hf
-    exact hf.aestronglyMeasurable
+  have hf_aesm : AEStronglyMeasurable f (Measure.map g μ') :=
+    hpush.symm ▸ hf.aestronglyMeasurable
   have hg_ae : AEMeasurable g μ' := hg.aemeasurable
   simp only [Function.comp]
   rw [← setIntegral_map hs hf_aesm hg_ae, hpush]

--- a/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/Cauchy.lean
+++ b/Exchangeability/DeFinetti/ViaL2/CesaroConvergence/Cauchy.lean
@@ -602,13 +602,11 @@ private lemma blockAvgFrozen_cauchy_in_L2
     have hρ_bd := correlation_coefficient_bounded Z hZ_meas 2 hZ_bdd
         σSq hσ_pos rfl covZ rfl ρ rfl hZ_var_uniform
 
-    let Cf := 2 * σSq * (1 - ρ)
-
     by_cases hρ_lt : ρ < 1
     · -- Standard case: ρ < 1
       exact cesaro_cauchy_rho_lt hX_contract hX_meas f hf_meas hf_bdd
         m rfl Z hZ_def hZ_meas hZ_contract hZ_var_uniform hZ_mean_zero hZ_cov_uniform
-        σSq hσ_pos rfl ρ hρ_bd rfl hρ_lt Cf rfl ε hε
+        σSq hσ_pos rfl ρ hρ_bd rfl hρ_lt (2 * σSq * (1 - ρ)) rfl ε hε
 
     · -- Edge case: ρ = 1 (perfect correlation) → blockAvg values are ae-equal
       have hρ_eq : ρ = 1 := le_antisymm hρ_bd.2 (not_lt.mp hρ_lt)

--- a/Exchangeability/DeFinetti/ViaMartingale/RevFiltration.lean
+++ b/Exchangeability/DeFinetti/ViaMartingale/RevFiltration.lean
@@ -88,9 +88,8 @@ lemma revFiltration_antitone (X : ℕ → Ω → α) :
   -- Need to show: revFiltration X n ≤ revFiltration X m when m ≤ n
   -- Strategy: shiftRV X n = shiftSeq (n - m) ∘ shiftRV X m
   simp only [revFiltration]
-  let k := n - m
-  -- Show shiftRV X n = shiftSeq k ∘ shiftRV X m
-  have h_comp : shiftRV X n = shiftSeq k ∘ shiftRV X m := by
+  -- Show shiftRV X n = shiftSeq (n - m) ∘ shiftRV X m
+  have h_comp : shiftRV X n = shiftSeq (n - m) ∘ shiftRV X m := by
     funext ω i
     simp only [shiftRV, shiftSeq, Function.comp_apply]
     congr 1


### PR DESCRIPTION
## Summary

Tracking findings from `analyze_let_usage.py` + the `rw_exact` HIGH-priority entries from `find_exact_candidates.py`. Each inline preserves semantics and shrinks the proof by 2-4 lines.

**`let` inlines** (single-use shorthand, no documentation value):
| File:line | Change |
|---|---|
| `ViaMartingale/RevFiltration.lean:91` | `let k := n - m`, used once in `shiftSeq k` → inline as `shiftSeq (n - m)` |
| `ViaL2/CesaroConvergence/Cauchy.lean:605` | `let Cf := 2 * σSq * (1 - ρ)`, used once in `cesaro_cauchy_rho_lt ... Cf rfl ...` → inline as `... (2 * σSq * (1 - ρ)) rfl ...` |

**`rw + exact` → term-mode `▸` collapses:**
| File:line | Change |
|---|---|
| `ViaKoopman/ContractableFactorization.lean:269, 521` (two parallel sites) | `by rw [hR_eq]; exact Eventually.of_forall …` → `hR_eq.symm ▸ Eventually.of_forall …` |
| `ViaKoopman/InfraCore.lean:247` | `by rw [← hpush] at hf; exact hf.aestronglyMeasurable` → `hpush.symm ▸ hf.aestronglyMeasurable` (drops the local `hf`-rewrite scaffolding) |
| `ViaKoopman/ContractableFactorization.lean:614` | `have h_preimage_eq := rfl; have hs_reindex_inv := by rw [h_preimage_eq]; exact …` → `have hs_reindex_inv := …` (the preimage equality was definitional, so both the named `rfl` and the `rw` were no-ops) |

**Other single-use `let` bindings the analyzer flagged but I left alone** — `Core.lean:212` `ι` (inclusion map, name carries meaning), `ShiftInvariantMeasure.lean:82-83` `ν₁/ν₂` (named for the two measures being compared), `MoreL2Helpers.lean:304` `ν` (directing measure), `KoopmanCommutation.lean:199` `F` (named in goal), `BlockAverage.lean:348` `k` (function, named with companion `hk_mono`).

**Net:** 4 files, +12 / −21 (−9 lines).

## Test plan

- [x] `lake build` clean (3527/3527 jobs, 0 warnings)
- [x] `#print axioms` on `deFinetti`, `deFinetti_viaL2`, `deFinetti_viaKoopman` — all `[propext, Classical.choice, Quot.sound]`
- [x] `lake exe checkdecls blueprint/lean_decls` passes
- [x] `python3 blueprint/check_blueprint.py` — 52 cites, 52 labels, 50 refs/uses, 52 lean_decls, all consistent
- [x] 0 sorries