### PR TITLE
chore(docs): refresh stale counts/dates/refs ahead of v1.3 release

### DIFF
--- a/Exchangeability/DeFinetti/L2Helpers.lean
+++ b/Exchangeability/DeFinetti/L2Helpers.lean
@@ -10,23 +10,23 @@ import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
 /-!
 # Helper Lemmas for L² de Finetti Proof
 
-This file contains auxiliary lemmas used in the L² approach to de Finetti's theorem
-(`ViaL2.lean`). All lemmas here are complete (no sorries) and compile cleanly.
+This file contains auxiliary lemmas used in the L² approach to de Finetti's theorem.
+All lemmas here are complete (no sorries) and compile cleanly.
 
 ## Contents
 
-1. **CovarianceHelpers**: Lemmas about contractable sequences and covariance structure
-2. **Lp Utility Lemmas**: Standard Lp space and ENNReal conversion helpers
-3. **FinIndexHelpers**: Fin reindexing lemmas for two-window bounds
+1. **Lp Utility Lemmas**: Standard Lp space and ENNReal conversion helpers
+2. **FinIndexHelpers**: Fin reindexing lemmas for two-window bounds
 
 ## Key Results
 
-- `contractable_map_single`: All marginals have the same distribution
-- `contractable_map_pair`: All bivariate marginals have the same joint distribution
-- `contractable_comp`: Contractability preserved under measurable postcomposition
 - `dist_toLp_eq_eLpNorm_sub`: Distance in L^p equals norm of difference
-- Various arithmetic bounds for convergence rates
+- Various arithmetic bounds for convergence rates (e.g. `sqrt_div_lt_half_eps_of_nat`)
 - Fin index reindexing lemmas for filtered sums
+
+The contractability/covariance helpers that previously lived here have moved to the
+canonical `Exchangeability.Contractable.{map_single, map_pair, comp}` API in
+`Exchangeability/Contractability.lean`.
 
 -/
 

--- a/README.md
+++ b/README.md
@@ -16,18 +16,18 @@ We implement **all three proofs** from Kallenberg (2005) of the key implication 
 1. **Martingale Approach** (Default)
    - Kallenberg's "third proof" (after Aldous)
    - Elegant probabilistic argument using reverse martingales
-   - [`Exchangeability/DeFinetti/ViaMartingale/`](Exchangeability/DeFinetti/ViaMartingale/) (13 files)
+   - [`Exchangeability/DeFinetti/ViaMartingale/`](Exchangeability/DeFinetti/ViaMartingale/) (12 files)
 
 2. **L² Approach**
    - Kallenberg's "second proof" - Elementary L² contractability bounds
    - Lightest dependencies (no ergodic theory required)
    - Formalized for ℝ-valued sequences with L² integrability
-   - [`Exchangeability/DeFinetti/ViaL2/`](Exchangeability/DeFinetti/ViaL2/) (12 files)
+   - [`Exchangeability/DeFinetti/ViaL2/`](Exchangeability/DeFinetti/ViaL2/) (24 files)
 
 3. **Koopman Approach**
    - Kallenberg's "first proof" - Mean Ergodic Theorem
    - Deep connection to dynamical systems and ergodic theory
-   - [`Exchangeability/DeFinetti/ViaKoopman/`](Exchangeability/DeFinetti/ViaKoopman/) (18 files)
+   - [`Exchangeability/DeFinetti/ViaKoopman/`](Exchangeability/DeFinetti/ViaKoopman/) (16 files)
 
 ### Import Graph
 
@@ -92,9 +92,9 @@ Exchangeability/
 │   └── ...
 ├── DeFinetti/                   # Three proofs of de Finetti
 │   ├── Theorem.lean            # Public API (exports ViaMartingale)
-│   ├── ViaMartingale/          # Martingale proof (13 files)
-│   ├── ViaL2/                  # L² proof (12 files)
-│   ├── ViaKoopman/             # Ergodic proof (18 files)
+│   ├── ViaMartingale/          # Martingale proof (12 files)
+│   ├── ViaL2/                  # L² proof (24 files)
+│   ├── ViaKoopman/             # Ergodic proof (16 files)
 │   ├── CommonEnding.lean       # Shared final step
 │   └── L2Helpers.lean          # L² contractability lemmas
 ├── Ergodic/                     # Ergodic theory (for Koopman)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Exchangeability/
 │   ├── ViaL2/                  # L² proof (24 files)
 │   ├── ViaKoopman/             # Ergodic proof (16 files)
 │   ├── CommonEnding.lean       # Shared final step
-│   └── L2Helpers.lean          # L² contractability lemmas
+│   └── L2Helpers.lean          # L² utility and Fin index lemmas
 ├── Ergodic/                     # Ergodic theory (for Koopman)
 │   ├── KoopmanMeanErgodic.lean
 │   ├── InvariantSigma.lean

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,16 +1,19 @@
 # Project Status: de Finetti Theorem Formalization
 
-**Last Updated:** 2026-01-12
+**Last Updated:** 2026-05-27
 
 ## Executive Summary
 
