### PR TITLE
docs(README): simplify Acknowledgments to point at lean4-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,6 @@ Exchangeability/
 
 ## Acknowledgments
 
-This formalization was developed with assistance from:
-- **Claude** (Anthropic) - Sonnet 4, Sonnet 4.5, Opus 4.5
-- **GPT** (OpenAI) - GPT-5.\*-Codex, GPT-5.\* Pro
+This formalization was developed with assistance from Claude and GPT models, using [lean4-skills](https://github.com/cameronfreer/lean4-skills).
 
 Built with [Lean 4](https://leanprover.github.io/) and [Mathlib](https://github.com/leanprover-community/mathlib4).


### PR DESCRIPTION
Replace the version-specific model list (Sonnet 4 / 4.5, Opus 4.5, GPT-5.* variants) with a concise pointer to [lean4-skills](https://github.com/cameronfreer/lean4-skills), per request.

```diff
-This formalization was developed with assistance from:
-- **Claude** (Anthropic) - Sonnet 4, Sonnet 4.5, Opus 4.5
-- **GPT** (OpenAI) - GPT-5.*-Codex, GPT-5.* Pro
+This formalization was developed with assistance from Claude and GPT models, using [lean4-skills](https://github.com/cameronfreer/lean4-skills).
```

No other changes; `lake build`/blueprint/etc. unaffected (README is documentation-only).