### PR TITLE
chore: drop last 3 linter.unusedVariables suppressions (3 → 0)

### DIFF
--- a/Exchangeability/DeFinetti/ViaKoopman/BlockInjection.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/BlockInjection.lean
@@ -172,7 +172,6 @@ private lemma shift_iterate_preimage_of_shiftInvariant (C : ℕ) (s : Set (Ω[α
   | zero => simp
   | succ k ih => rw [Function.iterate_succ', Set.preimage_comp, hs_shift, ih]
 
-set_option linter.unusedVariables false in
 /-- Reindexing by blockInjection preserves membership in shift-invariant sets.
 
 The key insight is that blockInjection is eventually a constant shift:
@@ -180,13 +179,17 @@ for i ≥ m, blockInjection(i) = i + (m*n - m).
 
 For shift-invariant sets s (where shift⁻¹(s) = s), membership is determined by
 the eventual behavior of the sequence. Since blockInjection only permutes
-finitely many coordinates and then shifts, it preserves membership in s. -/
-lemma reindex_blockInjection_preimage_shiftInvariant {m n : ℕ} (hn : 0 < n)
+finitely many coordinates and then shifts, it preserves membership in s.
+
+The `_hn : 0 < n` hypothesis is unused by the current proof but retained in the
+signature: callers (e.g. `ContractableFactorization`) already track it and the
+hypothesis is informative for readers. -/
+lemma reindex_blockInjection_preimage_shiftInvariant {m n : ℕ} (_hn : 0 < n)
     (j : Fin m → Fin n) (s : Set (Ω[α]))
     (hs : isShiftInvariant s) :
     (fun ω => ω ∘ blockInjection m n j) ⁻¹' s = s := by
-  -- hs gives: MeasurableSet s and shift ⁻¹' s = s
-  obtain ⟨hs_meas, hs_shift⟩ := hs
+  -- hs gives shift⁻¹(s) = s; the measurability component isn't needed here.
+  obtain ⟨_, hs_shift⟩ := hs
   ext ω
   simp only [Set.mem_preimage]
   -- Need: ω ∈ s ↔ (ω ∘ blockInjection m n j) ∈ s

--- a/Exchangeability/DeFinetti/ViaKoopman/InfraGeneralized.lean
+++ b/Exchangeability/DeFinetti/ViaKoopman/InfraGeneralized.lean
@@ -95,23 +95,16 @@ lemma condexp_precomp_iterate_eq_twosided
             | shiftInvariantSigmaℤ (α := α)] := h_base
       _ =ᵐ[μhat] μhat[f | shiftInvariantSigmaℤ (α := α)] := ih
 
-set_option linter.unusedVariables false in
 /-- Integrability of `f * g` when `g` is integrable and `|f| ≤ C`.
 
 This shows that multiplying an integrable function by a bounded function preserves integrability.
 The bound `|f * g| ≤ C * |g|` follows from `|f| ≤ C`. -/
 lemma Integrable.of_abs_bounded {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
-    {f g : Ω → ℝ} (hg : Integrable g μ) (C : ℝ) (hC : 0 ≤ C)
+    {f g : Ω → ℝ} (hg : Integrable g μ) (C : ℝ)
     (h_bound : ∀ ω, |f ω| ≤ C)
     (hfg_meas : AEStronglyMeasurable (fun ω => f ω * g ω) μ) :
     Integrable (fun ω => f ω * g ω) μ := by
-  have h_norm_bound : ∀ᵐ ω ∂μ, ‖f ω * g ω‖ ≤ C * ‖g ω‖ := by
-    apply Filter.Eventually.of_forall
-    intro ω
-    simp only [Real.norm_eq_abs]
-    calc |f ω * g ω| = |f ω| * |g ω| := abs_mul _ _
-      _ ≤ C * |g ω| := mul_le_mul_of_nonneg_right (h_bound ω) (abs_nonneg _)
-  -- Use Integrable.mono' with dominating function C * |g|
+  -- Dominating function: C * ‖g‖, integrable because g is.
   refine Integrable.mono' (hg.norm.const_mul C) hfg_meas ?_
   filter_upwards with ω
   simp only [Real.norm_eq_abs]

--- a/Exchangeability/DeFinetti/ViaL2/AlphaIicCE.lean
+++ b/Exchangeability/DeFinetti/ViaL2/AlphaIicCE.lean
@@ -48,7 +48,6 @@ We now define the **canonical** version using conditional expectation onto the t
 This avoids all pointwise headaches and gives us the endpoint limits for free.
 -/
 
-set_option linter.unusedVariables false in
 /-- **Canonical conditional expectation version** of α_{Iic t}.
 
 This is the conditional expectation of the indicator function `1_{(-∞,t]}∘X_0` with respect
@@ -59,12 +58,14 @@ existential `alphaIic` almost everywhere.
 - Has pointwise bounds `0 ≤ alphaIicCE ≤ 1` everywhere (not just a.e.)
 - Monotone in `t` almost everywhere (from positivity of conditional expectation)
 - Endpoint limits follow from L¹ contraction and dominated convergence
--/
+
+The `_hX_contract` and `_hX_L2` binders are retained for API uniformity with the
+`alphaIicCE_*` lemmas that *do* depend on them; this def itself only needs `hX_meas`. -/
 noncomputable def alphaIicCE
     {μ : Measure Ω} [IsProbabilityMeasure μ]
-    (X : ℕ → Ω → ℝ) (hX_contract : Contractable μ X)
+    (X : ℕ → Ω → ℝ) (_hX_contract : Contractable μ X)
     (hX_meas : ∀ i, Measurable (X i))
-    (hX_L2 : ∀ i, MemLp (X i) 2 μ)
+    (_hX_L2 : ∀ i, MemLp (X i) 2 μ)
     (t : ℝ) : Ω → ℝ := by
   classical
   -- Set up the tail σ-algebra and its sub-σ-algebra relation


### PR DESCRIPTION
## Summary

Closes the suppression audit started in #121. After this PR, the `Exchangeability/` tree has **zero** `nolint` / `set_option linter.*` suppressions and `lake build` reports **zero** warnings.

| File:line | Decl | Fix |
|---|---|---|
| `ViaKoopman/InfraGeneralized.lean:98` | `Integrable.of_abs_bounded` | The local `h_norm_bound` was dead — built and never used; the proof body just below redoes the same `filter_upwards`. Deleting it makes `hC : 0 ≤ C` also dead, so drop it from the signature too. **No callers anywhere in the tree** (0 hits via `git grep -nw`), so the API shrink is invisible. |
| `ViaKoopman/BlockInjection.lean:175` | `reindex_blockInjection_preimage_shiftInvariant` | (a) underscore-rename `hn` → `_hn` (single external caller passes positionally; short docstring note explains it's retained); (b) change `obtain ⟨hs_meas, hs_shift⟩ := hs` → `obtain ⟨_, hs_shift⟩ := hs` (measurability component not needed). |
| `ViaL2/AlphaIicCE.lean:51` | `alphaIicCE` | underscore-rename `hX_contract` / `hX_L2` (the def only needs `hX_meas`). No named-arg callers in tree (verified). Docstring note explains why binders are retained for API uniformity with the `alphaIicCE_*` lemmas. |

**Net:** 3 files, +15 / −18 (−3 lines).

## Test plan

- [x] `lake build` clean (3527/3527 jobs, **0 warnings, 0 suppressions**)
- [x] `#print axioms` on `deFinetti`, `deFinetti_viaL2`, `deFinetti_viaKoopman` — all `[propext, Classical.choice, Quot.sound]`
- [x] `lake exe checkdecls blueprint/lean_decls` passes
- [x] `python3 blueprint/check_blueprint.py` — 52 cites, 52 labels, 50 refs/uses, 52 lean_decls, all consistent
- [x] 0 sorries