+LOC counts below cover the `Exchangeability/` library tree (excluding the top-level
+`Exchangeability.lean` umbrella and `Main.lean`):
+
 | Proof Approach | Lines | Build | Status |
 |---------------|------:|-------|--------|
-| **ViaMartingale** | 3,770 | Pass | **COMPLETE** |
-| **ViaL2** | 12,476 | Pass | **COMPLETE** |
-| **ViaKoopman** | 6,893 | Pass | **COMPLETE** |
-| *Shared infrastructure* | 20,373 | — | — |
-| **Total** | **43,512** | Pass | **COMPLETE** |
+| **ViaMartingale** | 2,804 | Pass | **COMPLETE** |
+| **ViaL2** | 7,444 | Pass | **COMPLETE** |
+| **ViaKoopman** | 5,402 | Pass | **COMPLETE** |
+| *Shared infrastructure* | 11,117 | — | — |
+| **Total** | **26,767** | Pass | **COMPLETE** |
 
 **All three proofs complete.**
 
@@ -21,7 +24,7 @@
 ### ViaMartingale (Default)
 - Kallenberg's "third proof" (after Aldous)
 - Reverse martingale convergence
-- **Main theorem:** `deFinetti_viaMartingale`
+- **Main theorem:** `deFinetti` (re-exported from `Exchangeability.DeFinetti.Theorem`)
 
 ### ViaL2
 - Kallenberg's "second proof"
@@ -48,7 +51,7 @@ lake build Exchangeability.DeFinetti.ViaL2
 lake build Exchangeability.DeFinetti.ViaKoopman
 
 # Check axioms for a theorem
-lake env lean -c 'import Exchangeability; #print axioms deFinetti_viaMartingale'
+printf 'import Exchangeability\n#print axioms deFinetti\n' | lake env lean --stdin
 ```
 
 ---

--- a/STATUS.md
+++ b/STATUS.md
@@ -51,7 +51,7 @@ lake build Exchangeability.DeFinetti.ViaL2
 lake build Exchangeability.DeFinetti.ViaKoopman
 
 # Check axioms for a theorem
-printf 'import Exchangeability\n#print axioms deFinetti\n' | lake env lean --stdin
+printf 'import Exchangeability\n#print axioms Exchangeability.DeFinetti.deFinetti\n' | lake env lean --stdin
 ```
 
 ---

--- a/WorkPlans/README.md
+++ b/WorkPlans/README.md
@@ -2,7 +2,7 @@
 
 This directory contains active work plans, progress tracking, and development resources for the exchangeability formalization project.
 
-**Last Updated:** January 2026
+**Last Updated:** May 2026
 
 ## Active Documents
 
@@ -18,7 +18,7 @@ This directory contains active work plans, progress tracking, and development re
 
 ## Current Project Status
 
-**As of January 2026:**
+**As of May 2026:**
 
 | Proof | Status | Sorries |
 |-------|--------|---------|

--- a/docs/VIAMARTINGALE_PROOF.md
+++ b/docs/VIAMARTINGALE_PROOF.md
@@ -1,8 +1,17 @@
 # de Finetti's Theorem via Reverse Martingales
 
 This document describes the **martingale approach** to proving de Finetti's theorem,
-as implemented in `Exchangeability/DeFinetti/ViaMartingale.lean`. This is Aldous' elegant
+implemented under `Exchangeability/DeFinetti/ViaMartingale/`. This is Aldous' elegant
 proof, presented by Kallenberg (2005) as the "Third proof" of Theorem 1.1.
+
+> **Historical architecture note.** The "File Structure and Dependencies" and "Key
+> Technical Lemmas" sections below describe the *monolithic* `ViaMartingale.lean`
+> (a single ~5,000-line file) as it existed up through ~Jan 2026. The proof has
+> since been split into a directory `Exchangeability/DeFinetti/ViaMartingale/`
+> with 12 files (see `README.md` for the current structure); line-number
+> references in the tables below no longer resolve. The mathematical content
+> (proof strategy, time-reversal crossing bound, Kallenberg Lemma 1.3, etc.) is
+> unchanged.
 
 ## Status
 

--- a/home_page/index.md
+++ b/home_page/index.md
@@ -35,7 +35,7 @@ We formalize **all three proofs** from Kallenberg (2005):
 
 | Graph | Description |
 |-------|-------------|
-| [Modules (SVG)]({{ site.url }}/blueprint/import_graph_colored.svg) | 104 files, clickable links to docs |
+| [Modules (SVG)]({{ site.url }}/blueprint/import_graph_colored.svg) | 105 files, clickable links to docs |
 | [Modules (interactive)]({{ site.url }}/blueprint/import_graph_colored.html) | Draggable, zoomable |
 | [All declarations]({{ site.url }}/blueprint/import_graph_full_declarations.html) | Searchable |
 | [Blueprint only]({{ site.url }}/blueprint/dep_graph_document.html) | Documented items |

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,5 +1,5 @@
 name = "exchangeability"
