### PR TITLE
ci: bump actions/checkout v4 → v6 + opt JS actions into Node 24

### DIFF
--- a/.github/workflows/blueprint-check.yml
+++ b/.github/workflows/blueprint-check.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 env:
-  # Opt JS actions into the Node.js 24 runtime ahead of the 2026-06-02 default
+  # Opt JS actions into the Node.js 24 runtime ahead of the 2026-06-16 default
   # switchover; mirrors `blueprint.yml`.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 

--- a/.github/workflows/blueprint-check.yml
+++ b/.github/workflows/blueprint-check.yml
@@ -12,12 +12,17 @@ on:
 permissions:
   contents: read
 
+env:
+  # Opt JS actions into the Node.js 24 runtime ahead of the 2026-06-02 default
+  # switchover; mirrors `blueprint.yml`.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run blueprint consistency check
         run: |

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -15,12 +15,19 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  # Opt all JavaScript actions (including those pinned to older versions inside
+  # `leanprover/lean-action` and `leanprover-community/docgen-action`) into the
+  # Node.js 24 runtime ahead of the 2026-06-02 default switchover. Drop this
+  # block once all transitively-used actions ship Node.js 24 builds.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history for doc generation
 

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -18,7 +18,7 @@ permissions:
 env:
   # Opt all JavaScript actions (including those pinned to older versions inside
   # `leanprover/lean-action` and `leanprover-community/docgen-action`) into the
-  # Node.js 24 runtime ahead of the 2026-06-02 default switchover. Drop this
+  # Node.js 24 runtime ahead of the 2026-06-16 default switchover. Drop this
   # block once all transitively-used actions ship Node.js 24 builds.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 


### PR DESCRIPTION
## Summary

CI annotations on recent runs warn that five Node.js 20 actions will be force-bumped to Node.js 24 on **2026-06-02** (6 days from now). Getting ahead of that with a small two-file change.

| Action | Where | Fix |
|---|---|---|
| `actions/checkout@v4` | direct in both our workflows | bump to `@v6` (latest is v6.0.2, supports Node 24) |
| `actions/cache@5a3ec84e`, `actions/deploy-pages@d6db9016`, `actions/upload-artifact@v4`, `ruby/setup-ruby@eaecf785f` | transitive (inside `leanprover/lean-action@main` and `leanprover-community/docgen-action@main`) | can't bump directly; instead add workflow-level `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` (GitHub-recommended interim opt-in) |

Once the third-party actions ship Node 24 builds, the env var can come out. Documented inline in both files.

**Net:** 2 files, +14 / −2.

## Test plan

- [x] `yaml.safe_load` parses both workflows cleanly
- [ ] Will be exercised by the next merge to main (this PR itself triggers `blueprint-check.yml`)