-version = "0.1.0"
+version = "1.3.0"
 defaultTargets = ["Exchangeability"]
 
 [[require]]

--- a/paper/NOTES.md
+++ b/paper/NOTES.md
@@ -2,6 +2,16 @@
 
 Detailed storylines for the AFM paper on formalizing de Finetti's theorem.
 
+> **Historical note (drafted Jan 2026).** The quantitative numbers below — per-proof
+> LOC, file counts, "largest module" line counts, and ViaMartingale's monolithic
+> structure — reflect the codebase as of January 2026. The library has been
+> substantially restructured and golfed since (current totals are roughly 2.8K /
+> 7.4K / 5.4K LOC for ViaMartingale / ViaL2 / ViaKoopman respectively, and
+> `ViaMartingale.lean` is now a 12-file directory rather than a single 5K-line
+> module). The qualitative insights — three-proof comparison, equation
+> archaeology, condExpWith pattern, contractability framing — remain accurate.
+> Numbers will be refreshed when the paper is drafted from these notes.
+
 ---
 
 ## Storyline 1: Three-Proof Comparative Study

--- a/paper/README.md
+++ b/paper/README.md
@@ -1,6 +1,6 @@
 # AFM Paper: Formalizing de Finetti's Theorem
 
-## Current Status (January 2026)
+## Current Status (May 2026)
 
 | Proof Approach | Status | Ready for Paper? |
 |---------------|--------|------------------|


### PR DESCRIPTION
## Summary

Source documentation has drifted since v1.2 (2026-03-17); this catches it up ahead of the v1.3 tag.

### Version bump
| File | Change |
|---|---|
| `lakefile.toml` | `version = "0.1.0"` → `"1.3.0"`. (Deliberately NOT touching `lake-manifest.json`'s `"version": "1.2.0"` — that's Lake's manifest schema version, not our package version.) |

### Numbers and dates
| File | Stale value | Current |
|---|---|---|
| `STATUS.md` | "Last Updated: 2026-01-12" | "2026-05-27" |
| `STATUS.md` | Total 43,512 LOC | **26,767** (ViaMartingale 2,804 / ViaL2 7,444 / ViaKoopman 5,402 / Shared 11,117) — explicit scope note added: "`Exchangeability/` library tree, excluding top-level `Exchangeability.lean` umbrella and `Main.lean`" |
| `STATUS.md` L51 | `lake env lean -c '...'` (broken syntax in Lean 4.30) | `printf '...' \| lake env lean --stdin` |
| `STATUS.md` L24 | `deFinetti_viaMartingale` | `deFinetti` |
| `README.md` overview + project-structure block | ViaMartingale 13, ViaL2 12, ViaKoopman 18 | 12, 24, 16 (6 textual replacements across both locations) |
| `WorkPlans/README.md` L5, L21 | "January 2026" | "May 2026" |
| `paper/README.md` L3 | "January 2026" | "May 2026" |
| `home_page/index.md` L38 | 104 files | 105 files |

### Lean module docstring
- `Exchangeability/DeFinetti/L2Helpers.lean` — drop the three now-deleted names (`contractable_map_single`/`_pair`/`_comp`, migrated to `Exchangeability.Contractable.*` in PRs #114/#118/#120) from the "Key Results" list. Remove the stale "CovarianceHelpers" contents line. Add a one-line pointer to the canonical location of the moved API.

### Historical-note preambles (refresh-vs-relabel trade-off)
For these two files the qualitative content is still accurate but the embedded numbers are deeply stale; relabeling as historical is much lower-risk than re-writing.

- `paper/NOTES.md` — preamble noting the per-proof LOC, file counts, and "largest module" numbers reflect Jan 2026; the qualitative storylines (three-proof comparison, equation archaeology, condExpWith pattern, contractability framing) remain accurate and will be refreshed when the paper is drafted.
- `docs/VIAMARTINGALE_PROOF.md` — preamble noting the "File Structure and Dependencies" section describes the *monolithic* ~5,000-line `ViaMartingale.lean` from Jan 2026; the proof now lives in a 12-file directory and line-number references no longer resolve. Mathematical content (proof strategy, time-reversal crossing bound, Kallenberg Lemma 1.3 etc.) is unchanged.

## Out of scope for this PR

Per the release plan, the **stale checked-in blueprint/web HTML/PNG/SVG and `blueprint/print/print.pdf` artifacts** are NOT touched here — they need local regeneration (whatever toolchain was used in the Jan 2026 commit `27cfbbc5`). That's the separate Part B of the v1.3 release plan.

## Test plan

- [x] `lake build` clean (3527/3527 jobs, 0 warnings)
- [x] `#print axioms` on `deFinetti`, `deFinetti_viaL2`, `deFinetti_viaKoopman` — all `[propext, Classical.choice, Quot.sound]`
- [x] `lake exe checkdecls blueprint/lean_decls` passes
- [x] `python3 blueprint/check_blueprint.py` — 52 cites, 52 labels, 50 refs/uses, 52 lean_decls, all consistent
- [x] 0 sorries